### PR TITLE
feat: allow ICP users to use `iam_apikey` to provide their key

### DIFF
--- a/test/unit/baseService.test.js
+++ b/test/unit/baseService.test.js
@@ -348,6 +348,23 @@ describe('BaseService', function() {
     expect(instance._options.rejectUnauthorized).toBe(true);
   });
 
+  it('should convert an iam_apikey that starts with "icp-" to basic auth', () => {
+    const icpKey = 'icp-1234';
+    const instance = new TestService({
+      iam_apikey: icpKey,
+      username: 'thiswillbegone',
+      password: 'thiswillbegone',
+    });
+
+    const authHeader = instance._options.headers.Authorization;
+
+    expect(instance._options.username).toBe('apikey');
+    expect(instance._options.password).toBe(icpKey);
+    expect(instance._options.iam_apikey).not.toBeDefined();
+    expect(instance.tokenManager).toBeNull();
+    expect(authHeader.startsWith('Basic')).toBe(true);
+  });
+
   describe('check credentials for common problems', function() {
     function assertConstructorThrows(params) {
       expect(() => {


### PR DESCRIPTION
Allows ICP users to use the following pattern:

```js
const service = new SomeService({
  iam_apikey: 'icp-1234abcd'
});
```

This will be converted internally to basic auth with a username of `apikey` and a password of `icp-1234abcd` (the typical pattern for authenticating ICP).

Test case included.