### PR TITLE
Fix old version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-cloud-sdk-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-cloud-sdk-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Core functionality to support SDKs generated with IBM's OpenAPI 3 SDK Generator.",
   "main": "./index",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "lint": "npm run eslint:check && npm run tslint:check",
     "test": "jest --silent --verbose test/unit/",
     "test-travis": "jest --silent --runInBand test/unit/",
-    "report-coverage": "codecov"
+    "report-coverage": "codecov",
+    "prepare": "tsc"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
When I released v0.0.2, I did not build the JS code from TypeScript so the necessary changes were not released. I patched this by branching off of the v0.0.2 commit, making the changes, bumping the version to v0.0.3, publishing them, then reverting the package.json file back to the current version.

This PR just adds a `prepare` step to ensure this mistake won't be made again. This should be able to be removed once we add semantic release to the SDK.