### PR TITLE
fix: make `application/json` the default content type

### DIFF
--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -27,6 +27,13 @@ const pkg = require('../package.json');
 const isBrowser = typeof window === 'object';
 const globalTransactionId = 'x-global-transaction-id';
 
+// axios sets the default Content-Type for `post`, `put`, and `patch` operations
+// to 'application/x-www-form-urlencoded'. This causes problems, so overriding the
+// defaults here
+['post', 'put', 'patch'].forEach(method => {
+  axios.defaults.headers[method]['Content-Type'] = 'application/json';
+});
+
 /**
  * @private
  * @param {string} path


### PR DESCRIPTION
`axios` sets the default content type to `application/x-www-form-urlencoded`. This is problematic for operations like `createSession` in Assistant v2 , which is a POST but doesn't have a body or query parameters. The `axios` inserted header causes the service to choke. Sending `application/json` works fine and is consistent with how the other SDKs handle this problem.

This fix is required for the v4 release of the Watson Node SDK.