### PR TITLE
fix: parse error message from property errorMessage

### DIFF
--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -87,7 +87,7 @@ function hasStringProperty(obj: any, property: string): boolean {
 /**
  * Look for service error message in common places, by priority
  * first look in `errors[0].message`, then in `error`, then in
- * `message`
+ * `message`, then in `errorMessage`
  * @private
  * @param {Object} response - error response body received from service
  * @returns {string | undefined} the error message if is was found, undefined otherwise
@@ -101,6 +101,8 @@ function parseServiceErrorMessage(response: any): string | undefined {
     message = response.error;
   } else if (hasStringProperty(response, 'message')) {
     message = response.message;
+  } else if (hasStringProperty(response, 'errorMessage')) {
+    message = response.errorMessage;
   }
 
   return message;

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -17,6 +17,7 @@ describe('formatError', () => {
         ],
         message: 'Cant find the model.',
         error: 'Model not found.',
+        errorMessage: 'There is just no finding this model.',
         code: 404,
       },
       headers: {
@@ -48,9 +49,6 @@ describe('formatError', () => {
     expect(error.name).toBe('Not Found');
     expect(error.code).toBe(404);
     expect(error.message).toBe('Model not found.');
-    expect(error.body).toBe(
-      '{"message":"Cant find the model.","error":"Model not found.","code":404}'
-    );
     expect(error.headers).toEqual(basicAxiosError.response.headers);
   });
 
@@ -61,12 +59,22 @@ describe('formatError', () => {
     expect(error.name).toBe('Not Found');
     expect(error.code).toBe(404);
     expect(error.message).toBe('Cant find the model.');
-    expect(error.body).toBe('{"message":"Cant find the model.","code":404}');
+    expect(error.headers).toEqual(basicAxiosError.response.headers);
+  });
+
+  it('should get the message from errorMessage', () => {
+    delete basicAxiosError.response.data.message;
+    const error = formatError(basicAxiosError);
+    expect(error instanceof Error).toBe(true);
+    expect(error.name).toBe('Not Found');
+    expect(error.code).toBe(404);
+    expect(error.message).toBe('There is just no finding this model.');
+    expect(error.body).toBe('{"errorMessage":"There is just no finding this model.","code":404}');
     expect(error.headers).toEqual(basicAxiosError.response.headers);
   });
 
   it('should get error from status text when not found', () => {
-    delete basicAxiosError.response.data.message;
+    delete basicAxiosError.response.data.errorMessage;
     const error = formatError(basicAxiosError);
     expect(error instanceof Error).toBe(true);
     expect(error.message).toBe('Not Found');


### PR DESCRIPTION
Based on the error format of the IAM service, adding a field to check for when parsing the error - `errorMessage`. 

cc @joyychang 