### PR TITLE
Use NodeJS.ReadableStream instead of DOM ReadableStream

### DIFF
--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -51,7 +51,7 @@ const fromHeader = (buffer: Buffer): string => {
  * @param {String|ReadableStream|FileObject|Buffer|File} file - string filename or url, or binary File/Blob object
  * @return {String|undefined}
  */
-const fromFilename = (file: String | ReadableStream| FileObject |Buffer | File): string => {
+const fromFilename = (file: String | NodeJS.ReadableStream | FileObject | Buffer | File): string => {
   const ext: string = extname(
     (typeof file === 'string' && file) || file['name'] || ''
   );

--- a/test/unit/baseService.test.js
+++ b/test/unit/baseService.test.js
@@ -35,7 +35,8 @@ describe('BaseService', function() {
   it('should fail to instantiate if the instance is not instantiated with new', () => {
     expect(() => {
       // prettier-ignore
-      const base = BaseService({
+      // eslint-disable-next-line new-cap
+      BaseService({
         use_unauthenticated: true,
         version: 'v1',
       });


### PR DESCRIPTION
- Use `NodeJS.ReadableStream` instead of `ReadableStream` (which defaults to the type defined in the DOM library).
- This brings `ReadableStream`s usage in `content-type.ts` in line with all the other usage in this package (see https://github.com/IBM/node-sdk-core/issues/9#issuecomment-483523620).

Also:
- Gets linting to pass by fixing an `eslint` `no-unused-vars` error, and ignoring a `new-cap` error.