### PR TITLE
refactor: remove dependency on buffer-from and use native buffer

### DIFF
--- a/iam-token-manager/v1.ts
+++ b/iam-token-manager/v1.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import bufferFrom = require('buffer-from');
 import extend = require('extend');
 import { sendRequest } from '../lib/requestwrapper';
 
@@ -255,7 +254,7 @@ export class IamTokenManagerV1 {
       clientId = this.iamClientId;
       secret = this.iamSecret;
 	}
-    const encodedCreds = bufferFrom(`${clientId}:${secret}`).toString('base64');
+    const encodedCreds = Buffer.from(`${clientId}:${secret}`).toString('base64');
     return `Basic ${encodedCreds}`;
   }
 }

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// new Buffer() is deprecated, replaced with Buffer.from() in node v4.5.0+ -
-// `buffer-from` uses the new api when possible but falls back to the old one otherwise
-import bufferFrom = require('buffer-from');
 import extend = require('extend');
 import semver = require('semver');
 import vcapServices = require('vcap_services');
@@ -317,7 +314,7 @@ export class BaseService {
       if (!hasIamCredentials(_options) && !usesBasicForIam(_options)) {
         if (hasBasicCredentials(_options)) {
           // Calculate and add Authorization header to base options
-          const encodedCredentials = bufferFrom(
+          const encodedCredentials = Buffer.from(
             `${_options.username}:${_options.password}`
           ).toString('base64');
           const authHeader = { Authorization: `Basic ${encodedCredentials}` };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1698,7 +1698,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/is-stream": "~1.1.0",
     "@types/node": "~10.3.5",
     "axios": "^0.18.0",
-    "buffer-from": "~1.1.0",
     "dotenv": "^6.2.0",
     "extend": "~3.0.2",
     "file-type": "^7.7.1",


### PR DESCRIPTION
Upon further review of the `buffer-from` package, all it does is [provide a polyfill for the Node v4 style of creating buffers](https://github.com/LinusU/buffer-from/blob/master/index.js#L68).

Since we removed support for Node v4 in the last major release, this is no longer a necessary dependency. We can just use native buffers.