### PR TITLE
fix: carry user options from constructor to axios parameters

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -15,7 +15,6 @@
  */
 
 import extend = require('extend');
-import semver = require('semver');
 import vcapServices = require('vcap_services');
 import { IamTokenManagerV1 } from '../iam-token-manager/v1';
 import { stripTrailingSlash } from './helper';

--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -281,7 +281,7 @@ export function sendRequest(parameters, _callback) {
     httpsAgent: new https.Agent({ rejectUnauthorized }),
   };
 
-  axios(requestParams)
+  axios(extend(true, {}, options, requestParams))
     .then(res => {
       // the other sdks use the interface `result` for the body
       _callback(null, res.data, res);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10447,7 +10447,8 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "semver-regex": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "mime-types": "~2.1.18",
     "object.omit": "~3.0.0",
     "object.pick": "~1.3.0",
-    "semver": "^5.6.0",
     "vcap_services": "~0.3.4"
   },
   "engines": {
@@ -79,10 +78,11 @@
     "eslint:fix": "eslint . --fix",
     "eslint:check": "eslint . --cache",
     "lint": "npm run eslint:check && npm run tslint:check",
-    "test": "jest --silent --verbose test/unit/",
-    "test-travis": "jest --silent --runInBand test/unit/",
+    "test": "jest --verbose test/unit/",
+    "test-travis": "jest --runInBand test/unit/",
     "report-coverage": "codecov",
-    "prepare": "tsc"
+    "build": "tsc",
+    "prepare": "npm run build"
   },
   "jest": {
     "collectCoverage": true,

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -293,6 +293,37 @@ describe('sendRequest', () => {
       done();
     });
   });
+
+  it('should keep parameters in options that are not explicity set in requestwrapper', done => {
+    const parameters = {
+      defaultOptions: {
+        body: 'post=body',
+        formData: '',
+        qs: {},
+        method: 'POST',
+        rejectUnauthorized: true,
+        url:
+          'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id',
+        headers: {
+          'test-header': 'test-header-value',
+        },
+        responseType: 'buffer',
+      },
+      options: {
+        otherParam: 500,
+      },
+    };
+
+    axios.mockResolvedValue('res');
+
+    sendRequest(parameters, (err, body, res) => {
+      // assert results
+      expect(axios.mock.calls[0][0].otherParam).toEqual(500);
+      expect(res).toEqual('res');
+      expect(axios.mock.calls.length).toBe(1);
+      done();
+    });
+  });
 });
 
 describe('formatError', () => {


### PR DESCRIPTION
This allows users to set parameters on the `axios` config object using the service constructor.

Before this change, there is no way for the user to have any control over the `axios` configuration. In v3 of the SDK, we allowed parameters to be passed through to the `request` configuration, so this is consistent with that behavior. Maybe this is not something we want to do but I think it is helpful to the user.

Note that this only carries parameters from the service constructor, so it would apply to all requests. We could potentially make these parameters settable on a per-request basis but that would require more changes and is probably less desirable.