### PR TITLE
fix: do not read credentials file in webpack override scenario

### DIFF
--- a/lib/read-credentials-file.ts
+++ b/lib/read-credentials-file.ts
@@ -6,6 +6,10 @@ import path = require('path');
 const filename: string = 'ibm-credentials.env';
 
 export function readCredentialsFile() {
+  if (!fs.existsSync) {
+    return {};
+  }
+
   // first look for an env variable called IBM_CREDENTIALS_FILE
   // it should be the path to the file
 

--- a/test/unit/readCredentialsFile.test.js
+++ b/test/unit/readCredentialsFile.test.js
@@ -4,6 +4,23 @@ const readCredentialsFunctions = require('../../lib/read-credentials-file');
 const constructFilepath = readCredentialsFunctions.constructFilepath;
 const fileExistsAtPath = readCredentialsFunctions.fileExistsAtPath;
 const readCredentialsFile = readCredentialsFunctions.readCredentialsFile;
+const fs = require('fs');
+
+describe('browser scenario', () => {
+  const existSync = fs.existsSync;
+  beforeAll(() => {
+    fs.existsSync = undefined;
+  });
+
+  it('should return empty object when webpack override fs with empty object', () => {
+    const cred = readCredentialsFile();
+    expect(cred).toEqual({});
+  });
+
+  afterAll(() => {
+    fs.existsSync = existSync;
+  });
+});
 
 describe('read ibm credentials file', () => {
   const locationOfActualFile = __dirname + '/../resources';


### PR DESCRIPTION
Related to: https://github.com/watson-developer-cloud/node-sdk/issues/865