### PR TITLE
Refactor bluemix to cloud.ibm

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -298,7 +298,7 @@ export class BaseService {
     // but prefer credentials provided programatically
     _options = extend(
       {},
-      this.getCredentialsFromIBMCloud(this.name),
+      this.getCredentialsFromCloud(this.name),
       this.getCredentialsFromEnvironment(process.env, this.name),
       this.getCredentialsFromEnvironment(readCredentialsFile(), this.name),
       options,
@@ -385,7 +385,7 @@ export class BaseService {
    * @private
    * @returns {Credentials}
    */
-  private getCredentialsFromIBMCloud(vcapServicesName: string): Credentials {
+  private getCredentialsFromCloud(vcapServicesName: string): Credentials {
     let credentials: Credentials;
     let temp: any;
     if (this.name === 'visual_recognition') {

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -294,11 +294,11 @@ export class BaseService {
       _options = extend(_options, options);
       return _options;
     }
-    // Get credentials from environment properties or Bluemix,
+    // Get credentials from environment properties or IBM Cloud,
     // but prefer credentials provided programatically
     _options = extend(
       {},
-      this.getCredentialsFromBluemix(this.name),
+      this.getCredentialsFromIbmCloud(this.name),
       this.getCredentialsFromEnvironment(process.env, this.name),
       this.getCredentialsFromEnvironment(readCredentialsFile(), this.name),
       options,
@@ -380,12 +380,12 @@ export class BaseService {
     };
   }
   /**
-   * Pulls credentials from VCAP_SERVICES env property that bluemix sets
+   * Pulls credentials from VCAP_SERVICES env property that IBM Cloud sets
    * @param {string} vcap_services_name
    * @private
    * @returns {Credentials}
    */
-  private getCredentialsFromBluemix(vcapServicesName: string): Credentials {
+  private getCredentialsFromIbmCloud(vcapServicesName: string): Credentials {
     let credentials: Credentials;
     let temp: any;
     if (this.name === 'visual_recognition') {

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -298,7 +298,7 @@ export class BaseService {
     // but prefer credentials provided programatically
     _options = extend(
       {},
-      this.getCredentialsFromIbmCloud(this.name),
+      this.getCredentialsFromIBMCloud(this.name),
       this.getCredentialsFromEnvironment(process.env, this.name),
       this.getCredentialsFromEnvironment(readCredentialsFile(), this.name),
       options,
@@ -385,7 +385,7 @@ export class BaseService {
    * @private
    * @returns {Credentials}
    */
-  private getCredentialsFromIbmCloud(vcapServicesName: string): Credentials {
+  private getCredentialsFromIBMCloud(vcapServicesName: string): Credentials {
     let credentials: Credentials;
     let temp: any;
     if (this.name === 'visual_recognition') {

--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -4,7 +4,7 @@ import { FileObject } from '../lib/helper';
 // This module attempts to identify common content-types based on the filename or header
 // It is not exhaustive, and for best results, you should always manually specify the content-type option.
 // See the complete list of supported content-types at
-// https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
+// https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-input#formats
 
 // *some* file types can be identified by the first 3-4 bytes of the file
 const headerContentTypes: { [key: string]: string } = {

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -421,7 +421,7 @@ describe('formatError', () => {
   it('check the unauthenticated thing - iam', () => {
     basicAxiosError.response.status = 400;
     basicAxiosError.response.data.context = {
-      url: 'http://iam.bluemix.net',
+      url: 'https://iam.cloud.ibm.com/identity/token',
     };
     const error = formatError(basicAxiosError);
     expect(error instanceof Error).toBe(true);


### PR DESCRIPTION
This pull request refactors bluemix to cloud.ibm. `getCredentialsFromBluemix()` is a private method. Are we safe refactoring this to `getCredentialsFromIbmCloud`?