### PR TITLE
fix(IAM): renamed UserOptions iam_secret to iam_client_secret to be consistent with other cores

### DIFF
--- a/iam-token-manager/v1.ts
+++ b/iam-token-manager/v1.ts
@@ -38,7 +38,7 @@ export type Options = {
   iamAccessToken?: string;
   iamUrl?: string;
   iamClientId?: string;
-  iamSecret?: string;
+  iamClientSecret?: string;
 }
 
 // this interface is a representation of the response
@@ -60,7 +60,7 @@ export class IamTokenManagerV1 {
   private iamApikey: string;
   private userAccessToken: string;
   private iamClientId: string;
-  private iamSecret: string;
+  private iamClientSecret: string;
 
   /**
    * IAM Token Manager Service
@@ -85,10 +85,10 @@ export class IamTokenManagerV1 {
     if (options.iamClientId) {
       this.iamClientId = options.iamClientId;
     }
-    if (options.iamSecret) {
-      this.iamSecret = options.iamSecret;
+    if (options.iamClientSecret) {
+      this.iamClientSecret = options.iamClientSecret;
     }
-    if (onlyOne(options.iamClientId, options.iamSecret)) {
+    if (onlyOne(options.iamClientId, options.iamClientSecret)) {
       // tslint:disable-next-line
       console.log(CLIENT_ID_SECRET_WARNING);
     }
@@ -127,20 +127,20 @@ export class IamTokenManagerV1 {
   }
 
   /**
-   * Set the IAM 'client_id' and 'secret' values.
+   * Set the IAM 'client_id' and 'client_secret' values.
    * These values are used to compute the Authorization header used
    * when retrieving or refreshing the IAM access token.
    * If these values are not set, then a default Authorization header
    * will be used when interacting with the IAM token server.
    *
    * @param {string} iamClientId - The client id 
-   * @param {string} iamSecret - The secret
+   * @param {string} iamClientSecret - The client secret
    * @returns {void}
    */
-  public setIamAuthorizationInfo(iamClientId: string, iamSecret: string): void {
+  public setIamAuthorizationInfo(iamClientId: string, iamClientSecret: string): void {
     this.iamClientId = iamClientId;
-    this.iamSecret = iamSecret;
-    if (onlyOne(iamClientId, iamSecret)) {
+    this.iamClientSecret = iamClientSecret;
+    if (onlyOne(iamClientId, iamClientSecret)) {
       // tslint:disable-next-line
       console.log(CLIENT_ID_SECRET_WARNING);
     }
@@ -271,14 +271,14 @@ export class IamTokenManagerV1 {
   private computeIamAuthHeader(): string {
 	// Use bx:bx as default auth header creds.
 	let clientId = 'bx';
-	let secret = 'bx';
+	let clientSecret = 'bx';
 	
 	// If both the clientId and secret were specified by the user, then use them.
-	if (this.iamClientId && this.iamSecret) {
+	if (this.iamClientId && this.iamClientSecret) {
       clientId = this.iamClientId;
-      secret = this.iamSecret;
+      clientSecret = this.iamClientSecret;
 	}
-    const encodedCreds = Buffer.from(`${clientId}:${secret}`).toString('base64');
+    const encodedCreds = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
     return `Basic ${encodedCreds}`;
   }
 }

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -40,7 +40,7 @@ export interface UserOptions {
   iam_apikey?: string;
   iam_url?: string;
   iam_client_id?: string;
-  iam_secret?: string;
+  iam_client_secret?: string;
   disable_ssl_verification?: boolean;
 }
 
@@ -126,7 +126,7 @@ export class BaseService {
    * @param {string} [options.iam_access_token] - iam access token provided and managed by user
    * @param {string} [options.iam_url] - url for iam service api, needed for services in staging
    * @param {string} [options.iam_client_id] - client id (username) for request to iam service
-   * @param {string} [options.iam_secret] - secret (password) for request to iam service
+   * @param {string} [options.iam_client_secret] - secret (password) for request to iam service
    * @param {string} [options.username] - required unless use_unauthenticated is set
    * @param {string} [options.password] - required unless use_unauthenticated is set
    * @param {boolean} [options.use_unauthenticated] - skip credential requirement
@@ -166,14 +166,14 @@ export class BaseService {
         iamAccessToken: _options.iam_access_token,
         iamUrl: _options.iam_url,
         iamClientId: _options.iam_client_id,
-        iamSecret: _options.iam_secret
+        iamClientSecret: _options.iam_client_secret
       });
     } else if (usesBasicForIam(_options)) {
       this.tokenManager = new IamTokenManagerV1({
         iamApikey: _options.password,
         iamUrl: _options.iam_url,
         iamClientId: _options.iam_client_id,
-        iamSecret: _options.iam_secret
+        iamClientSecret: _options.iam_client_secret
       });
     } else {
       this.tokenManager = null;

--- a/test/unit/baseService.test.js
+++ b/test/unit/baseService.test.js
@@ -291,7 +291,7 @@ describe('BaseService', function() {
       iam_access_token: 'real-token-84',
       iam_url: 'iam.com/api',
       iam_client_id: 'abc',
-      iam_secret: 'abc',
+      iam_client_secret: 'abc',
     });
 
     expect(instance.tokenManager).toBeDefined();
@@ -300,7 +300,7 @@ describe('BaseService', function() {
     expect(instance.tokenManager.userAccessToken).toBeDefined();
     expect(instance.tokenManager.iamUrl).toBeDefined();
     expect(instance.tokenManager.iamClientId).toBeDefined();
-    expect(instance.tokenManager.iamSecret).toBeDefined();
+    expect(instance.tokenManager.iamClientSecret).toBeDefined();
   });
 
   it('should pass all credentials to token manager when given iam with basic', function() {
@@ -309,7 +309,7 @@ describe('BaseService', function() {
       password: 'key1234',
       iam_url: 'iam.com/api',
       iam_client_id: 'abc',
-      iam_secret: 'abc',
+      iam_client_secret: 'abc',
     });
 
     expect(instance.tokenManager).toBeDefined();
@@ -317,7 +317,7 @@ describe('BaseService', function() {
     expect(instance.tokenManager.iamApikey).toBeDefined();
     expect(instance.tokenManager.iamUrl).toBeDefined();
     expect(instance.tokenManager.iamClientId).toBeDefined();
-    expect(instance.tokenManager.iamSecret).toBeDefined();
+    expect(instance.tokenManager.iamClientSecret).toBeDefined();
   });
 
   it('should not fail if setAccessToken is called and token manager is null', function() {

--- a/test/unit/iamTokenManager.test.js
+++ b/test/unit/iamTokenManager.test.js
@@ -223,7 +223,7 @@ describe('iam_token_manager_v1', function() {
     const instance = new IamTokenManagerV1({
       iamApikey: 'abcd-1234',
       iamClientId: 'foo',
-      iamSecret: 'bar',
+      iamClientSecret: 'bar',
     });
 
     requestWrapper.sendRequest.mockImplementation((parameters, _callback) => {
@@ -267,7 +267,7 @@ describe('iam_token_manager_v1', function() {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     const instance = new IamTokenManagerV1({
       iamApikey: 'abcd-1234',
-      iamSecret: 'bar',
+      iamClientSecret: 'bar',
     });
 
     // verify warning was triggered


### PR DESCRIPTION
This PR renames `iam_secret` to `iam_client_secret` and `iamSecret` to `iamClientSecret` so that the node sdk core will be similar to other cores wrt IAM-related terminology.