### PR TITLE
fix: temporarily disable gzipping until axios bug fix is released

### DIFF
--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -269,8 +269,11 @@ export function sendRequest(parameters, _callback) {
     headers = extend(true, {}, headers, multipartForm.getHeaders());
   }
 
+  // TEMPORARY: Disabling gzipping due to bug in axios until fix is released:
+  // https://github.com/axios/axios/pull/1129
+
   // accept gzip encoded responses if Accept-Encoding is not already set
-  headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'gzip';
+  // headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'gzip';
 
   const requestParams = {
     url,

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -45,7 +45,7 @@ describe('sendRequest', () => {
         'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
       );
       expect(axios.mock.calls[0][0].headers).toEqual({
-        'Accept-Encoding': 'gzip',
+        // 'Accept-Encoding': 'gzip',
         'test-header': 'test-header-value',
       });
       expect(axios.mock.calls[0][0].httpsAgent.options.rejectUnauthorized).toEqual(
@@ -134,7 +134,7 @@ describe('sendRequest', () => {
         'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
       );
       expect(axios.mock.calls[0][0].headers).toEqual({
-        'Accept-Encoding': 'gzip',
+        // 'Accept-Encoding': 'gzip',
         'test-header': 'override-header-value',
         'add-header': 'add-header-value',
       });
@@ -207,7 +207,7 @@ describe('sendRequest', () => {
         'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
       );
       expect(axios.mock.calls[0][0].headers).toMatchObject({
-        'Accept-Encoding': 'gzip',
+        // 'Accept-Encoding': 'gzip',
         'test-header': 'override-header-value',
         'add-header': 'add-header-value',
       });


### PR DESCRIPTION
Currently, `204` responses (no content) get flagged as errors because `axios` chokes when it tries to unzip an empty response.

A fix for this bug has been merged ([see PR](https://github.com/axios/axios/pull/1129)) but has not been released yet. Since it looks like `axios` is not doing patch releases for bug fixes right now but is waiting for their next big release (0.19), we need to temporarily disable gzipping in the SDK.

We could do this only for operations that return a 204 but that would require generator changes so I think that would be more work than necessary, considering a fix for the bug seems to be in the somewhat near future.

If someone thinks that it would be worth it to do that, I'm happy to do it. Just let me know