### PR TITLE
fix: remove node request objects from detailed response

### DIFF
--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -291,6 +291,8 @@ export function sendRequest(parameters, _callback) {
 
   axios(extend(true, {}, options, requestParams))
     .then(res => {
+      delete res.config;
+      delete res.request;
       // the other sdks use the interface `result` for the body
       _callback(null, res.data, res);
     })


### PR DESCRIPTION
This will prevent the circular JSON error when attempting to stringify the detailed response. The detailed response will include the status code, the status, the headers, and the data.