### PR TITLE
build: drop support for Node versions 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- 6
-- 8
 - 10
+- 12
 script:
 - npm run prepare
 - npm run lint
@@ -17,4 +16,4 @@ deploy:
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 10
+    node: 12

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -1,0 +1,4 @@
+# Migration Guide for v1
+
+## Breaking Changes
+Node versions 6 and 8 are no longer supported.

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "vcap_services": "~0.3.4"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "scripts": {
     "commitmsg": "commitlint -E GIT_PARAMS",


### PR DESCRIPTION
BREAKING CHANGE: This SDK may no longer work with applications running on Node 6 or 8.

First official commit to the v1 release candidate branch.