### PR TITLE
fix: extend constructor options type to allow additional properties

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -46,6 +46,8 @@ export interface UserOptions {
   iam_client_secret?: string;
   authentication_type?: string;
   disable_ssl_verification?: boolean;
+  /** Allow additional request config parameters */
+  [propName: string]: any;
 }
 
 export interface BaseServiceOptions extends UserOptions {


### PR DESCRIPTION
We expose the `axios` config options in the constructor but we don't allow any flexibility in the constructor options type. This will allow TypeScript users to use the request parameters like the `axios` config properties.