### PR TITLE
fix: share service request wrapper instance with token managers

### DIFF
--- a/auth/iam-token-manager-v1.ts
+++ b/auth/iam-token-manager-v1.ts
@@ -42,6 +42,7 @@ export type Options = {
   iamAccessToken?: string;
   iamClientId?: string;
   iamClientSecret?: string;
+  requestWrapper?: any;
 }
 
 // this interface is a representation of the response

--- a/auth/icp4d-token-manager-v1.ts
+++ b/auth/icp4d-token-manager-v1.ts
@@ -24,6 +24,7 @@ export type Options = {
   username?: string;
   password?: string;
   disableSslVerification?: boolean;
+  requestWrapper?: any;
 }
 
 // this interface is a representation of the response

--- a/auth/jwt-token-manager-v1.ts
+++ b/auth/jwt-token-manager-v1.ts
@@ -25,6 +25,7 @@ function getCurrentTime(): number {
 export type Options = {
   accessToken?: string;
   url?: string;
+  requestWrapper?: any;
 }
 
 export class JwtTokenManagerV1 {
@@ -61,7 +62,8 @@ export class JwtTokenManagerV1 {
       this.userAccessToken = options.accessToken;
     }
 
-    this.requestWrapperInstance = new RequestWrapper();
+    // not required, but the SDK will always pass in a request wrapper instance
+    this.requestWrapperInstance = options.requestWrapper || new RequestWrapper();
   }
 
   /**

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -200,6 +200,8 @@ export class BaseService {
     // used to disable ssl checking for icp
     this._options.rejectUnauthorized = !options.disable_ssl_verification;
 
+    this.requestWrapperInstance = new RequestWrapper(this._options);
+
     if (_options.authentication_type === 'iam' || hasIamCredentials(_options)) {
       this.tokenManager = new IamTokenManagerV1({
         iamApikey: _options.iam_apikey,
@@ -207,6 +209,7 @@ export class BaseService {
         url: _options.iam_url,
         iamClientId: _options.iam_client_id,
         iamClientSecret: _options.iam_client_secret,
+        requestWrapper: this.requestWrapperInstance,
       });
     } else if (usesBasicForIam(_options)) {
       this.tokenManager = new IamTokenManagerV1({
@@ -214,6 +217,7 @@ export class BaseService {
         url: _options.iam_url,
         iamClientId: _options.iam_client_id,
         iamClientSecret: _options.iam_client_secret,
+        requestWrapper: this.requestWrapperInstance,
       });
     } else if (isForICP4D(_options)) {
       if (!_options.icp4d_url && !_options.icp4d_access_token) {
@@ -225,12 +229,11 @@ export class BaseService {
         password: _options.password,
         accessToken: _options.icp4d_access_token,
         disableSslVerification: options.disable_ssl_verification,
+        requestWrapper: this.requestWrapperInstance,
       });
     } else {
       this.tokenManager = null;
     }
-
-    this.requestWrapperInstance = new RequestWrapper(this._options);
   }
 
   /**
@@ -298,10 +301,12 @@ export class BaseService {
         accessToken: access_token,
         url: this._options.icp4d_url,
         disableSslVerification: this._options.disable_ssl_verification,
+        requestWrapper: this.requestWrapperInstance,
       });
     } else {
       this.tokenManager = new IamTokenManagerV1({
         accessToken: access_token,
+        requestWrapper: this.requestWrapperInstance,
       });
     }
   }

--- a/test/unit/base-service-integration.test.js
+++ b/test/unit/base-service-integration.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const util = require('util');
+const BaseService = require('../../lib/base_service').BaseService;
+
+function TestService(options) {
+  BaseService.call(this, options);
+}
+
+util.inherits(TestService, BaseService);
+
+TestService.prototype.name = 'test';
+TestService.prototype.version = 'v1';
+
+TestService.URL = 'https://gateway.watsonplatform.net/test/api';
+
+/*
+ * Test the way the BaseService interacts with other modules
+*/
+describe('Base service - token manager - integration', function() {
+  it('should propagate request properties to token managers', function() {
+    const hostname = 'jabba.the.hutt';
+    const port = 'mos eisley';
+
+    const instance = new TestService({
+      iam_apikey: 'r2-d2',
+      proxy: {
+        hostname,
+        port,
+      },
+    });
+
+    expect(instance.tokenManager).toBeDefined();
+
+    const axiosOptions = instance.tokenManager.requestWrapperInstance.axiosInstance.defaults;
+    expect(axiosOptions.proxy.hostname).toBe(hostname);
+    expect(axiosOptions.proxy.port).toBe(port);
+  });
+});


### PR DESCRIPTION
This will allow users to configure all requests, rather than just the service requests. This was causing a bug where users could not use the SDK behind a corporate proxy. They could specify the proxy for the service request but the IAM request would error.