### PR TITLE
refactor: rename noauth authenticator to noAuth authenticator

### DIFF
--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -20,5 +20,5 @@ export { BasicAuthenticator } from './basic-authenticator';
 export { BearerTokenAuthenticator } from './bearer-token-authenticator';
 export { CloudPakForDataAuthenticator } from './cloud-pak-for-data-authenticator';
 export { IamAuthenticator } from './iam-authenticator';
-export { NoauthAuthenticator } from './no-auth-authenticator';
+export { NoAuthAuthenticator } from './no-auth-authenticator';
 export { TokenRequestBasedAuthenticator } from './token-request-based-authenticator';

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -17,9 +17,9 @@
 import { Authenticator } from './authenticator';
 import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
-export class NoauthAuthenticator extends Authenticator implements AuthenticatorInterface {
+export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
   /**
-   * Noauth Authenticator Class
+   * NoAuth Authenticator Class
    *
    * Provides a way to use a service without specifying credentials.
    *

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -22,7 +22,7 @@ import {
   BearerTokenAuthenticator,
   CloudPakForDataAuthenticator,
   IamAuthenticator,
-  NoauthAuthenticator,
+  NoAuthAuthenticator,
 } from '../authenticators';
 
 import { readExternalSources } from './read-external-sources';
@@ -58,8 +58,8 @@ export function getAuthenticatorFromEnvironment(serviceName: string) {
   let authenticator;
 
   switch (credentials.authType) {
-    case 'noauth':
-      authenticator = new NoauthAuthenticator();
+    case 'noAuth':
+      authenticator = new NoAuthAuthenticator();
       break;
     case 'basic':
       authenticator = new BasicAuthenticator(credentials);

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -19,12 +19,12 @@ RequestWrapper.mockImplementation(() => {
 });
 
 // mock the authenticator
-const noauthLocation = '../../auth/authenticators/no-auth-authenticator';
-jest.mock(noauthLocation);
-const { NoauthAuthenticator } = require(noauthLocation);
+const noAuthLocation = '../../auth/authenticators/no-auth-authenticator';
+jest.mock(noAuthLocation);
+const { NoAuthAuthenticator } = require(noAuthLocation);
 const authenticateMock = jest.fn();
 
-NoauthAuthenticator.mockImplementation(() => {
+NoAuthAuthenticator.mockImplementation(() => {
   return {
     authenticate: authenticateMock,
   };
@@ -37,7 +37,7 @@ const { BaseService } = require('../../lib/base_service');
 const NO_OP = () => {};
 const DEFAULT_URL = 'https://gateway.watsonplatform.net/test/api';
 const DEFAULT_NAME = 'test';
-const AUTHENTICATOR = new NoauthAuthenticator();
+const AUTHENTICATOR = new NoAuthAuthenticator();
 const EMPTY_OBJECT = {}; // careful that nothing is ever added to this object
 
 setupFakeService(); // set up the TestService "class"
@@ -247,7 +247,7 @@ describe('Base Service', () => {
       authenticator: AUTHENTICATOR,
     });
 
-    // note that the NoauthAuthenticator can't actually call the callback with an error,
+    // note that the NoAuthAuthenticator can't actually call the callback with an error,
     // but others can
     const fakeError = new Error('token request failed');
     authenticateMock.mockImplementation((_, callback) => callback(fakeError));

--- a/test/unit/get-authenticator-from-environment.test.js
+++ b/test/unit/get-authenticator-from-environment.test.js
@@ -6,7 +6,7 @@ const {
   BearerTokenAuthenticator,
   CloudPakForDataAuthenticator,
   IamAuthenticator,
-  NoauthAuthenticator,
+  NoAuthAuthenticator,
 } = require('../../auth');
 
 // create a mock for the read-external-sources module
@@ -31,10 +31,10 @@ describe('Get Authenticator From Environment Module', () => {
     expect(() => getAuthenticatorFromEnvironment(SERVICE_NAME)).toThrow();
   });
 
-  it('should get noauth authenticator', () => {
+  it('should get no auth authenticator', () => {
     setUpNoauthPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
-    expect(authenticator).toBeInstanceOf(NoauthAuthenticator);
+    expect(authenticator).toBeInstanceOf(NoAuthAuthenticator);
     expect(readExternalSourcesMock).toHaveBeenCalled();
   });
 
@@ -87,7 +87,7 @@ describe('Get Authenticator From Environment Module', () => {
 // mock payloads for the read-external-sources module
 function setUpNoauthPayload() {
   readExternalSourcesMock.mockImplementation(() => ({
-    authType: 'noauth',
+    authType: 'noAuth',
   }));
 }
 

--- a/test/unit/no-auth-authenticator.test.js
+++ b/test/unit/no-auth-authenticator.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { NoauthAuthenticator } = require('../../auth');
+const { NoAuthAuthenticator } = require('../../auth');
 
-describe('Noauth Authenticator', () => {
+describe('NoAuth Authenticator', () => {
   it('should call callback on authenticate', done => {
-    const authenticator = new NoauthAuthenticator();
+    const authenticator = new NoAuthAuthenticator();
     authenticator.authenticate({}, err => {
       expect(err).toBeNull();
       done();


### PR DESCRIPTION
Update all instances of the word "noauth" to be two words - "no auth" - using language specific naming conventions.