### PR TITLE
Fix handling of array form parameters

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -338,7 +338,20 @@ export class BaseService {
    * are being used to authenticate the request. If so, the token is
    * retrieved by the token manager.
    *
-   * @param {Object} parameters - service request options passed in by user
+   * @param {Object} parameters - service request options passed in by user.
+   * @param {string} parameters.options.method - the http method.
+   * @param {string} parameters.options.url - the URL of the service.
+   * @param {string} parameters.options.path - the path to be appended to the service URL.
+   * @param {string} parameters.options.qs - the querystring to be included in the URL.
+   * @param {string} parameters.options.body - the data to be sent as the request body.
+   * @param {Object} parameters.options.form - an object containing the key/value pairs for a www-form-urlencoded request.
+   * @param {Object} parameters.options.formData - an object containing the contents for a multipart/form-data request.
+   * The following processing is performed on formData values:
+   * - string: no special processing -- the value is sent as is
+   * - object: the value is converted to a JSON string before insertion into the form body
+   * - NodeJS.ReadableStream|FileObject|Buffer|FileParamAttributes: sent as a file, with any associated metadata
+   * - array: each element of the array is sent as a separate form part using any special processing as described above
+   * @param {HeaderOptions} parameters.options.headers - additional headers to be passed on the request.
    * @param {Function} callback - callback function to pass the response back to
    * @returns {ReadableStream|undefined}
    */

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -43,12 +43,21 @@ export interface FileStream extends NodeJS.ReadableStream {
 }
 
 // custom type guards
-function isFileObject(obj: any): obj is FileObject {
+export function isFileObject(obj: any): obj is FileObject {
   return Boolean(obj && obj.value);
 }
 
 function isFileStream(obj: any): obj is FileStream {
   return obj && isReadable(obj) && obj.path;
+}
+
+export function isFileParamAttributes(obj: any): obj is FileParamAttributes {
+  return obj && obj.data &&
+   (
+     isReadable(obj.data) ||
+     Buffer.isBuffer(obj.data) ||
+     isFileObject(obj.data)
+   );
 }
 
 export function isFileParam(obj: any): boolean {
@@ -58,7 +67,7 @@ export function isFileParam(obj: any): boolean {
       isReadable(obj) ||
       Buffer.isBuffer(obj) ||
       isFileObject(obj) ||
-      (obj.data && isFileParam(obj.data))
+      isFileParamAttributes(obj)
     )
   );
 }
@@ -164,6 +173,7 @@ export function getFormat(
  * this function builds a `form-data` object for each file parameter
  * @param {FileParamAttributes} fileParams - the file parameter attributes
  * @param {NodeJS.ReadableStream|Buffer|FileObject} fileParams.data - the data content of the file
+ * @param (string) fileParams.filename - the filename of the file
  * @param {string} fileParams.contentType - the content type of the file
  * @returns {FileObject}
  */

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -200,11 +200,11 @@ describe('sendRequest', () => {
           'add-header': 'add-header-value',
         },
         formData: {
-          file: fs.createReadStream('../blank.wav'),
+          file: fs.createReadStream(__dirname + '/../resources/blank.wav'),
           null_item: null,
           custom_file: {
             filename: 'custom.wav',
-            data: fs.createReadStream('../blank.wav'),
+            data: fs.createReadStream(__dirname + '/../resources/blank.wav'),
           },
           array_item: ['a', 'b'],
           object_item: { a: 'a', b: 'b' },
@@ -242,6 +242,13 @@ describe('sendRequest', () => {
       expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
         'Content-Disposition: form-data; name=\\"array_item\\"'
       );
+      // There should be two "array_item" parts
+      expect(
+        (
+          JSON.stringify(mockAxiosInstance.mock.calls[0][0].data).match(/name=\\"array_item\\"/g) ||
+          []
+        ).length
+      ).toEqual(2);
       expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
         'Content-Disposition: form-data; name=\\"custom_file\\"'
       );


### PR DESCRIPTION
This PR fixes the handling of array form parameters.

In a `multipart/form-data` request body, an array property should be serialized as multiple form data parts, each with the name of the array property and one of the elements of the array.

I've also added documentation for the primary exported method, `createRequest`, and refactored the processing of file properties to make it simpler/clearer.