### PR TITLE
minor refactoring for the authentication changes

### DIFF
--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -15,8 +15,6 @@
  */
 
 import { OutgoingHttpHeaders } from 'http';
-import { getMissingParams } from '../../lib/helper';
-import { checkCredentials } from '../utils/helpers'; // just using '../utils' here leads to a test failure. need to open an issue against typescript
 import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export class Authenticator implements AuthenticatorInterface {
@@ -35,21 +33,5 @@ export class Authenticator implements AuthenticatorInterface {
 
   public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
     throw new Error('Should be implemented by subclass!');
-  }
-
-  protected validate(options: any, requiredOptions: string[]): void {
-    // check for required params
-    const missingParamsError = getMissingParams(options, requiredOptions);
-    if (missingParamsError) {
-      throw missingParamsError;
-    }
-
-    // check certain credentials for common user errors: username, password, and apikey
-    // note: will only apply to certain authenticators
-    const credsToCheck = ['username', 'password', 'apikey']
-    const credentialProblems = checkCredentials(options, credsToCheck);
-    if (credentialProblems) {
-      throw new Error(credentialProblems);
-    }
   }
 }

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import extend = require('extend');
-import { computeBasicAuthHeader } from '../utils';
+import { computeBasicAuthHeader, validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
@@ -42,7 +42,7 @@ export class BasicAuthenticator extends Authenticator implements AuthenticatorIn
   constructor(options: Options) {
     super();
 
-    this.validate(options, this.requiredOptions);
+    validateInput(options, this.requiredOptions);
 
     this.username = options.username;
     this.password = options.password;

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -15,6 +15,7 @@
  */
 
 import extend = require('extend');
+import { validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
@@ -38,7 +39,7 @@ export class BearerTokenAuthenticator extends Authenticator implements Authentic
   constructor(options: Options) {
     super();
 
-    this.validate(options, this.requiredOptions);
+    validateInput(options, this.requiredOptions);
 
     this.bearerToken = options.bearerToken;
   }

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -16,6 +16,7 @@
 
 import { OutgoingHttpHeaders } from 'http';
 import { Cp4dTokenManager } from '../token-managers';
+import { validateInput } from '../utils';
 import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
 
 export interface Options extends BaseOptions {
@@ -26,6 +27,7 @@ export interface Options extends BaseOptions {
 
 export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator {
   protected requiredOptions = ['username', 'password', 'url'];
+  protected tokenManager: Cp4dTokenManager;
   private username: string;
   private password: string;
 
@@ -41,7 +43,7 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
   constructor(options: Options) {
     super(options);
 
-    this.validate(options, this.requiredOptions);
+    validateInput(options, this.requiredOptions);
 
     this.username = options.username;
     this.password = options.password;

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -16,6 +16,7 @@
 
 import { OutgoingHttpHeaders } from 'http';
 import { IamTokenManager } from '../token-managers';
+import { validateInput } from '../utils';
 import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
 
 export interface Options extends BaseOptions {
@@ -26,6 +27,7 @@ export interface Options extends BaseOptions {
 
 export class IamAuthenticator extends TokenRequestBasedAuthenticator {
   protected requiredOptions = ['apikey'];
+  protected tokenManager: IamTokenManager;
   private apikey: string;
   private clientId: string;
   private clientSecret: string;
@@ -41,7 +43,7 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
   constructor(options: Options) {    
     super(options);
 
-    this.validate(options, this.requiredOptions);
+    validateInput(options, this.requiredOptions);
 
     this.apikey = options.apikey;
     this.clientId = options.clientId;

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -29,7 +29,7 @@ export type BaseOptions = {
 }
 
 export class TokenRequestBasedAuthenticator extends Authenticator implements AuthenticatorInterface {
-  protected tokenManager: any;
+  protected tokenManager: JwtTokenManager;
   protected url: string;
   protected headers: OutgoingHttpHeaders;
   protected disableSslVerification: boolean;
@@ -66,11 +66,11 @@ export class TokenRequestBasedAuthenticator extends Authenticator implements Aut
     // if they try to pass in a non-boolean value,
     // use the "truthy-ness" of the value
     this.disableSslVerification = Boolean(value);
-    this.tokenManager.disableSslVerification = this.disableSslVerification; // could use a setter here
+    this.tokenManager.setDisableSslVerification(this.disableSslVerification);
   }
 
   /**
-   * Set a completely new set of headers. Should we have a method to add/remove a single header?
+   * Set a completely new set of headers.
    *
    * @param {OutgoingHttpHeaders} headers - the new set of headers as an object
    * @returns {void}
@@ -81,7 +81,7 @@ export class TokenRequestBasedAuthenticator extends Authenticator implements Aut
       return;
     }
     this.headers = headers;
-    this.tokenManager.headers = this.headers;
+    this.tokenManager.setHeaders(this.headers);
   }
 
   public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -16,16 +16,13 @@
 
 import extend = require('extend');
 import { getMissingParams } from '../../lib/helper';
-import { computeBasicAuthHeader } from '../utils';
-import { JwtTokenManager } from './jwt-token-manager';
+import { computeBasicAuthHeader, validateInput } from '../utils';
+import { JwtTokenManager, TokenManagerOptions } from './jwt-token-manager';
 
-// we should make these options extend the ones from the base class
-export type Options = {
+interface Options extends TokenManagerOptions {
   url: string;
-  username?: string;
-  password?: string;
-  disableSslVerification?: boolean;
-  requestWrapper?: any;
+  username: string;
+  password: string;
 }
 
 // this interface is a representation of the response
@@ -44,6 +41,7 @@ export interface CpdTokenData {
 }
 
 export class Cp4dTokenManager extends JwtTokenManager {
+  protected requiredOptions = ['username', 'password', 'url'];
   private username: string;
   private password: string;
 
@@ -65,12 +63,7 @@ export class Cp4dTokenManager extends JwtTokenManager {
 
     this.tokenName = 'accessToken';
 
-    // check for required params
-    const requiredOptions = ['username', 'password', 'url'];
-    const missingParamsError = getMissingParams(options, requiredOptions);
-    if (missingParamsError) {
-      throw missingParamsError;
-    }
+    validateInput(options, this.requiredOptions);
 
     const tokenApiPath = '/v1/preauth/validateAuth';
 

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -17,8 +17,8 @@
 import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import { getMissingParams } from '../../lib/helper';
-import { computeBasicAuthHeader } from '../utils';
-import { JwtTokenManager } from './jwt-token-manager';
+import { computeBasicAuthHeader, validateInput } from '../utils';
+import { JwtTokenManager, TokenManagerOptions } from './jwt-token-manager';
 
 /**
  * Check for only one of two elements being defined.
@@ -36,13 +36,10 @@ function onlyOne(a: any, b: any): boolean {
 
 const CLIENT_ID_SECRET_WARNING = 'Warning: Client ID and Secret must BOTH be given, or the header will not be included.';
 
-export type Options = {
+interface Options extends TokenManagerOptions {
   apikey: string;
-  url?: string;
   clientId?: string;
   clientSecret?: string;
-  disableSslVerification?: boolean;
-  headers?: OutgoingHttpHeaders;
 }
 
 // this interface is a representation of the response
@@ -57,6 +54,7 @@ export interface IamTokenData {
 }
 
 export class IamTokenManager extends JwtTokenManager {
+  protected requiredOptions = ['apikey'];
   private apikey: string;
   private clientId: string;
   private clientSecret: string;
@@ -75,12 +73,7 @@ export class IamTokenManager extends JwtTokenManager {
   constructor(options: Options) {
     super(options);
 
-    // check for required params
-    const requiredOptions = ['apikey'];
-    const missingParamsError = getMissingParams(options, requiredOptions);
-    if (missingParamsError) {
-      throw missingParamsError;
-    }
+    validateInput(options, this.requiredOptions);
     
     this.apikey = options.apikey;
 

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -23,8 +23,10 @@ function getCurrentTime(): number {
   return Math.floor(Date.now() / 1000);
 }
 
-export type Options = {
+export type TokenManagerOptions = {
   url?: string;
+  headers?: OutgoingHttpHeaders;
+  disableSslVerification?: boolean;
   /** Allow additional request config parameters */
   [propName: string]: any;
 }
@@ -48,9 +50,9 @@ export class JwtTokenManager {
    * @param {String} [options.accessToken] - user-managed access token
    * @constructor
    */
-  constructor(options: Options) {
+  constructor(options: TokenManagerOptions) {
     // all parameters are optional
-    options = options || {} as Options;
+    options = options || {} as TokenManagerOptions;
 
     this.tokenInfo = {};
     this.tokenName = 'access_token';
@@ -96,6 +98,32 @@ export class JwtTokenManager {
       // 2. use valid, managed token
       return cb(null, this.tokenInfo[this.tokenName]);
     }
+  }
+
+  /**
+   * Setter for the disableSslVerification property.
+   *
+   * @param {boolean} value - the new value for the disableSslVerification property
+   * @returns {void}
+   */
+  public setDisableSslVerification(value: boolean): void {
+    // if they try to pass in a non-boolean value,
+    // use the "truthy-ness" of the value
+    this.disableSslVerification = Boolean(value);
+  }
+
+  /**
+   * Set a completely new set of headers.
+   *
+   * @param {OutgoingHttpHeaders} headers - the new set of headers as an object
+   * @returns {void}
+   */
+  public setHeaders(headers: OutgoingHttpHeaders): void {
+    if (typeof headers !== 'object') {
+      // do nothing, for now
+      return;
+    }
+    this.headers = headers;
   }
 
   /**

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -18,6 +18,7 @@ import camelcase = require('camelcase');
 import extend = require('extend');
 
 import {
+  Authenticator,
   BasicAuthenticator,
   BearerTokenAuthenticator,
   CloudPakForDataAuthenticator,
@@ -27,7 +28,7 @@ import {
 
 import { readExternalSources } from './read-external-sources';
 
-export function getAuthenticatorFromEnvironment(serviceName: string) {
+export function getAuthenticatorFromEnvironment(serviceName: string): Authenticator {
   if (!serviceName) {
     throw new Error('Service name is required.');
   }

--- a/auth/utils/helpers.ts
+++ b/auth/utils/helpers.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { getMissingParams } from '../../lib/helper';
+
 /**
  * Compute and return a Basic Authorization header from a username and password.
  *
@@ -39,7 +41,7 @@ function badCharAtAnEnd(value: string): boolean {
  * @param {string[]} credsToCheck - An array containing the keys of the credentials to check for problems 
  * @returns {string | null} - Returns a string with the error message if there were problems, null if not
  */
-export function checkCredentials(obj: any, credsToCheck: string[]) : string | null {
+export function checkCredentials(obj: any, credsToCheck: string[]) : Error | null {
   let errorMessage = '';
   credsToCheck.forEach(cred => {
     if (obj[cred] && badCharAtAnEnd(obj[cred])) {
@@ -49,8 +51,24 @@ export function checkCredentials(obj: any, credsToCheck: string[]) : string | nu
 
   if (errorMessage.length) {
     errorMessage += 'Revise these credentials - they should not start or end with curly brackets or quotes.';
-    return errorMessage;
+    return new Error(errorMessage);
   } else {
     return null;
+  }
+}
+
+export function validateInput(options: any, requiredOptions: string[]): void {
+  // check for required params
+  const missingParamsError = getMissingParams(options, requiredOptions);
+  if (missingParamsError) {
+    throw missingParamsError;
+  }
+
+  // check certain credentials for common user errors: username, password, and apikey
+  // note: will only apply to certain authenticators
+  const credsToCheck = ['username', 'password', 'apikey']
+  const credentialProblems = checkCredentials(options, credsToCheck);
+  if (credentialProblems) {
+    throw credentialProblems;
   }
 }

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -28,7 +28,7 @@ export interface UserOptions {
   version?: string;
   headers?: OutgoingHttpHeaders;
   disableSslVerification?: boolean;
-  authenticator: AuthenticatorInterface;
+  authenticator?: AuthenticatorInterface;
   /** Allow additional request config parameters */
   [propName: string]: any;
 }
@@ -79,7 +79,7 @@ export class BaseService {
     // check serviceUrl for common user errors
     const credentialProblems = checkCredentials(options, ['serviceUrl']);
     if (credentialProblems) {
-      throw new Error(credentialProblems);
+      throw credentialProblems;
     }
 
     // if disableSslVerification is not explicity set to the boolean value `true`,


### PR DESCRIPTION
* refactor validate method to be used across authenticators/token mangers
* add types for token manager properties in authenticators
* add return type for `getAuthenticatorFromEnvironment`
* return `Error` object in `checkCredentials` rather than a `string`
* add setters for `disableSslVerification` and `headers` in token managers so we can use stricter typing
* Make `authenticator` optional in the base service options

This last point needed to be done to compile the Watson SDKs - TypeScript does not allow you to declare an optional parameter on an interface that extends another interface where the same parameter is required. We aren't _exactly_ extending the interface (although I think we should) but we use the "extended" interface in a place where the base interface is expected and TS complains. This resolves the issue. We still validate for the authenticator, just can't type it that way.