### PR TITLE
chore: replace @types/is-stream with correct @types/isstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,13 +1574,10 @@
         "@types/node": "*"
       }
     },
-    "@types/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
-      "requires": {
-        "@types/node": "*"
-      }
+    "@types/isstream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/isstream/-/isstream-0.1.0.tgz",
+      "integrity": "sha512-jo6R5XtVMgu1ej3H4o9NXiUE/4ZxyxmDrGslGiBa4/ugJr+Olw2viio/F2Vlc+zrwC9HJzuApOCCVC2g5jqV0w=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@types/extend": "~3.0.0",
     "@types/file-type": "~5.2.1",
-    "@types/is-stream": "~1.1.0",
+    "@types/isstream": "^0.1.0",
     "@types/node": "~10.3.5",
     "axios": "^0.18.0",
     "camelcase": "^5.3.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["node", "extend", "isstream"]    /* Type declaration files to be included in compilation. */
+    // "types": ["node", "extend", "isstream"]/* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["node", "extend", "is-stream"]    /* Type declaration files to be included in compilation. */
+    "types": ["node", "extend", "isstream"]    /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 


### PR DESCRIPTION
This changes the installed `@types` file to use the right typing package for the isstream module that is depended upon concretely.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
