### PR TITLE
feat: refactor core to use Promises instead of callbacks

### DIFF
--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -23,9 +23,6 @@ export interface AuthenticateOptions {
   [propName: string]: any;
 }
 
-// callback can send one arg, error or null
-export type AuthenticateCallback = (result: null | Error) => void;
-
 export interface AuthenticatorInterface {
-  authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void
+  authenticate(options: AuthenticateOptions): Promise<void | Error>
 }

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import { OutgoingHttpHeaders } from 'http';
-import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export class Authenticator implements AuthenticatorInterface {
   /**
@@ -31,7 +31,8 @@ export class Authenticator implements AuthenticatorInterface {
     }
   }
 
-  public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
-    throw new Error('Should be implemented by subclass!');
+  public authenticate(options: AuthenticateOptions): Promise<void | Error> {
+    const error = new Error('Should be implemented by subclass!');
+    return Promise.reject(error);
   }
 }

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -17,7 +17,7 @@
 import extend = require('extend');
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { Authenticator } from './authenticator';
-import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export type Options = {
   username?: string;
@@ -48,11 +48,13 @@ export class BasicAuthenticator extends Authenticator implements AuthenticatorIn
     this.password = options.password;
   }
 
-  public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
-    const authHeaderString = computeBasicAuthHeader(this.username, this.password);
-    const authHeader = { Authorization: authHeaderString }
+  public authenticate(options: AuthenticateOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const authHeaderString = computeBasicAuthHeader(this.username, this.password);
+      const authHeader = { Authorization: authHeaderString }
 
-    options.headers = extend(true, {}, options.headers, authHeader);
-    callback(null);
+      options.headers = extend(true, {}, options.headers, authHeader);
+      resolve();
+    });
   }
 }

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -17,7 +17,7 @@
 import extend = require('extend');
 import { validateInput } from '../utils';
 import { Authenticator } from './authenticator';
-import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export type Options = {
   bearerToken: string;
@@ -48,9 +48,11 @@ export class BearerTokenAuthenticator extends Authenticator implements Authentic
     this.bearerToken = bearerToken;
   }
 
-  public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
-    const authHeader = { Authorization: `Bearer ${this.bearerToken}` };
-    options.headers = extend(true, {}, options.headers, authHeader);
-    callback(null);
+  public authenticate(options: AuthenticateOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const authHeader = { Authorization: `Bearer ${this.bearerToken}` };
+      options.headers = extend(true, {}, options.headers, authHeader);
+      resolve();
+    });
   }
 }

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import { Authenticator } from './authenticator';
-import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
   /**
@@ -29,8 +29,8 @@ export class NoAuthAuthenticator extends Authenticator implements AuthenticatorI
     super();
   }
 
-  public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
+  public authenticate(options: AuthenticateOptions): Promise<void> {
     // immediately proceed to request. it will probably fail
-    callback(null);
+    return Promise.resolve();
   }
 }

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -18,7 +18,7 @@ import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import { JwtTokenManager } from '../token-managers';
 import { Authenticator } from './authenticator';
-import { AuthenticateCallback, AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
 export type BaseOptions = {
   headers?: OutgoingHttpHeaders;
@@ -84,15 +84,11 @@ export class TokenRequestBasedAuthenticator extends Authenticator implements Aut
     this.tokenManager.setHeaders(this.headers);
   }
 
-  public authenticate(options: AuthenticateOptions, callback: AuthenticateCallback): void {
-    this.tokenManager.getToken((err, token) => {
-      if (err) {
-        callback(err);
-      } else {
-        const authHeader = { Authorization: `Bearer ${token}` };
-        options.headers = extend(true, {}, options.headers, authHeader);
-        callback(null);
-      }
+  public authenticate(options: AuthenticateOptions): Promise<void | Error> {
+    return this.tokenManager.getToken().then(token => {
+      const authHeader = { Authorization: `Bearer ${token}` };
+      options.headers = extend(true, {}, options.headers, authHeader);
+      return;
     });
   }
 }

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -77,19 +77,11 @@ export class Cp4dTokenManager extends JwtTokenManager {
   }
 
   /**
-   * Callback for handling response.
-   *
-   * @callback requestTokenCallback
-   * @param {Error} An error if there is one, null otherwise
-   * @param {Object} The response if request is successful, null otherwise
-   */
-  /**
    * Request an CP4D token using a basic auth header.
    *
-   * @param {requestTokenCallback} callback - The callback that handles the response.
-   * @returns {void}
+   * @returns {Promise}
    */
-  protected requestToken(callback: Function): void {
+  protected requestToken(): Promise<any> {
     // these cannot be overwritten
     const requiredHeaders = {
       Authorization: computeBasicAuthHeader(this.username, this.password),
@@ -103,6 +95,6 @@ export class Cp4dTokenManager extends JwtTokenManager {
         rejectUnauthorized: !this.disableSslVerification,
       }
     };
-    this.requestWrapperInstance.sendRequest(parameters, callback);
+    return this.requestWrapperInstance.sendRequest(parameters);
   }
 }

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -112,19 +112,11 @@ export class IamTokenManager extends JwtTokenManager {
   }
 
   /**
-   * Callback for handling response.
-   *
-   * @callback requestTokenCallback
-   * @param {Error} An error if there is one, null otherwise
-   * @param {Object} The response if request is successful, null otherwise
-   */
-  /**
    * Request an IAM token using an API key.
    *
-   * @param {requestTokenCallback} callback - The callback that handles the response.
-   * @returns {void}
+   * @returns {Promise}
    */
-  protected requestToken(callback: Function): void {
+  protected requestToken(): Promise<any> {
     // these cannot be overwritten
     const requiredHeaders = {
       'Content-type': 'application/x-www-form-urlencoded',
@@ -148,6 +140,7 @@ export class IamTokenManager extends JwtTokenManager {
         rejectUnauthorized: !this.disableSslVerification,
       }
     };
-    this.requestWrapperInstance.sendRequest(parameters, callback);
+    
+    return this.requestWrapperInstance.sendRequest(parameters);
   }
 }

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -149,18 +149,18 @@ export class BaseService {
    * @param {Object} parameters.defaultOptions
    * @param {string} parameters.defaultOptions.serviceUrl - the base URL of the service
    * @param {OutgoingHttpHeaders} parameters.defaultOptions.headers - additional headers to be passed on the request.
-   * @param {Function} callback - callback function to pass the response back to
-   * @returns {ReadableStream|undefined}
+   * @returns {Promise<any>}
    */
-  protected createRequest(parameters, callback) {
+  protected createRequest(parameters): Promise<any> {
     // validate serviceUrl parameter has been set
     const serviceUrl = parameters.defaultOptions && parameters.defaultOptions.serviceUrl;
     if (!serviceUrl || typeof serviceUrl !== 'string') {
-      return callback(new Error('The service URL is required'), null);
+      return Promise.reject(new Error('The service URL is required'));
     }
 
-    this.authenticator.authenticate(parameters.defaultOptions, err => {
-      err ? callback(err) : this.requestWrapperInstance.sendRequest(parameters, callback);
+    return this.authenticator.authenticate(parameters.defaultOptions).then(() => {
+      // resolve() handles rejection as well, so resolving the result of sendRequest should allow for proper handling later
+      return this.requestWrapperInstance.sendRequest(parameters);
     });
   }
 

--- a/test/unit/basic-authenticator.test.js
+++ b/test/unit/basic-authenticator.test.js
@@ -41,15 +41,13 @@ describe('Basic Authenticator', () => {
     }).toThrow(/Revise these credentials/);
   });
 
-  it('should update the options and send `null` in the callback', done => {
+  it('should update the options and resolve the Promise with `null`', async done => {
     const authenticator = new BasicAuthenticator(CONFIG);
-
     const options = {};
+    const result = await authenticator.authenticate(options);
 
-    authenticator.authenticate(options, err => {
-      expect(err).toBeNull();
-      expect(options.headers.Authorization).toBe('Basic ZGF2ZTpncm9obA==');
-      done();
-    });
+    expect(result).toBeUndefined();
+    expect(options.headers.Authorization).toBe('Basic ZGF2ZTpncm9obA==');
+    done();
   });
 });

--- a/test/unit/bearer-token-authenticator.test.js
+++ b/test/unit/bearer-token-authenticator.test.js
@@ -19,16 +19,14 @@ describe('Bearer Token Authenticator', () => {
     }).toThrow();
   });
 
-  it('should update the options and send `null` in the callback', done => {
+  it('should update the options and resolve with `null`', async done => {
     const authenticator = new BearerTokenAuthenticator(config);
-
     const options = {};
+    const result = await authenticator.authenticate(options);
 
-    authenticator.authenticate(options, err => {
-      expect(err).toBeNull();
-      expect(options.headers.Authorization).toBe(`Bearer ${config.bearerToken}`);
-      done();
-    });
+    expect(result).toBeUndefined();
+    expect(options.headers.Authorization).toBe(`Bearer ${config.bearerToken}`);
+    done();
   });
 
   it('should re-set the bearer token using the setter', () => {

--- a/test/unit/cp4d-token-manager.test.js
+++ b/test/unit/cp4d-token-manager.test.js
@@ -89,18 +89,16 @@ describe('CP4D Token Manager', () => {
 
   describe('requestToken', () => {
     it('should call sendRequest with all request options', () => {
-      const noop = () => {};
       const instance = new Cp4dTokenManager({
         url: URL,
         username: USERNAME,
         password: PASSWORD,
       });
 
-      instance.requestToken(noop);
+      instance.requestToken();
 
       // extract arguments sendRequest was called with
       const params = mockSendRequest.mock.calls[0][0];
-      const callback = mockSendRequest.mock.calls[0][1];
 
       expect(mockSendRequest).toHaveBeenCalled();
       expect(params.options).toBeDefined();
@@ -108,9 +106,7 @@ describe('CP4D Token Manager', () => {
       expect(params.options.method).toBe('GET');
       expect(params.options.rejectUnauthorized).toBe(true);
       expect(params.options.headers).toBeDefined();
-
       expect(params.options.headers.Authorization).toBe('Basic c2hlcmxvY2s6aG9sbWVz');
-      expect(callback).toBe(noop);
     });
   });
 });

--- a/test/unit/no-auth-authenticator.test.js
+++ b/test/unit/no-auth-authenticator.test.js
@@ -3,11 +3,11 @@
 const { NoAuthAuthenticator } = require('../../auth');
 
 describe('NoAuth Authenticator', () => {
-  it('should call callback on authenticate', done => {
+  it('should resolve Promise on authenticate', async done => {
     const authenticator = new NoAuthAuthenticator();
-    authenticator.authenticate({}, err => {
-      expect(err).toBeNull();
-      done();
-    });
+    const result = await authenticator.authenticate({});
+
+    expect(result).toBeUndefined();
+    done();
   });
 });

--- a/test/unit/request-token-based-authenticator.test.js
+++ b/test/unit/request-token-based-authenticator.test.js
@@ -35,17 +35,22 @@ describe('Request Based Token Authenticator', () => {
     expect(authenticator.tokenManager.headers).toEqual(config.headers);
   });
 
-  it('should call the callback in authenticate with an error if the token request fails', done => {
+  it('should reject the Promise in authenticate with an error if the token request fails', done => {
     const authenticator = new TokenRequestBasedAuthenticator(config);
     const fakeError = new Error('fake error');
     const getTokenSpy = jest
       .spyOn(authenticator.tokenManager, 'getToken')
-      .mockImplementation(cb => cb(fakeError));
+      .mockImplementation(() => Promise.reject(fakeError));
 
-    authenticator.authenticate({}, err => {
-      expect(getTokenSpy).toHaveBeenCalled();
-      expect(err).toBe(fakeError);
-      done();
-    });
+    authenticator.authenticate({}).then(
+      res => {
+        done(`Promise unexpectedly resolved with value: ${res}`);
+      },
+      err => {
+        expect(getTokenSpy).toHaveBeenCalled();
+        expect(err).toBe(fakeError);
+        done();
+      }
+    );
   });
 });

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -52,7 +52,7 @@ describe('sendRequest', () => {
     mockAxiosInstance.mockReset();
   });
 
-  it('should send a request with default parameters', done => {
+  it('should send a request with default parameters', async done => {
     const parameters = {
       defaultOptions: {
         body: 'post=body',
@@ -70,27 +70,26 @@ describe('sendRequest', () => {
 
     mockAxiosInstance.mockResolvedValue(axiosResolveValue);
 
-    requestWrapperInstance.sendRequest(parameters, (err, res) => {
-      // assert results
-      expect(mockAxiosInstance.mock.calls[0][0].data).toEqual('post=body');
-      expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
-        'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
-      );
-      expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-        // 'Accept-Encoding': 'gzip',
-        'test-header': 'test-header-value',
-      });
-      expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
-      expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual(
-        parameters.defaultOptions.responseType
-      );
-      expect(res).toEqual(expectedResult);
-      expect(mockAxiosInstance.mock.calls.length).toBe(1);
-      done();
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(mockAxiosInstance.mock.calls[0][0].data).toEqual('post=body');
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
+      'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
+      // 'Accept-Encoding': 'gzip',
+      'test-header': 'test-header-value',
     });
+    expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
+    expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual(
+      parameters.defaultOptions.responseType
+    );
+    expect(res).toEqual(expectedResult);
+    expect(mockAxiosInstance.mock.calls.length).toBe(1);
+    done();
   });
 
-  it('should call formatError if request failed', done => {
+  it('should call formatError if request failed', async done => {
     const parameters = {
       defaultOptions: {
         body: 'post=body',
@@ -108,15 +107,20 @@ describe('sendRequest', () => {
 
     mockAxiosInstance.mockRejectedValue('error');
 
-    requestWrapperInstance.sendRequest(parameters, (err, res) => {
-      // assert results
-      expect(err).toEqual(expect.anything());
-      expect(res).toBeUndefined();
-      done();
-    });
+    let res;
+    let err;
+    try {
+      res = await requestWrapperInstance.sendRequest(parameters);
+    } catch (e) {
+      err = e;
+    }
+    // assert results
+    expect(err).toBeInstanceOf(Error);
+    expect(res).toBeUndefined();
+    done();
   });
 
-  it('should send a request where option parameters overrides defaults', done => {
+  it('should send a request where option parameters overrides defaults', async done => {
     const parameters = {
       defaultOptions: {
         formData: '',
@@ -154,30 +158,29 @@ describe('sendRequest', () => {
       return Promise.resolve(axiosResolveValue);
     });
 
-    requestWrapperInstance.sendRequest(parameters, (err, res) => {
-      // assert results
-      expect(serializedParams).toBe('version=2018-10-15&array_style=a%2Cb');
-      expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
-        'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
-      );
-      expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-        // 'Accept-Encoding': 'gzip',
-        'test-header': 'override-header-value',
-        'add-header': 'add-header-value',
-      });
-      expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.options.method);
-      expect(mockAxiosInstance.mock.calls[0][0].params).toEqual({
-        array_style: 'a,b',
-        version: '2018-10-15',
-      });
-      expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
-      expect(res).toEqual(expectedResult);
-      expect(mockAxiosInstance.mock.calls.length).toBe(1);
-      done();
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(serializedParams).toBe('version=2018-10-15&array_style=a%2Cb');
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
+      'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
+      // 'Accept-Encoding': 'gzip',
+      'test-header': 'override-header-value',
+      'add-header': 'add-header-value',
     });
+    expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.options.method);
+    expect(mockAxiosInstance.mock.calls[0][0].params).toEqual({
+      array_style: 'a,b',
+      version: '2018-10-15',
+    });
+    expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
+    expect(res).toEqual(expectedResult);
+    expect(mockAxiosInstance.mock.calls.length).toBe(1);
+    done();
   });
 
-  it('should send a request with multiform data', done => {
+  it('should send a request with multiform data', async done => {
     const parameters = {
       defaultOptions: {
         formData: '',
@@ -224,52 +227,51 @@ describe('sendRequest', () => {
       return Promise.resolve(axiosResolveValue);
     });
 
-    requestWrapperInstance.sendRequest(parameters, (err, res) => {
-      // assert results
-      expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
-        'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
-      );
-      expect(mockAxiosInstance.mock.calls[0][0].headers).toMatchObject({
-        // 'Accept-Encoding': 'gzip',
-        'test-header': 'override-header-value',
-        'add-header': 'add-header-value',
-      });
-      expect(mockAxiosInstance.mock.calls[0][0].headers['content-type']).toMatch(
-        'multipart/form-data; boundary=--------------------------'
-      );
-      expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
-      expect(mockAxiosInstance.mock.calls[0][0].params).toEqual(parameters.options.qs);
-      expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
-      expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
-        'Content-Disposition: form-data; name=\\"object_item\\"'
-      );
-      expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
-        'Content-Disposition: form-data; name=\\"array_item\\"'
-      );
-      // There should be two "array_item" parts
-      expect(
-        (
-          JSON.stringify(mockAxiosInstance.mock.calls[0][0].data).match(/name=\\"array_item\\"/g) ||
-          []
-        ).length
-      ).toEqual(2);
-      expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
-        'Content-Disposition: form-data; name=\\"custom_file\\"'
-      );
-      expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).not.toMatch(
-        'Content-Disposition: form-data; name=\\"null_item\\"'
-      );
-      expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).not.toMatch(
-        'Content-Disposition: form-data; name=\\"no_data\\"'
-      );
-
-      expect(res).toEqual(expectedResult);
-      expect(mockAxiosInstance.mock.calls.length).toBe(1);
-      done();
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
+      'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].headers).toMatchObject({
+      // 'Accept-Encoding': 'gzip',
+      'test-header': 'override-header-value',
+      'add-header': 'add-header-value',
     });
+    expect(mockAxiosInstance.mock.calls[0][0].headers['content-type']).toMatch(
+      'multipart/form-data; boundary=--------------------------'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
+    expect(mockAxiosInstance.mock.calls[0][0].params).toEqual(parameters.options.qs);
+    expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
+    expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
+      'Content-Disposition: form-data; name=\\"object_item\\"'
+    );
+    expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
+      'Content-Disposition: form-data; name=\\"array_item\\"'
+    );
+    // There should be two "array_item" parts
+    expect(
+      (
+        JSON.stringify(mockAxiosInstance.mock.calls[0][0].data).match(/name=\\"array_item\\"/g) ||
+        []
+      ).length
+    ).toEqual(2);
+    expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).toMatch(
+      'Content-Disposition: form-data; name=\\"custom_file\\"'
+    );
+    expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).not.toMatch(
+      'Content-Disposition: form-data; name=\\"null_item\\"'
+    );
+    expect(JSON.stringify(mockAxiosInstance.mock.calls[0][0])).not.toMatch(
+      'Content-Disposition: form-data; name=\\"no_data\\"'
+    );
+
+    expect(res).toEqual(expectedResult);
+    expect(mockAxiosInstance.mock.calls.length).toBe(1);
+    done();
   });
 
-  it('should send a request with form data', done => {
+  it('should send a request with form data', async done => {
     const parameters = {
       defaultOptions: {
         form: { a: 'a', b: 'b' },
@@ -305,30 +307,29 @@ describe('sendRequest', () => {
       return Promise.resolve(axiosResolveValue);
     });
 
-    requestWrapperInstance.sendRequest(parameters, (err, res) => {
-      // assert results
-      expect(mockAxiosInstance.mock.calls[0][0].data).toEqual('a=a&b=b');
-      expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
-        'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
-      );
-      expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-        'Accept-Encoding': 'compress',
-        'test-header': 'override-header-value',
-        'add-header': 'add-header-value',
-        'Content-type': 'application/x-www-form-urlencoded',
-      });
-      expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.options.method);
-      expect(mockAxiosInstance.mock.calls[0][0].params).toEqual(parameters.options.qs);
-      expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
-      expect(res).toEqual(expectedResult);
-      expect(mockAxiosInstance.mock.calls.length).toBe(1);
-      done();
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(mockAxiosInstance.mock.calls[0][0].data).toEqual('a=a&b=b');
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
+      'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
+      'Accept-Encoding': 'compress',
+      'test-header': 'override-header-value',
+      'add-header': 'add-header-value',
+      'Content-type': 'application/x-www-form-urlencoded',
     });
+    expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.options.method);
+    expect(mockAxiosInstance.mock.calls[0][0].params).toEqual(parameters.options.qs);
+    expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('json');
+    expect(res).toEqual(expectedResult);
+    expect(mockAxiosInstance.mock.calls.length).toBe(1);
+    done();
   });
 
   // Need to rewrite this to test instantiation with userOptions
 
-  //   it('should keep parameters in options that are not explicitly set in requestwrapper', done => {
+  //   it('should keep parameters in options that are not explicitly set in requestwrapper', async done => {
   //     const parameters = {
   //       defaultOptions: {
   //         body: 'post=body',


### PR DESCRIPTION
Refactors the entire library to use Promises instead of callbacks. This is a pretty big change but since the SDK is really the only "user", I don't think it will cause any problems.

The generated SDK code should be able to change slightly to achieve no difference in current behavior. The current plan is to start returning Promises first in the generated Watson SDK, with callbacks being an accommodation. We also want to start generating new services using only Promises. This PR enables that route, as it moves all callback handling out of the core and into the generated SDK.

If this is too big of a change to make too late in the game, that's fine, but this work is necessary to move towards a Promise-only approach and doing it this way gives us more flexibility in the generated SDKs to use either approach.

If this is agreeable, I will open a corresponding PR in the generator.

FYI: This PR makes heavy use of the fact that every `then` and `catch` block returns a Promise itself and that "returning" or "throwing" inside of these blocks, will resolve and reject in a later chained Promise, respectively. Where we were previously passing one callback around to multiple functions, we are now bubbling up results through chained Promises. Using the other method, we used to lose some error information that is now becoming visible. This required some small changes in the unit tests. On that point, I think the code is improved overall.