### PR TITLE
fix: dynamic imports for webpack compatibility

### DIFF
--- a/auth/utils/read-credentials-file.ts
+++ b/auth/utils/read-credentials-file.ts
@@ -1,5 +1,20 @@
-import dotenv = require('dotenv');
-import fs = require('fs');
+let dotenv;
+let fs;
+// use dynamic imports to pacify webpack tree shaking
+import( /* webpackIgnore: true */ 'dotenv')
+.then(module => {
+  dotenv = module;
+})
+.catch(err => {
+  dotenv = {};
+});
+import( /* webpackIgnore: true */ 'fs')
+.then(module => {
+  fs = module;
+})
+.catch(err => {
+  fs = {};
+});
 import os = require('os');
 import path = require('path');
 


### PR DESCRIPTION
This change uses dynamic imports to allow webpack users (commonly used in Angular and React projects) to use the Node SDK Core and its consumers out of the box.  Previously, React users needed to configure polyfills for webpack in order to trick the dependency resolution for `dotenv` and `fs`.

These changes will require removing instructions in the `ibm-watson` Node SDK documentation about how to consume these packages in client environments.

##### Checklist
- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
