### PR TITLE
fix: provide bundlers alternate file for browser support

### DIFF
--- a/auth/utils/read-credentials-file.browser.ts
+++ b/auth/utils/read-credentials-file.browser.ts
@@ -1,0 +1,4 @@
+// Dummy for browser
+export function readCredentialsFile() {
+  return {};
+};

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "semver": "^6.2.0",
     "vcap_services": "~0.3.4"
   },
+  "browser": {
+    "./auth/utils/read-credentials-file": "./auth/utils/read-credentials-file.browser"
+  },
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
This change uses the `browser` [property](https://docs.npmjs.com/files/package.json#browser) to allow browser users leveraging bundlers like webpack (in Angular and React projects) to use the Node SDK Core and its consumers out of the box. Previously, React users needed to configure polyfills for webpack in order to trick the dependency resolution for **dotenv** and **fs**.

These changes will require removing instructions in the **ibm-watson** Node SDK documentation about how to consume these packages in client environments.

#### Checklist
 - [x] npm test passes (tip: npm run lint-fix can correct most style issues)