### PR TITLE
feat: allow node-sdk-core 0.x to work with new ibm-crendentials.env

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -449,7 +449,7 @@ export class BaseService {
       return this.getCredentialsFromEnvironment(envObj, 'visual_recognition');
     }
     // Case handling for assistant - should look for assistant env variables before conversation
-    if (name === 'conversation' && (envObj[`ASSISTANT_USERNAME`] ||  envObj[`ASSISTANT_IAM_APIKEY`])) {
+    if (name === 'conversation' && (envObj[`ASSISTANT_USERNAME`] ||  envObj[`ASSISTANT_IAM_APIKEY`] || envObj[`ASSISTANT_APIKEY`])) {
        return this.getCredentialsFromEnvironment(envObj, 'assistant');
     }
     const _name: string = name.toUpperCase();
@@ -457,10 +457,10 @@ export class BaseService {
     const nameWithUnderscore: string = _name.replace(/-/g, '_');
     const username: string = envObj[`${_name}_USERNAME`] || envObj[`${nameWithUnderscore}_USERNAME`];
     const password: string = envObj[`${_name}_PASSWORD`] || envObj[`${nameWithUnderscore}_PASSWORD`];
-    const apiKey: string = envObj[`${_name}_API_KEY`] || envObj[`${nameWithUnderscore}_API_KEY`];
     const url: string = envObj[`${_name}_URL`] || envObj[`${nameWithUnderscore}_URL`];
     const iamAccessToken: string = envObj[`${_name}_IAM_ACCESS_TOKEN`] || envObj[`${nameWithUnderscore}_IAM_ACCESS_TOKEN`];
     const iamApiKey: string = envObj[`${_name}_IAM_APIKEY`] || envObj[`${nameWithUnderscore}_IAM_APIKEY`];
+    const apiKey: string = envObj[`${_name}_APIKEY`] || envObj[`${nameWithUnderscore}_APIKEY`];
     const iamUrl: string = envObj[`${_name}_IAM_URL`] || envObj[`${nameWithUnderscore}_IAM_URL`];
     const iamClientId: string = envObj[`${_name}_IAM_CLIENT_ID`] || envObj[`${_name}_IAM_CLIENT_ID`];
     const iamClientSecret: string = envObj[`${_name}_IAM_CLIENT_SECRET`] || envObj[`${_name}_IAM_CLIENT_SECRET`];
@@ -473,7 +473,7 @@ export class BaseService {
       password,
       url,
       iam_access_token: iamAccessToken,
-      iam_apikey: iamApiKey,
+      iam_apikey: iamApiKey || apiKey,
       iam_url: iamUrl,
       iam_client_id: iamClientId,
       iam_client_secret: iamClientSecret,

--- a/test/unit/baseService.test.js
+++ b/test/unit/baseService.test.js
@@ -411,6 +411,19 @@ describe('BaseService', function() {
     expect(instance.tokenManager).not.toBeNull();
   });
 
+  it('should create a iam token manger instance if env variables specify apikey credential', function() {
+    process.env.TEST_APIKEY = 'test1234';
+    const instance = new TestService();
+    const actual = instance.getServiceCredentials();
+    const expected = {
+      iam_apikey: 'test1234',
+      url: 'https://gateway.watsonplatform.net/test/api',
+    };
+    expect(actual).toEqual(expected);
+    expect(instance.tokenManager).toBeDefined();
+    expect(instance.tokenManager).not.toBeNull();
+  });
+
   it('should create a token manager instance if username is `apikey` and use the password as the API key', function() {
     const apikey = 'abcd-1234';
     const instance = new TestService({


### PR DESCRIPTION
From my understand and talking with @dpopp07, with the release of the v5 API SDK, the `ibm-credentials.env` file is going to change format from:
```
TEXT_TO_SPEECH_IAM_APIKEY=my_api_key
TEXT_TO_SPEECH_URL=https://stream.watsonplatform.net/text-to-speech/api
```

to be:
```
TEXT_TO_SPEECH_APIKEY=my_api_key
TEXT_TO_SPEECH_URL=https://stream.watsonplatform.net/text-to-speech/api
```

This PR allows the v4 API to consume this new format to make things slightly less painful for those of us who cannot immediately upgrade to v5, but would like to continue downloading these env files when setting up new services in the meantime.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
