### PR TITLE
feat: adding configureService method for external config options

### DIFF
--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -174,7 +174,7 @@ describe('Base Service', () => {
       authenticator: AUTHENTICATOR,
     });
 
-    const fromCredsFile = testService.readOptionsFromExternalConfig();
+    const fromCredsFile = testService.readOptionsFromExternalConfig(DEFAULT_NAME);
 
     expect(fromCredsFile.serviceUrl).toBe(serviceUrl);
     expect(fromCredsFile.disableSslVerification).toBe(disableSsl);
@@ -337,6 +337,54 @@ describe('Base Service', () => {
         serviceUrl: 'myapi.com/{instanceId}',
       });
     }).toThrow(/Revise these credentials/);
+  });
+
+  it('should have the default baseOptions values when instantiating', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+    });
+    expect(testService.baseOptions.serviceUrl).toEqual(DEFAULT_URL);
+    expect(testService.baseOptions.disableSslVerification).toEqual(false);
+    expect(testService.baseOptions.qs).toBeDefined();
+    expect(testService.baseOptions.qs).toEqual(EMPTY_OBJECT);
+  });
+
+  it('should configure service by calling configureService method after instantiating', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+    });
+
+    expect(testService.baseOptions.serviceUrl).toEqual(
+      'https://gateway.watsonplatform.net/test/api'
+    );
+    expect(testService.baseOptions.disableSslVerification).toEqual(false);
+
+    readExternalSourcesMock.mockImplementation(() => ({
+      url: 'abc123.com',
+      disableSsl: true,
+    }));
+
+    testService.configureService(DEFAULT_NAME);
+
+    expect(readExternalSourcesMock).toHaveBeenCalled();
+    expect(testService.baseOptions.serviceUrl).toEqual('abc123.com');
+    expect(testService.baseOptions.disableSslVerification).toEqual(true);
+  });
+
+  it('configureService method should throw error if service name is not provided', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+    });
+    const fakeError = new Error('Error configuring service. Service name is required.');
+    let err;
+
+    try {
+      testService.configureService();
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toStrictEqual(fakeError);
   });
 });
 


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1118

Changes:
- moved the external configuration code outside of the constructor into it's own method.
- for compatibility, the constructor calls the new method until we move to the service factory's complete implementation.

The new method will now be invoked from the generator after the BaseService's constructor is called.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
