### PR TITLE
build: update npmignore to include some missed files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 test/resources
 test/unit
 test/.eslintrc.js
-node_modules
 coverage
 .jshintignore
 .hshintrc
@@ -9,13 +8,10 @@ examples
 .editorconfig
 .jshintrc
 .travis.yml
-.DS_Store
 # documentation files
-LICENSE
+CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 RELEASE.md
-CONTRIBUTING.md
-CHANGELOG.md
 jsdoc/
 doc/
 dependency-lint.yml
@@ -24,6 +20,7 @@ transform.js
 scripts/
 # this is created in the build on travis ci when it updates the docs in the gh-pages branch
 gh-pages/
+tsconfig.json
 tslint.json
 typings.json
 typings
@@ -34,5 +31,8 @@ typings
 .eslintcache
 .eslintignore
 .gitattributes
+.prettierrc
+.releaserc
+commitlint.config.js
 *.ts
 !*.d.ts


### PR DESCRIPTION
Updates the `.npmignore` file as some number of non-package files were being included in the npm archive on installation.

Note, per documentation on [package.json#Keeping Files Out of Your Package](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package), there are a number of files that are always implicitly ignored and recommended to not include them in the `.npmignore` file, which for this repo include:
* LICENSE
* CHANGELOG.md
* node_modules
* .DS_Store

I was not sure if the following files were supposed to be ignored or not as well so I did not add them to the file:
* AUTHENTICATION.md
* MIGRATION-V1.md

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
