### PR TITLE
Documentation for node-sdk-core

### DIFF
--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -25,7 +25,7 @@ import { OutgoingHttpHeaders } from 'http';
  */
 export interface AuthenticateOptions {
   /**
-   * Headers authentication information will be added too.
+   * Headers to augment with authentication information.
    */
   headers?: OutgoingHttpHeaders;
 

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -21,7 +21,7 @@ import { OutgoingHttpHeaders } from 'http';
 
 /**
  * The request object containing the headers property that
- * authentication information will be added too.
+ * authentication information will be added to.
  */
 export interface AuthenticateOptions {
   /**

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -40,8 +40,8 @@ export interface AuthenticatorInterface {
   /**
    * Add authentication information to the specified request.
    *
-   * @param {object} options - The request to augment with authentication information.
-   * @param {Object.<string, string>} options.headers - The headers the
+   * @param {object} options The request to augment with authentication information.
+   * @param {Object.<string, string>} options.headers The headers the
    *   authentication information will be added too.
    */
   authenticate(request: AuthenticateOptions): Promise<void | Error>

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -25,7 +25,7 @@ import { OutgoingHttpHeaders } from 'http';
  */
 export interface AuthenticateOptions {
   /**
-   * Headers to be added to the request by the Authenticator.
+   * Headers authentication information will be added too.
    */
   headers?: OutgoingHttpHeaders;
 

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -41,7 +41,7 @@ export interface AuthenticatorInterface {
    * Add authentication information to the specified request.
    *
    * @param {object} options The request to augment with authentication information.
-   * @param {Object.<string, string>} options.headers The headers the
+   * @param {object.<string, string>} options.headers The headers the
    *   authentication information will be added too.
    */
   authenticate(request: AuthenticateOptions): Promise<void | Error>

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -18,11 +18,31 @@ import { OutgoingHttpHeaders } from 'http';
 
 // This could just be the type for the `baseOptions` field of the Base Service
 // but to avoid a circular dependency or a refactor, this will do for now
+
+/**
+ * The request object containing the field called headers that
+ * authentication information will be added too.
+ */
 export interface AuthenticateOptions {
+  /**
+   * Headers to be added to the request by the Authenticator.
+   */
   headers?: OutgoingHttpHeaders;
+
   [propName: string]: any;
 }
 
+/**
+ * This interface defines the common methods associated with an Authenticator
+ * implementation.
+ */
 export interface AuthenticatorInterface {
-  authenticate(options: AuthenticateOptions): Promise<void | Error>
+  /**
+   * Add authentication information to the specified request.
+   *
+   * @param {object} options - The request to augment with authentication information.
+   * @param {Object.<string, string>} options.headers - The headers the
+   *   authentication information will be added too.
+   */
+  authenticate(request: AuthenticateOptions): Promise<void | Error>
 }

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -20,7 +20,7 @@ import { OutgoingHttpHeaders } from 'http';
 // but to avoid a circular dependency or a refactor, this will do for now
 
 /**
- * The request object containing the field called headers that
+ * The request object containing the headers property that
  * authentication information will be added too.
  */
 export interface AuthenticateOptions {

--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -40,9 +40,9 @@ export interface AuthenticatorInterface {
   /**
    * Add authentication information to the specified request.
    *
-   * @param {object} options The request to augment with authentication information.
-   * @param {object.<string, string>} options.headers The headers the
-   *   authentication information will be added too.
+   * @param {object} requestOptions The request to augment with authentication information.
+   * @param {object.<string, string>} requestOptions.headers The headers the
+   *   authentication information will be added to.
    */
-  authenticate(request: AuthenticateOptions): Promise<void | Error>
+  authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>
 }

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -40,7 +40,7 @@ export class Authenticator implements AuthenticatorInterface {
    * Augment the request with authentication information.
    *
    * @param {object} request - The request to augment with authentication information.
-   * @param {Object.<string, string>} request.headers - The headers the
+   * @param {object.<string, string>} request.headers - The headers the
    *   authentication information will be added too.
    * @throws {Error} - The authenticate method was not implemented by a
    *   subclass.

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -39,13 +39,13 @@ export class Authenticator implements AuthenticatorInterface {
   /**
    * Augment the request with authentication information.
    *
-   * @param {object} request - The request to augment with authentication information.
-   * @param {object.<string, string>} request.headers - The headers the
+   * @param {object} requestOptions - The request to augment with authentication information.
+   * @param {object.<string, string>} requestOptions.headers - The headers the
    *   authentication information will be added too.
    * @throws {Error} - The authenticate method was not implemented by a
    *   subclass.
    */
-  public authenticate(request: AuthenticateOptions): Promise<void | Error> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
     const error = new Error('Should be implemented by subclass!');
     return Promise.reject(error);
   }

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-import { OutgoingHttpHeaders } from 'http';
 import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
+/**
+ * Base Authenticator class for other Authenticators to extend. Not intended
+ * to be used as a stand-alone authenticator.
+ */
 export class Authenticator implements AuthenticatorInterface {
+
   /**
-   * Base Authenticator Class
+   * Create a new Authenticator instance.
    *
-   * Provides the Base Authenticator class for others to extend.
+   * @throws {Error} The `new` keyword was not used to create construct the
+   *   authenticator.
    */
   constructor() {
     if (!(this instanceof Authenticator)) {
@@ -31,7 +36,16 @@ export class Authenticator implements AuthenticatorInterface {
     }
   }
 
-  public authenticate(options: AuthenticateOptions): Promise<void | Error> {
+  /**
+   * Augment the request with authentication information.
+   *
+   * @param {object} request - The request to augment with authentication information.
+   * @param {Object.<string, string>} request.headers - The headers the
+   *   authentication information will be added too.
+   * @throws {Error} - The authentication method was not implemented by a
+   *   subclass.
+   */
+  public authenticate(request: AuthenticateOptions): Promise<void | Error> {
     const error = new Error('Should be implemented by subclass!');
     return Promise.reject(error);
   }

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -42,7 +42,7 @@ export class Authenticator implements AuthenticatorInterface {
    * @param {object} request - The request to augment with authentication information.
    * @param {Object.<string, string>} request.headers - The headers the
    *   authentication information will be added too.
-   * @throws {Error} - The authentication method was not implemented by a
+   * @throws {Error} - The authenticate method was not implemented by a
    *   subclass.
    */
   public authenticate(request: AuthenticateOptions): Promise<void | Error> {

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -19,9 +19,7 @@ import { computeBasicAuthHeader, validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
 
-/*
- * Configuration values for basic authentication.
- */
+/** Configuration options for basic authentication. */
 export type Options = {
   /** The username to be used in basic authorization. */
   username: string;
@@ -49,7 +47,7 @@ export class BasicAuthenticator extends Authenticator {
   /**
    * Create a new BearerTokenAuthenticator instance.
    *
-   * @param {Object<string, string>} options Configuration options.
+   * @param {Object<string, string>} options Configuration options for basic authentication.
    * @param {string} options.username The username portion of basic authentication.
    * @param {string} options.password The password portion of basic authentication.
    * @throws {Error} The configuration options are not valid.
@@ -73,7 +71,7 @@ export class BasicAuthenticator extends Authenticator {
    * @param {Object.<string, string>} request.headers - The headers the
    *   authentication information will be added too.
    */
-  public authenticate(request: AuthenticateOptions): Promise<void> {
+  public authenticate(request: AuthenticateOptions): Promise<void | Error>  {
     return new Promise((resolve) => {
       request.headers = extend(true, {}, request.headers, this.authHeader);
       resolve();

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -62,12 +62,12 @@ export class BasicAuthenticator extends Authenticator {
 
   /**
    * Add basic authentication information to `request`. The basic authentication information
-   * will be added to the Authorization property of`request.headers` in the form:
+   * will be set in the Authorization property of`request.headers` in the form:
    *
    *     Authorization: Basic <encoded username and password>
    *
    * @param {object} request - The request to augment with authentication information.
-   * @param {Object.<string, string>} request.headers - The headers the
+   * @param {object.<string, string>} request.headers - The headers the
    *   authentication information will be added too.
    */
   public authenticate(request: AuthenticateOptions): Promise<void | Error>  {

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -61,9 +61,8 @@ export class BasicAuthenticator extends Authenticator {
   }
 
   /**
-   * Add basic authentication information to request.
-   *
-   * Basic Authorization will be sent as an Authorization header in the form:
+   * Add basic authentication information to `request`. The basic authentication information
+   * will be added to the Authorization property of`request.headers` in the form:
    *
    *     Authorization: Basic <encoded username and password>
    *

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -66,13 +66,13 @@ export class BasicAuthenticator extends Authenticator {
    *
    *     Authorization: Basic <encoded username and password>
    *
-   * @param {object} request - The request to augment with authentication information.
-   * @param {object.<string, string>} request.headers - The headers the
+   * @param {object} requestOptions - The request to augment with authentication information.
+   * @param {object.<string, string>} requestOptions.headers - The headers the
    *   authentication information will be added too.
    */
-  public authenticate(request: AuthenticateOptions): Promise<void | Error>  {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>  {
     return new Promise((resolve) => {
-      request.headers = extend(true, {}, request.headers, this.authHeader);
+      requestOptions.headers = extend(true, {}, requestOptions.headers, this.authHeader);
       resolve();
     });
   }

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -61,7 +61,7 @@ export class BasicAuthenticator extends Authenticator {
   }
 
   /**
-   * Add basic authentication information to options.
+   * Add basic authentication information to request.
    *
    * Basic Authorization will be sent as an Authorization header in the form:
    *

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -47,7 +47,7 @@ export class BasicAuthenticator extends Authenticator {
   /**
    * Create a new BearerTokenAuthenticator instance.
    *
-   * @param {Object<string, string>} options Configuration options for basic authentication.
+   * @param {object} options Configuration options for basic authentication.
    * @param {string} options.username The username portion of basic authentication.
    * @param {string} options.password The password portion of basic authentication.
    * @throws {Error} The configuration options are not valid.

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -26,8 +26,8 @@ export type Options = {
 }
 
 /**
- * The BearerTokenAuthenticator will add a passed-in or set bearer token
- *   to requests.
+ * The BearerTokenAuthenticator will set a user-provided bearer token
+ *   in requests.
  *
  * The bearer token will be sent as an Authorization header in the form:
  *
@@ -54,7 +54,7 @@ export class BearerTokenAuthenticator extends Authenticator {
   }
 
   /**
-   * Set a new bearer token to be sent in subsequent service operations.
+   * Set a new bearer token to be sent in subsequent requests.
    *
    * @param {string} bearerToken The bearer token that will be sent in service
    *   requests.
@@ -69,15 +69,15 @@ export class BearerTokenAuthenticator extends Authenticator {
    *
    *      Authorization: Bearer <bearer-token>
    *
-   * @param {object} request - The request to augment with authentication
+   * @param {object} requestOptions - The request to augment with authentication
    *   information.
-   * @param {object.<string, string>} request.headers - The headers the
+   * @param {object.<string, string>} requestOptions.headers - The headers the
    *   authentication information will be added to.
    */
-  public authenticate(request: AuthenticateOptions): Promise<void> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void> {
     return new Promise((resolve) => {
       const authHeader = { Authorization: `Bearer ${this.bearerToken}` };
-      request.headers = extend(true, {}, request.headers, authHeader);
+      requestOptions.headers = extend(true, {}, requestOptions.headers, authHeader);
       resolve();
     });
   }

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -64,7 +64,7 @@ export class BearerTokenAuthenticator extends Authenticator {
   }
 
   /**
-   * Add a bearer token to the options.
+   * Add a bearer token to the request.
    *
    * The bearer token will be sent as an Authorization header in the form:
    *

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -64,9 +64,8 @@ export class BearerTokenAuthenticator extends Authenticator {
   }
 
   /**
-   * Add a bearer token to the request.
-   *
-   * The bearer token will be sent as an Authorization header in the form:
+   * Add a bearer token to the `request`. The bearer token information
+   * will be added to the Authorization property of`request.headers` in the form:
    *
    *      Authorization: Bearer <bearer-token>
    *

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -65,13 +65,13 @@ export class BearerTokenAuthenticator extends Authenticator {
 
   /**
    * Add a bearer token to the `request`. The bearer token information
-   * will be added to the Authorization property of`request.headers` in the form:
+   * will be set in the Authorization property of`request.headers` in the form:
    *
    *      Authorization: Bearer <bearer-token>
    *
    * @param {object} request - The request to augment with authentication
    *   information.
-   * @param {Object.<string, string>} request.headers - The headers the
+   * @param {object.<string, string>} request.headers - The headers the
    *   authentication information will be added to.
    */
   public authenticate(request: AuthenticateOptions): Promise<void> {

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -17,25 +17,36 @@
 import extend = require('extend');
 import { validateInput } from '../utils';
 import { Authenticator } from './authenticator';
-import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions } from './authenticator-interface';
 
+/**
+ * The configuration options for bearer authentication.
+ */
 export type Options = {
+  /** The bearer token to be added to requests. */
   bearerToken: string;
 }
 
-export class BearerTokenAuthenticator extends Authenticator implements AuthenticatorInterface {
+/**
+ * The BearerTokenAuthenticator will add a passed-in or set bearer token
+ *   to requests.
+ *
+ * The bearer token will be sent as an Authorization header in the form:
+ *
+ *      Authorization: Bearer <bearer-token>
+ */
+export class BearerTokenAuthenticator extends Authenticator {
   protected requiredOptions = ['bearerToken'];
   private bearerToken: string;
 
-  /**
-   * Bearer Token Authenticator Class
-   *
-   * Handles the Bearer Token pattern.
-   *
-   * @param {Object} options
-   * @param {String} options.bearerToken - bearer token to pass in header
-   * @constructor
-   */
+ /**
+  * Create a new BearerTokenAuthenticator instance.
+  *
+  * @param {object} options Configuration options.
+  * @param {string} options.bearerToken The bearer token to be added
+  *   to requests.
+  * @throws {Error} The configuration bearerToken is not valid, or unspecified.
+  */
   constructor(options: Options) {
     super();
 
@@ -44,14 +55,32 @@ export class BearerTokenAuthenticator extends Authenticator implements Authentic
     this.bearerToken = options.bearerToken;
   }
 
+  /**
+   * Set a new bearer token to be sent in subsequent service operations.
+   *
+   * @param {string} bearerToken The bearer token that will be sent in service
+   *   requests.
+   */
   public setBearerToken(bearerToken: string): void {
     this.bearerToken = bearerToken;
   }
 
-  public authenticate(options: AuthenticateOptions): Promise<void> {
-    return new Promise((resolve, reject) => {
+  /**
+   * Add a bearer token to the options.
+   *
+   * The bearer token will be sent as an Authorization header in the form:
+   *
+   *      Authorization: Bearer <bearer-token>
+   *
+   * @param {object} request - The request to augment with authentication
+   *   information.
+   * @param {Object.<string, string>} request.headers - The headers the
+   *   authentication information will be added too.
+   */
+  public authenticate(request: AuthenticateOptions): Promise<void> {
+    return new Promise((resolve) => {
       const authHeader = { Authorization: `Bearer ${this.bearerToken}` };
-      options.headers = extend(true, {}, options.headers, authHeader);
+      request.headers = extend(true, {}, request.headers, authHeader);
       resolve();
     });
   }

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -19,9 +19,7 @@ import { validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
 
-/**
- * The configuration options for bearer authentication.
- */
+/** Configuration options for bearer authentication. */
 export type Options = {
   /** The bearer token to be added to requests. */
   bearerToken: string;
@@ -42,7 +40,7 @@ export class BearerTokenAuthenticator extends Authenticator {
  /**
   * Create a new BearerTokenAuthenticator instance.
   *
-  * @param {object} options Configuration options.
+  * @param {object} options Configuration options for bearer authentication.
   * @param {string} options.bearerToken The bearer token to be added
   *   to requests.
   * @throws {Error} The configuration bearerToken is not valid, or unspecified.

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -47,13 +47,13 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * Create a new [[CloudPakForDataAuthenticator]] instance.
    *
    * @param {object} options Configuration options for CloudPakForData authentication.
+   * @param {string} options.url For HTTP token requests.
+   * @param {string} options.username The username used to obtain a bearer token.
+   * @param {string} options.password The password used to obtain a bearer token.
    * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
-   * @param {string} options.url For HTTP token requests.
-   * @param {object<string, string>} [options.headers] to be sent with every
-   * @param {string} options.username The username used to obtain a bearer token.
-   * @param {string} options.password The password used to obtain a bearer token.
+   * @param {object<string, string>} [options.headers] to be sent with every.
    * @throws `Error` The username, password, and/or url are not valid, or unspecified, for Cloud Pak For Data token
    *   requests.
    */

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -47,11 +47,11 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * Create a new [[CloudPakForDataAuthenticator]] instance.
    *
    * @param {object} options Configuration options for CloudPakForData authentication.
-   * @param {boolean} options.disableSslVerification A flag that indicates
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
    * @param {string} options.url For HTTP token requests.
-   * @param {object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} [options.headers] to be sent with every
    * @param {string} options.username The username used to obtain a bearer token.
    * @param {string} options.password The password used to obtain a bearer token.
    * @throws `Error` The username, password, and/or url are not valid, or unspecified, for Cloud Pak For Data token

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -48,9 +48,13 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * Create a new [[CloudPakForDataAuthenticator]] instance with an internal [[Cp4dTokenManager]].
    *
    * @param {object} options Configuration options for CloudPakForData authentication.
+   * @param {boolean} options.disableSslVerification A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not
+   * @param {string} options.url For HTTP token requests.
+   * @param {object<string, string>} options.headers to be sent with every
    * @param {string} options.username The username used to obtain a bearer token.
    * @param {string} options.password The password used to obtain a bearer token.
-   * @param {string} options.url The URL representing the Cloud Pak for Data token service endpoint.
    * @throws `Error` The username, password, and/or url are not valid, or unspecified, for Cloud Pak For Data token
    *   requests.
    */

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -14,31 +14,47 @@
  * limitations under the License.
  */
 
-import { OutgoingHttpHeaders } from 'http';
 import { Cp4dTokenManager } from '../token-managers';
 import { validateInput } from '../utils';
-import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+import { BaseOptions, TokenRequestBasedAuthenticator }
+  from './token-request-based-authenticator';
 
+/**
+ * Configuration values for CloudPakForData Authenticator.
+ */
 export interface Options extends BaseOptions {
+  /** The username used to obtain a bearer token. */
   username: string;
+  /** The password used to obtain a bearer token. */
   password: string;
+  /** The URL representing the Cloud Pak for Data token service endpoint. */
   url: string;
 }
 
-export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator {
+/**
+ * The [[CloudPakForDataAuthenticator]] utilizes a username and password pair to
+ *   obtain a suitable bearer token, via a [[Cp4dTokenManager]], and adds it
+ *   requests.
+ *
+ * The bearer token will be sent as an Authorization header in the form:
+ *
+ *      Authorization: Bearer <bearer-token>
+ */
+export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
+{
   protected requiredOptions = ['username', 'password', 'url'];
   protected tokenManager: Cp4dTokenManager;
   private username: string;
   private password: string;
-
   /**
-   * Cloud Pak for Data Authenticator Class
+   * Create a new [[CloudPakForDataAuthenticator]] instance with an internal [[Cp4dTokenManager]].
    *
-   * Handles the CP4D authentication pattern:
-   * A username and password are provided and used to retrieve a bearer token.
-   *
-   * @param {Object} options
-   * @constructor
+   * @param {object} options Configuration options.
+   * @param {string} options.username The username used to obtain a bearer token.
+   * @param {string} options.password The password used to obtain a bearer token.
+   * @param {string} options.url The URL representing the Cloud Pak for Data token service endpoint.
+   * @throws `Error` The username, password, and/or url are not valid, or unspecified, for Cloud Pak For Data token
+   *   requests.
    */
   constructor(options: Options) {
     super(options);
@@ -48,8 +64,8 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
     this.username = options.username;
     this.password = options.password;
 
-    // the param names are shared between the authenticator and the token manager
-    // so we can just pass along the options object
+    // the param names are shared between the authenticator and the token
+    // manager so we can just pass along the options object
     this.tokenManager = new Cp4dTokenManager(options);
   }
 }

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -19,9 +19,7 @@ import { validateInput } from '../utils';
 import { BaseOptions, TokenRequestBasedAuthenticator }
   from './token-request-based-authenticator';
 
-/**
- * Configuration values for CloudPakForData Authenticator.
- */
+/** Configuration options for CloudPakForData authentication. */
 export interface Options extends BaseOptions {
   /** The username used to obtain a bearer token. */
   username: string;
@@ -49,7 +47,7 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
   /**
    * Create a new [[CloudPakForDataAuthenticator]] instance with an internal [[Cp4dTokenManager]].
    *
-   * @param {object} options Configuration options.
+   * @param {object} options Configuration options for CloudPakForData authentication.
    * @param {string} options.username The username used to obtain a bearer token.
    * @param {string} options.password The password used to obtain a bearer token.
    * @param {string} options.url The URL representing the Cloud Pak for Data token service endpoint.

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -31,8 +31,7 @@ export interface Options extends BaseOptions {
 
 /**
  * The [[CloudPakForDataAuthenticator]] utilizes a username and password pair to
- *   obtain a suitable bearer token, via a [[Cp4dTokenManager]], and adds it
- *   requests.
+ *   obtain a suitable bearer token and sets them in requests.
  *
  * The bearer token will be sent as an Authorization header in the form:
  *
@@ -45,7 +44,7 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
   private username: string;
   private password: string;
   /**
-   * Create a new [[CloudPakForDataAuthenticator]] instance with an internal [[Cp4dTokenManager]].
+   * Create a new [[CloudPakForDataAuthenticator]] instance.
    *
    * @param {object} options Configuration options for CloudPakForData authentication.
    * @param {boolean} options.disableSslVerification A flag that indicates

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -29,7 +29,7 @@ export interface Options extends BaseOptions {
    */
   clientId?: string;
   /**
-   * The client_id and client_secret fields are used to form a "basic"
+   * The `clientId` and `clientSecret` fields are used to form a "basic"
    * authorization header for IAM token requests.
    */
   clientSecret?: string;
@@ -64,9 +64,9 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
    * @param {string} options.url for HTTP token requests.
    * @param {object<string, string>} options.headers to be sent with every
    * @param {string} options.apikey The IAM api key.
-   * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
+   * @param {string=} options.clientId The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string=} options.clientSecret The client_id and client_secret fields are used to form a "basic"
+   * @param {string=} options.clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @throws {Error} When the configuration options are not valid.
    */
@@ -86,9 +86,9 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
 
   /**
    * Setter for the mutually inclusive `clientId` and the `clientSecret`.
-   * @param {string} clientId The client_id and client_secret fields are used to form a "basic"
+   * @param {string} clientId The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string} clientSecret The client_id and client_secret fields are used to form a "basic"
+   * @param {string} clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    */
   public setClientIdAndSecret(clientId: string, clientSecret: string): void {

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -56,6 +56,11 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
    * Create a new [[IamAuthenticator]] instance with an internal [[IamTokenManager]].
    *
    * @param {object} options Configuration options for IAM authentication.
+   * @param {boolean} options.disableSslVerification A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not
+   * @param {string} options.url for HTTP token requests.
+   * @param {object<string, string>} options.headers to be sent with every
    * @param {string} options.apikey The IAM api key.
    * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
    *   authorization header for IAM token requests.

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -19,10 +19,7 @@ import { validateInput } from '../utils';
 import { BaseOptions, TokenRequestBasedAuthenticator }
   from './token-request-based-authenticator';
 
-/**
- * Configuration values for [[IamAuthenticator]] behavior. Requires an `apikey`
- * field, and optionally a mutually inclusive` clientId`, and `clientSecret`pair.
- */
+/** Configuration options for IAM authentication. */
 export interface Options extends BaseOptions {
   /** The IAM api key */
   apikey: string;
@@ -58,7 +55,7 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
    *
    * Create a new [[IamAuthenticator]] instance with an internal [[IamTokenManager]].
    *
-   * @param {object} options Configuration options.
+   * @param {object} options Configuration options for IAM authentication.
    * @param {string} options.apikey The IAM api key.
    * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
    *   authorization header for IAM token requests.

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -36,9 +36,10 @@ export interface Options extends BaseOptions {
 }
 
 /**
- * The [[IamAuthenticator]] utilizes an `apikey`, or `clientId` and
- *   `clientSecret` pair to obtain a suitable bearer token, via an
- *   [[IamTokenManager]], and adds it to requests.
+ * The [[IamAuthenticator]] utilizes an `apikey` to obtain a suitable bearer
+ * token and adds it to requests. If specified the optional mutually inclusive
+ * `clientId` and`clientSecret` pair can be used to influence rate-limiting for
+ * requests to the IAM token server.
  *
  * The bearer token will be sent as an Authorization header in the form:
  *
@@ -53,7 +54,7 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
 
   /**
    *
-   * Create a new [[IamAuthenticator]] instance with an internal [[IamTokenManager]].
+   * Create a new [[IamAuthenticator]] instance.
    *
    * @param {object} options Configuration options for IAM authentication.
    * @param {boolean} options.disableSslVerification A flag that indicates

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -14,17 +14,39 @@
  * limitations under the License.
  */
 
-import { OutgoingHttpHeaders } from 'http';
 import { IamTokenManager } from '../token-managers';
 import { validateInput } from '../utils';
-import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+import { BaseOptions, TokenRequestBasedAuthenticator }
+  from './token-request-based-authenticator';
 
+/**
+ * Configuration values for [[IamAuthenticator]] behavior. Requires an `apikey`
+ * field, and optionally a mutually inclusive` clientId`, and `clientSecret`pair.
+ */
 export interface Options extends BaseOptions {
+  /** The IAM api key */
   apikey: string;
+  /**
+   * The client_id and client_secret fields are used to form a "basic"
+   * authorization header for IAM token requests.
+   */
   clientId?: string;
+  /**
+   * The client_id and client_secret fields are used to form a "basic"
+   * authorization header for IAM token requests.
+   */
   clientSecret?: string;
 }
 
+/**
+ * The [[IamAuthenticator]] utilizes an `apikey`, or `clientId` and
+ *   `clientSecret` pair to obtain a suitable bearer token, via an
+ *   [[IamTokenManager]], and adds it to requests.
+ *
+ * The bearer token will be sent as an Authorization header in the form:
+ *
+ *      Authorization: Bearer <bearer-token>
+ */
 export class IamAuthenticator extends TokenRequestBasedAuthenticator {
   protected requiredOptions = ['apikey'];
   protected tokenManager: IamTokenManager;
@@ -33,14 +55,18 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
   private clientSecret: string;
 
   /**
-   * IAM Authenticator Class
    *
-   * Handles the IAM authentication pattern.
+   * Create a new [[IamAuthenticator]] instance with an internal [[IamTokenManager]].
    *
-   * @param {Object} options
-   * @constructor
+   * @param {object} options Configuration options.
+   * @param {string} options.apikey The IAM api key.
+   * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string=} options.clientSecret The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @throws {Error} When the configuration options are not valid.
    */
-  constructor(options: Options) {    
+  constructor(options: Options) {
     super(options);
 
     validateInput(options, this.requiredOptions);
@@ -48,18 +74,18 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
     this.apikey = options.apikey;
     this.clientId = options.clientId;
     this.clientSecret = options.clientSecret;
-    
-    // the param names are shared between the authenticator and the token manager
-    // so we can just pass along the options object
+
+    // the param names are shared between the authenticator and the token
+    // manager so we can just pass along the options object
     this.tokenManager = new IamTokenManager(options);
   }
 
   /**
-   * Setter for the Client ID and the Client Secret. Both should be provided.
-   *
-   * @param {string} clientId
-   * @param {string} clientSecret
-   * @returns {void}
+   * Setter for the mutually inclusive `clientId` and the `clientSecret`.
+   * @param {string} clientId The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} clientSecret The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
    */
   public setClientIdAndSecret(clientId: string, clientSecret: string): void {
     this.clientId = clientId;

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -64,9 +64,9 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
    * @param {string} options.url for HTTP token requests.
    * @param {object<string, string>} options.headers to be sent with every
    * @param {string} options.apikey The IAM api key.
-   * @param {string=} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string=} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @throws {Error} When the configuration options are not valid.
    */

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -39,7 +39,7 @@ export interface Options extends BaseOptions {
  * The [[IamAuthenticator]] will use the user-supplied `apikey`
  * values to obtain a bearer token from a token server.  When the bearer token
  * expires, a new token is obtained from the token server. If specified the
- * optional mutually inclusive`clientId` and`clientSecret` pair can be used to
+ * optional mutually inclusive `clientId` and`clientSecret` pair can be used to
  * influence rate-limiting for requests to the IAM token server.
  *
  * The bearer token will be sent as an Authorization header in the form:

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -64,9 +64,9 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
    * @param {string} options.url for HTTP token requests.
    * @param {object<string, string>} options.headers to be sent with every
    * @param {string} options.apikey The IAM api key.
-   * @param {string=} options.clientId The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string=} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string=} options.clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string=} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @throws {Error} When the configuration options are not valid.
    */

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * @module auth
+ * @module authenticators
  * The ibm-cloud-sdk-core module supports the following types of authentication:
  *
  * Basic Authentication

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -14,6 +14,29 @@
  * limitations under the License.
  */
 
+/**
+ * @module auth
+ * The ibm-cloud-sdk-core module supports the following types of authentication:
+ *
+ * Basic Authentication
+ * Bearer Token
+ * Identity and Access Management (IAM)
+ * Cloud Pak for Data
+ * No Authentication
+ *
+ * The authentication types that are appropriate for a particular service may vary from service to service.
+ * Each authentication type is implemented as an Authenticator for consumption by a service.
+ *
+ * classes:
+ *   AuthenticatorInterface: Implement this class to provide custom authentication schemes to services.
+ *   Authenticator: Extend this class to provide custom authentication schemes to services.
+ *   BasicAuthenticator: Authenticator for passing supplied basic authentication information to service endpoint.
+ *   BearerTokenAuthenticator: Authenticator for passing supplied bearer token to service endpoint.
+ *   CloudPakForDataAuthenticator: Authenticator for passing CP4D authentication information to service endpoint.
+ *   IAMAuthenticator: Authenticator for passing IAM authentication information to service endpoint.
+ *   NoAuthAuthenticator: Performs no authentication. Useful for testing purposes.
+ */
+
 export { AuthenticatorInterface } from './authenticator-interface';
 export { Authenticator } from './authenticator';
 export { BasicAuthenticator } from './basic-authenticator';

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -24,8 +24,8 @@
  * Cloud Pak for Data
  * No Authentication
  *
- * The authentication types that are appropriate for a particular service may vary from service to service.
- * Each authentication type is implemented as an Authenticator for consumption by a service.
+ * The supported authentication types may vary from service to service. Each
+ * authentication type is implemented as an Authenticator for consumption by a service.
  *
  * classes:
  *   AuthenticatorInterface: Implement this class to provide custom authentication schemes to services.

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -23,12 +23,12 @@ import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-int
  * Provides a way to use a service without specifying credentials.
  *
  */
-export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
+export class NoAuthAuthenticator extends Authenticator {
   constructor() {
     super();
   }
 
-  public authenticate(options: AuthenticateOptions): Promise<void> {
+  public authenticate(request: AuthenticateOptions): Promise<void> {
     // immediately proceed to request. it will probably fail
     return Promise.resolve();
   }

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import { Authenticator } from './authenticator';
-import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
+import { AuthenticateOptions } from './authenticator-interface';
 
 /**
  * NoAuth Authenticator Class

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -18,10 +18,9 @@ import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
 
 /**
- * NoAuth Authenticator Class
- *
- * Provides a way to use a service without specifying credentials.
- *
+ * NoAuthAuthenticator is a placeholder authenticator implementation which
+ * performs no authentication of outgoing REST API requests. It might be
+ * useful during development and testing.
  */
 export class NoAuthAuthenticator extends Authenticator {
   constructor() {

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -17,15 +17,14 @@
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
-export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
   /**
    * NoAuth Authenticator Class
    *
    * Provides a way to use a service without specifying credentials.
    *
-   * @constructor
    */
-  constructor() {    
+export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
+  constructor() {
     super();
   }
 

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -17,12 +17,12 @@
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-interface';
 
-  /**
-   * NoAuth Authenticator Class
-   *
-   * Provides a way to use a service without specifying credentials.
-   *
-   */
+/**
+ * NoAuth Authenticator Class
+ *
+ * Provides a way to use a service without specifying credentials.
+ *
+ */
 export class NoAuthAuthenticator extends Authenticator implements AuthenticatorInterface {
   constructor() {
     super();

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -110,16 +110,16 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
    *
    *     Authorization: Bearer <bearer-token>
    *
-   * @param {object} request - The request to augment with authentication
+   * @param {object} requestOptions - The request to augment with authentication
    *   information.
-   * @param {object.<string, string>} request.headers - The headers the
+   * @param {object.<string, string>} requestOptions.headers - The headers the
    *   authentication information will be added too. Overrides default headers
    *   where there's conflict.
    */
-  public authenticate(request: AuthenticateOptions): Promise<void | Error> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
     return this.tokenManager.getToken().then(token => {
       const authHeader = { Authorization: `Bearer ${token}` };
-      request.headers = extend(true, {}, request.headers, authHeader);
+      requestOptions.headers = extend(true, {}, requestOptions.headers, authHeader);
       return;
     });
   }

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -56,10 +56,10 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
    * Create a new [[TokenRequestBasedAuthenticator]] instance with an internal [[JwtTokenManager]].
    *
    * @param {object} options Configuration options.
+   * @param {string} options.url for HTTP token requests.
    * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
-   *   disabled or not
-   * @param {string} options.url for HTTP token requests.
+   *   disabled or not.
    * @param {object<string, string>} [options.headers] to be sent with every
    *   outbound HTTP requests to token services.
    */

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -105,9 +105,8 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
   }
 
   /**
-   * Adds bearer token information to the passed in request object. The
-   * bearer token information will be added to the Authorization field of:
-   * `request.headers` in the form:
+   * Adds bearer token information to `request`. The bearer token information
+   * will be added to the Authorization property of`request.headers` in the form:
    *
    *     Authorization: Bearer <bearer-token>
    *

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -60,7 +60,7 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
    * @param {string} options.url for HTTP token requests.
-   * @param {Object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} options.headers to be sent with every
    *   outbound HTTP requests to token services.
    */
   constructor(options: BaseOptions) {
@@ -92,8 +92,8 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
   /**
    * Set headers.
    *
-   * @param {Object<string, string>} headers Default headers to be sent with
-   *   every Cloud Pak For Data token request.
+   * @param {object<string, string>} headers Default headers to be sent with
+   *   every Cloud Pak For Data token request. Overwrites previous default headers.
    */
   public setHeaders(headers: OutgoingHttpHeaders): void {
     if (typeof headers !== 'object') {
@@ -106,14 +106,15 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
 
   /**
    * Adds bearer token information to `request`. The bearer token information
-   * will be added to the Authorization property of`request.headers` in the form:
+   * will be set in the Authorization property of`request.headers` in the form:
    *
    *     Authorization: Bearer <bearer-token>
    *
    * @param {object} request - The request to augment with authentication
    *   information.
-   * @param {Object.<string, string>} request.headers - The headers the
-   *   authentication information will be added too.
+   * @param {object.<string, string>} request.headers - The headers the
+   *   authentication information will be added too. Overrides default headers
+   *   where there's conflict.
    */
   public authenticate(request: AuthenticateOptions): Promise<void | Error> {
     return this.tokenManager.getToken().then(token => {

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -105,7 +105,7 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
   }
 
   /**
-   * Adds bearer token information to the passed in options object. The
+   * Adds bearer token information to the passed in request object. The
    * bearer token information will be added to the Authorization field of:
    * `request.headers` in the form:
    *

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -56,11 +56,11 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
    * Create a new [[TokenRequestBasedAuthenticator]] instance with an internal [[JwtTokenManager]].
    *
    * @param {object} options Configuration options.
-   * @param {boolean} options.disableSslVerification A flag that indicates
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
    * @param {string} options.url for HTTP token requests.
-   * @param {object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} [options.headers] to be sent with every
    *   outbound HTTP requests to token services.
    */
   constructor(options: BaseOptions) {

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -20,9 +20,7 @@ import { JwtTokenManager } from '../token-managers';
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
 
-/**
- * Configuration options for TokenRequestBasedAuthenticators.
- */
+/** Configuration options for token-based authentication. */
 export type BaseOptions = {
   /** Headers to be sent with every outbound HTTP requests to token services. */
   headers?: OutgoingHttpHeaders;

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -18,7 +18,7 @@ import extend = require('extend');
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { JwtTokenManager, TokenManagerOptions } from './jwt-token-manager';
 
-/** Configuration options. */
+/** Configuration options for CP4D token retrieval. */
 interface Options extends TokenManagerOptions {
   /** The endpoint for CP4D token requests. */
   url: string;
@@ -47,7 +47,7 @@ export interface CpdTokenData {
  * Token Manager of CloudPak for data.
  *
  * The Token Manager performs basic auth with a username and password
- *    to acquire CP4D tokens.
+ * to acquire CP4D tokens.
  */
 export class Cp4dTokenManager extends JwtTokenManager {
   protected requiredOptions = ['username', 'password', 'url'];

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -61,9 +61,11 @@ export class Cp4dTokenManager extends JwtTokenManager {
    * @param {string} options.username The username portion of basic authentication.
    * @param {string} options.password The password portion of basic authentication.
    * @param {string} options.url The endpoint for CP4D token requests.
-   * @param {boolean} options.disableSslVerification A flag that indicates
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not.
+   * @param {object<string, string>} [options.headers] Headers to be sent with every
+   *   outbound HTTP requests to token services.
    * @constructor
    */
   constructor(options: Options) {

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -15,13 +15,16 @@
  */
 
 import extend = require('extend');
-import { getMissingParams } from '../../lib/helper';
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { JwtTokenManager, TokenManagerOptions } from './jwt-token-manager';
 
+/** Configuration options. */
 interface Options extends TokenManagerOptions {
+  /** The endpoint for CP4D token requests. */
   url: string;
+  /** The username portion of basic authentication. */
   username: string;
+  /** The password portion of basic authentication. */
   password: string;
 }
 
@@ -40,22 +43,27 @@ export interface CpdTokenData {
   accessToken: string;
 }
 
+/**
+ * Token Manager of CloudPak for data.
+ *
+ * The Token Manager performs basic auth with a username and password
+ *    to acquire CP4D tokens.
+ */
 export class Cp4dTokenManager extends JwtTokenManager {
   protected requiredOptions = ['username', 'password', 'url'];
   private username: string;
   private password: string;
 
   /**
-   * ICP Token Manager Service
+   * Create a new [[Cp4dTokenManager]] instance.
    *
-   * Retreives and stores ICP access tokens.
-   *
-   * @param {Object} options
-   * @param {String} options.username
-   * @param {String} options.password
-   * @param {String} options.accessToken - user-managed access token
-   * @param {String} options.url - URL for the CP4D cluster
-   * @param {Boolean} options.disableSslVerification - disable SSL verification for token request
+   * @param {object} options Configuration options.
+   * @param {string} options.username The username portion of basic authentication.
+   * @param {string} options.password The password portion of basic authentication.
+   * @param {string} options.url The endpoint for CP4D token requests.
+   * @param {boolean} options.disableSslVerification A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not.
    * @constructor
    */
   constructor(options: Options) {
@@ -76,11 +84,6 @@ export class Cp4dTokenManager extends JwtTokenManager {
     this.password = options.password;
   }
 
-  /**
-   * Request an CP4D token using a basic auth header.
-   *
-   * @returns {Promise}
-   */
   protected requestToken(): Promise<any> {
     // these cannot be overwritten
     const requiredHeaders = {

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -16,7 +16,6 @@
 
 import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
-import { getMissingParams } from '../../lib/helper';
 import logger from '../../lib/logger';
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { JwtTokenManager, TokenManagerOptions } from './jwt-token-manager';
@@ -43,6 +42,7 @@ interface Options extends TokenManagerOptions {
   clientSecret?: string;
 }
 
+// TODO: Remove this interface.
 // this interface is a representation of the response
 // object from the IAM service, hence the snake_case
 // parameter names
@@ -54,6 +54,11 @@ export interface IamTokenData {
   expiration: number;
 }
 
+/**
+ * The IAMTokenManager takes an api key and performs the necessary interactions with
+ * the IAM token service to obtain and store a suitable bearer token. Additionally, the IAMTokenManager
+ * will retrieve bearer tokens via basic auth using a supplied client_id and client_secret pair.
+ */
 export class IamTokenManager extends JwtTokenManager {
   protected requiredOptions = ['apikey'];
   private apikey: string;
@@ -61,14 +66,16 @@ export class IamTokenManager extends JwtTokenManager {
   private clientSecret: string;
 
   /**
-   * IAM Token Manager Service
    *
-   * Retreives and stores IAM access tokens.
+   * Create a new [[IamTokenManager]] instance.
    *
-   * @param {Object} options
-   * @param {String} options.apikey
-   * @param {String} options.iamAccessToken
-   * @param {String} options.iamUrl - url of the iam api to retrieve tokens from
+   * @param {object} options Configuration options.
+   * @param {string} options.apikey The IAM api key.
+   * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string=} options.clientSecret The client_id and client_secret fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [url='https://iam.cloud.ibm.com/identity/token'] The IAM endpoint for token requests.
    * @constructor
    */
   constructor(options: Options) {
@@ -99,8 +106,8 @@ export class IamTokenManager extends JwtTokenManager {
    * If these values are not set, no Authorization header will be
    * set on the request (it is not required).
    *
-   * @param {string} clientId - The client id
-   * @param {string} clientSecret - The client secret
+   * @param {string} clientId - The client id.
+   * @param {string} clientSecret - The client secret.
    * @returns {void}
    */
   public setClientIdAndSecret(clientId: string, clientSecret: string): void {

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -46,7 +46,7 @@ interface Options extends TokenManagerOptions {
 /**
  * The IAMTokenManager takes an api key and performs the necessary interactions with
  * the IAM token service to obtain and store a suitable bearer token. Additionally, the IAMTokenManager
- * will retrieve bearer tokens via basic auth using a supplied client_id and client_secret pair.
+ * will retrieve bearer tokens via basic auth using a supplied `clientId` and `clientSecret` pair.
  */
 export class IamTokenManager extends JwtTokenManager {
   protected requiredOptions = ['apikey'];
@@ -60,9 +60,9 @@ export class IamTokenManager extends JwtTokenManager {
    *
    * @param {object} options Configuration options.
    * @param {string} options.apikey The IAM api key.
-   * @param {string=} options.clientId The client_id and client_secret fields are used to form a "basic"
+   * @param {string=} options.clientId The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string=} options.clientSecret The client_id and client_secret fields are used to form a "basic"
+   * @param {string=} options.clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @param {string} [url='https://iam.cloud.ibm.com/identity/token'] The IAM endpoint for token requests.
    * @constructor

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -36,22 +36,11 @@ function onlyOne(a: any, b: any): boolean {
 
 const CLIENT_ID_SECRET_WARNING = 'Warning: Client ID and Secret must BOTH be given, or the header will not be included.';
 
+/** Configuration options for IAM token retrieval. */
 interface Options extends TokenManagerOptions {
   apikey: string;
   clientId?: string;
   clientSecret?: string;
-}
-
-// TODO: Remove this interface.
-// this interface is a representation of the response
-// object from the IAM service, hence the snake_case
-// parameter names
-export interface IamTokenData {
-  access_token: string;
-  refresh_token: string;
-  token_type: string;
-  expires_in: number;
-  expiration: number;
 }
 
 /**

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -65,6 +65,11 @@ export class IamTokenManager extends JwtTokenManager {
    * @param {string=} options.clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @param {string} [url='https://iam.cloud.ibm.com/identity/token'] The IAM endpoint for token requests.
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not.
+   * @param {object<string, string>} [options.headers] Headers to be sent with every
+   *   outbound HTTP requests to token services.
    * @constructor
    */
   constructor(options: Options) {
@@ -89,7 +94,7 @@ export class IamTokenManager extends JwtTokenManager {
   }
 
   /**
-   * Set the IAM 'client_id' and 'client_secret' values.
+   * Set the IAM `clientId` and `clientSecret` values.
    * These values are used to compute the Authorization header used
    * when retrieving the IAM access token.
    * If these values are not set, no Authorization header will be

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -60,9 +60,9 @@ export class IamTokenManager extends JwtTokenManager {
    *
    * @param {object} options Configuration options.
    * @param {string} options.apikey The IAM api key.
-   * @param {string=} options.clientId The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
-   * @param {string=} options.clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
+   * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @param {string} [url='https://iam.cloud.ibm.com/identity/token'] The IAM endpoint for token requests.
    * @param {boolean} [options.disableSslVerification] A flag that indicates

--- a/auth/token-managers/index.ts
+++ b/auth/token-managers/index.ts
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+/**
+ * @module token-managers
+ * The ibm-cloud-sdk-core module supports the following types of token authentication:
+ *
+ * Identity and Access Management (IAM)
+ * Cloud Pak for Data
+ *
+ * The token managers sit inside of an authenticator and do the work to retrieve
+ * tokens where as the authenticators add these tokens to the actual request.
+ *
+ * classes:
+ *   IamTokenManager: Token Manager of CloudPak for data.
+ *   Cp4dTokenManager: Authenticator for passing IAM authentication information to service endpoint.
+ *   JwtTokenManager: A class for shared functionality for parsing, storing, and requesting JWT tokens.
+ */
+
+
  export { IamTokenManager } from './iam-token-manager';
  export { Cp4dTokenManager } from './cp4d-token-manager';
  export { JwtTokenManager } from './jwt-token-manager';

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -25,13 +25,25 @@ function getCurrentTime(): number {
 }
 
 export type TokenManagerOptions = {
+  /** The endpoint for token requests. */
   url?: string;
+  /** Headers to be sent with every service token request. */
   headers?: OutgoingHttpHeaders;
+  /**
+   * A flag that indicates whether verification of
+   *   the server's SSL certificate should be disabled or not.
+   */
   disableSslVerification?: boolean;
   /** Allow additional request config parameters */
   [propName: string]: any;
 }
 
+/**
+ * A class for shared functionality for parsing, storing, and requesting
+ * JWT tokens. Intended to be used as a parent to be extended for token
+ * request management. Child classes should implement `requestToken()`
+ * to retrieve the bearer token from intended sources.
+ */
 export class JwtTokenManager {
   protected url: string;
   protected tokenName: string;
@@ -42,14 +54,15 @@ export class JwtTokenManager {
   private expireTime: number;
 
   /**
-   * Token Manager Service
-   *
-   * Retreives and stores JSON web tokens.
-   *
-   * @param {Object} options
-   * @param {String} options.url - url of the api to retrieve tokens from
-   * @param {String} [options.accessToken] - user-managed access token
+   * Create a new [[JwtTokenManager]] instance.
    * @constructor
+   * @param {object} options Configuration options.
+   * @param {boolean} options.disableSslVerification A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not
+   * @param {string} options.url for HTTP token requests.
+   * @param {Object<string, string>} options.headers to be sent with every
+   *   outbound HTTP requests to token services.
    */
   constructor(options: TokenManagerOptions) {
     // all parameters are optional
@@ -71,13 +84,9 @@ export class JwtTokenManager {
   }
 
   /**
-   * This function returns a Promise that resolves with an access token, if successful.
-   * The source of the token is determined by the following logic:
-   * 1. If user provides their own managed access token, assume it is valid and send it
-   * 2. a) If this class is managing tokens and does not yet have one, make a request for one
-   *    b) If this class is managing tokens and the token has expired, request a new one
-   * 3. If this class is managing tokens and has a valid token stored, send it
-   *
+   * Retrieve a new token using `requestToken()` in the case there is not a
+   *   currently stored token from a previous call, or the previous token
+   *   has expired.
    */
   public getToken(): Promise<any> {
     if (!this.tokenInfo[this.tokenName] || this.isTokenExpired()) {
@@ -95,7 +104,8 @@ export class JwtTokenManager {
   /**
    * Setter for the disableSslVerification property.
    *
-   * @param {boolean} value - the new value for the disableSslVerification property
+   * @param {boolean} value - the new value for the disableSslVerification
+   *   property
    * @returns {void}
    */
   public setDisableSslVerification(value: boolean): void {
@@ -119,7 +129,7 @@ export class JwtTokenManager {
   }
 
   /**
-   * Request a JWT using an API key.
+   * Fully implemented and will be throw an error when called.
    *
    * @returns {Promise}
    */

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -24,6 +24,7 @@ function getCurrentTime(): number {
   return Math.floor(Date.now() / 1000);
 }
 
+/** Configuration options for JWT token retrieval. */
 export type TokenManagerOptions = {
   /** The endpoint for token requests. */
   url?: string;

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -62,7 +62,7 @@ export class JwtTokenManager {
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
    * @param {string} options.url for HTTP token requests.
-   * @param {Object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} options.headers to be sent with every
    *   outbound HTTP requests to token services.
    */
   constructor(options: TokenManagerOptions) {

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -129,11 +129,6 @@ export class JwtTokenManager {
     this.headers = headers;
   }
 
-  /**
-   * Fully implemented and will be throw an error when called.
-   *
-   * @returns {Promise}
-   */
   protected requestToken(): Promise<any> {
     const errMsg = '`requestToken` MUST be overridden by a subclass of JwtTokenManagerV1.';
     const err = new Error(errMsg);

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -60,9 +60,9 @@ export class JwtTokenManager {
    * @param {object} options Configuration options.
    * @param {boolean} options.disableSslVerification A flag that indicates
    *   whether verification of the token server's SSL certificate should be
-   *   disabled or not
+   *   disabled or not.
    * @param {string} options.url for HTTP token requests.
-   * @param {object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} [options.headers] Headers to be sent with every
    *   outbound HTTP requests to token services.
    */
   constructor(options: TokenManagerOptions) {

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -129,6 +129,11 @@ export class JwtTokenManager {
     this.headers = headers;
   }
 
+  /**
+   * Request a JWT using an API key.
+   *
+   * @returns {Promise}
+   */
   protected requestToken(): Promise<any> {
     const errMsg = '`requestToken` MUST be overridden by a subclass of JwtTokenManagerV1.';
     const err = new Error(errMsg);

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -58,10 +58,10 @@ export class JwtTokenManager {
    * Create a new [[JwtTokenManager]] instance.
    * @constructor
    * @param {object} options Configuration options.
-   * @param {boolean} options.disableSslVerification A flag that indicates
+   * @param {string} options.url for HTTP token requests.
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not.
-   * @param {string} options.url for HTTP token requests.
    * @param {object<string, string>} [options.headers] Headers to be sent with every
    *   outbound HTTP requests to token services.
    */

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -28,6 +28,17 @@ import {
 
 import { readExternalSources } from './read-external-sources';
 
+/**
+ * Look for external configuration of authenticator.
+ *
+ * Try to get authenticator from external sources, with the following priority:
+ * 1. Credentials file(ibm-credentials.env)
+ * 2. Environment variables
+ * 3. VCAP Services(Cloud Foundry)
+ *
+ * @param {string} serviceName The service name prefix.
+ *
+ */
 export function getAuthenticatorFromEnvironment(serviceName: string): Authenticator {
   if (!serviceName) {
     throw new Error('Service name is required.');
@@ -52,7 +63,7 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
 
   if (credentials.authDisableSsl) {
     credentials.disableSslVerification = credentials.authDisableSsl;
-    delete credentials.authDisableSsl; 
+    delete credentials.authDisableSsl;
   }
 
   // default the auth type to `iam` if authType is undefined, or not a string

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -32,9 +32,9 @@ import { readExternalSources } from './read-external-sources';
  * Look for external configuration of authenticator.
  *
  * Try to get authenticator from external sources, with the following priority:
- * 1. Credentials file(ibm-credentials.env)
+ * 1. Credentials file (ibm-credentials.env)
  * 2. Environment variables
- * 3. VCAP Services(Cloud Foundry)
+ * 3. VCAP Services (Cloud Foundry)
  *
  * @param {string} serviceName The service name prefix.
  *

--- a/auth/utils/helpers.ts
+++ b/auth/utils/helpers.ts
@@ -58,8 +58,8 @@ export function checkCredentials(obj: any, credsToCheck: string[]) : Error | nul
 }
 
 /**
- * @param options - A configuration object.
- * @param requiredOptions - The list of of properties the options must have specified.
+ * @param {object} options - A configuration options object.
+ * @param {string[]} requiredOptions - The list of of properties the options must have specified.
  */
 export function validateInput(options: any, requiredOptions: string[]): void {
   // check for required params

--- a/auth/utils/helpers.ts
+++ b/auth/utils/helpers.ts
@@ -38,7 +38,7 @@ function badCharAtAnEnd(value: string): boolean {
  * Checks credentials for common user mistakes of copying {, }, or " characters from the documentation
  *
  * @param {object} obj - The options object holding credentials
- * @param {string[]} credsToCheck - An array containing the keys of the credentials to check for problems 
+ * @param {string[]} credsToCheck - An array containing the keys of the credentials to check for problems
  * @returns {string | null} - Returns a string with the error message if there were problems, null if not
  */
 export function checkCredentials(obj: any, credsToCheck: string[]) : Error | null {
@@ -57,6 +57,10 @@ export function checkCredentials(obj: any, credsToCheck: string[]) : Error | nul
   }
 }
 
+/**
+ * @param options - A configuration object.
+ * @param requiredOptions - The list of of properties the options must have specified.
+ */
 export function validateInput(options: any, requiredOptions: string[]): void {
   // check for required params
   const missingParamsError = getMissingParams(options, requiredOptions);

--- a/auth/utils/index.ts
+++ b/auth/utils/index.ts
@@ -18,12 +18,6 @@
  * @module utils
  * Helper functions used by generated SDKs.
  *
- * Identity and Access Management (IAM)
- * Cloud Pak for Data
- *
- * The token managers sit inside of an authenticator and do the work to retrieve
- * tokens where as the authenticators add these tokens to the actual request.
- *
  * functions:
  *   getAuthenticatorFromEnvironment: Get authenticator from external sources.
  *   readExternalSources: Get config object from external sources.

--- a/auth/utils/index.ts
+++ b/auth/utils/index.ts
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+/**
+ * @module utils
+ * Helper functions used by generated SDKs.
+ *
+ * Identity and Access Management (IAM)
+ * Cloud Pak for Data
+ *
+ * The token managers sit inside of an authenticator and do the work to retrieve
+ * tokens where as the authenticators add these tokens to the actual request.
+ *
+ * functions:
+ *   getAuthenticatorFromEnvironment: Get authenticator from external sources.
+ *   readExternalSources: Get config object from external sources.
+ */
+
+
+
 export * from './helpers';
 export * from './read-credentials-file';
 export { getAuthenticatorFromEnvironment } from './get-authenticator-from-environment';

--- a/auth/utils/read-credentials-file.ts
+++ b/auth/utils/read-credentials-file.ts
@@ -6,6 +6,10 @@ import logger from '../../lib/logger';
 
 const filename: string = 'ibm-credentials.env';
 
+/**
+ * Return a config object based on a credentials file. Credentials files can
+ * be specified filepath via the environment variable: `IBM_CREDENTIALS_FILE`.
+ */
 export function readCredentialsFile() {
   if (!fs.existsSync) {
     return {};

--- a/auth/utils/read-external-sources.ts
+++ b/auth/utils/read-external-sources.ts
@@ -15,20 +15,19 @@
  */
 
 import camelcase = require('camelcase');
-import extend = require('extend');
 import isEmpty = require('lodash.isempty');
 import vcapServices = require('vcap_services');
 import { readCredentialsFile } from './read-credentials-file';
 
-/*
+/**
  * Read properties stored in external sources like Environment Variables,
  * the credentials file, VCAP services, etc. and return them as an
  * object. The keys of this object will have the service name prefix removed
  * and will be converted to lower camel case.
  *
  * Only one source will be used at a time.
+ * @param {string} serviceName The service name prefix.
  */
-
 export function readExternalSources(serviceName: string) {
   if (!serviceName) {
     throw new Error('Service name is required.');
@@ -53,7 +52,7 @@ function getProperties(serviceName: string): any {
   }
 
   if (isEmpty(properties)) {
-    properties = getCredentialsFromCloud(serviceName);    
+    properties = getCredentialsFromCloud(serviceName);
   }
 
   return properties;

--- a/auth/utils/read-external-sources.ts
+++ b/auth/utils/read-external-sources.ts
@@ -66,7 +66,7 @@ function getProperties(serviceName: string): any {
  * For example, if service.name is speech_to_text,
  * env properties are SPEECH_TO_TEXT_USERNAME and SPEECH_TO_TEXT_PASSWORD
  *
- * @param {Object} envObj - the object containing the credentials keyed by environment variables
+ * @param {object} envObj - the object containing the credentials keyed by environment variables
  * @returns {Credentials}
  */
 function filterPropertiesByServiceName(envObj: any, serviceName: string): any {

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -17,13 +17,14 @@
 
 import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
-import semver = require('semver');
-import vcapServices = require('vcap_services');
 import { AuthenticatorInterface, checkCredentials, readExternalSources } from '../auth';
 import { stripTrailingSlash } from './helper';
 import logger from './logger';
 import { RequestWrapper } from './request-wrapper';
 
+/**
+ * Configuration values for a service.
+ */
 export interface UserOptions {
   /** The Authenticator object used to authenticate requests to the service */
   authenticator?: AuthenticatorInterface;
@@ -41,10 +42,20 @@ export interface UserOptions {
   [propName: string]: any;
 }
 
+/**
+ * Additional service configuration.
+ */
 export interface BaseServiceOptions extends UserOptions {
+  /** Querystring to be sent with every request. If not a string will be stringified. */
   qs: any;
 }
 
+/**
+ * Common functionality shared by generated service classes.
+ *
+ * The base service authenticates requests via its authenticator, stores cookies, and
+ * wraps responses from the service endpoint in DetailedResponse or APIException objects.
+ */
 export class BaseService {
   static URL: string;
   name: string;
@@ -53,17 +64,6 @@ export class BaseService {
   private authenticator: AuthenticatorInterface;
   private requestWrapperInstance;
 
-  /**
-   * Internal base class that other services inherit from
-   * @param {UserOptions} options
-   * @param {OutgoingHttpHeaders} [options.headers]
-   * @param {string} [options.url] - override default service base url
-   * @private
-   * @abstract
-   * @constructor
-   * @throws {Error}
-   * @returns {BaseService}
-   */
   constructor(userOptions: UserOptions) {
     if (!(this instanceof BaseService)) {
       const err = 'the "new" keyword is required to create service instances';
@@ -158,22 +158,22 @@ export class BaseService {
   /**
    * Wrapper around `sendRequest` that enforces the request will be authenticated.
    *
-   * @param {object} parameters - service request options passed in by user
-   * @param {string} parameters.options.method - the http method
-   * @param {string} parameters.options.url - the path portion of the URL to be appended to the serviceUr
-   * @param {object} [parameters.options.path] - the path parameters to be inserted into the URL
-   * @param {object} [parameters.options.qs] - the querystring to be included in the URL
-   * @param {object} [parameters.options.body] - the data to be sent as the request body
-   * @param {object} [parameters.options.form] - an object containing the key/value pairs for a www-form-urlencoded request
-   * @param {object} [parameters.options.formData] - an object containing the contents for a multipart/form-data request
+   * @param {object} parameters Service request options passed in by user.
+   * @param {string} parameters.options.method The http method.
+   * @param {string} parameters.options.url The path portion of the URL to be appended to the serviceUrl.
+   * @param {object} parameters.options.path The path parameters to be inserted into the URL.
+   * @param {object} parameters.options.qs The querystring to be included in the URL.
+   * @param {object} parameters.options.body The data to be sent as the request body.
+   * @param {object} parameters.options.form An object containing the key/value pairs for a www-form-urlencoded request.
+   * @param {object} parameters.options.formData An object containing the contents for a multipart/form-data request
    * The following processing is performed on formData values:
    * - string: no special processing -- the value is sent as is
    * - object: the value is converted to a JSON string before insertion into the form body
    * - NodeJS.ReadableStream|Buffer|FileWithMetadata: sent as a file, with any associated metadata
    * - array: each element of the array is sent as a separate form part using any special processing as described above
-   * @param {object} parameters.defaultOptions
-   * @param {string} parameters.defaultOptions.serviceUrl - the base URL of the service
-   * @param {OutgoingHttpHeaders} parameters.defaultOptions.headers - additional headers to be passed on the request
+   * @param {object} parameters.defaultOptions Options that can obe overridden for individual requests.
+   * @param {string} parameters.defaultOptions.serviceUrl The base URL of the service.
+   * @param {OutgoingHttpHeaders} parameters.defaultOptions.headers Additional headers to be passed on the request.
    * @returns {Promise<any>}
    */
   protected createRequest(parameters): Promise<any> {

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -172,12 +172,12 @@ export class BaseService {
    *
    * @param {object} parameters Service request options passed in by user.
    * @param {string} parameters.options.method The http method.
-   * @param {string} parameters.options.url The path portion of the URL to be appended to the serviceUrl.
-   * @param {object} parameters.options.path The path parameters to be inserted into the URL.
-   * @param {object} parameters.options.qs The querystring to be included in the URL.
-   * @param {object} parameters.options.body The data to be sent as the request body.
-   * @param {object} parameters.options.form An object containing the key/value pairs for a www-form-urlencoded request.
-   * @param {object} parameters.options.formData An object containing the contents for a multipart/form-data request
+   * @param {string} [parameters.options.url] The path portion of the URL to be appended to the serviceUrl.
+   * @param {object} [parameters.options.path] The path parameters to be inserted into the URL.
+   * @param {object} [parameters.options.qs] The querystring to be included in the URL.
+   * @param {object} [parameters.options.body] The data to be sent as the request body.
+   * @param {object} [parameters.options.form] An object containing the key/value pairs for a www-form-urlencoded request.
+   * @param {object} [parameters.options.formData] An object containing the contents for a multipart/form-data request
    * The following processing is performed on formData values:
    * - string: no special processing -- the value is sent as is
    * - object: the value is converted to a JSON string before insertion into the form body

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -63,7 +63,19 @@ export class BaseService {
   protected baseOptions: BaseServiceOptions;
   private authenticator: AuthenticatorInterface;
   private requestWrapperInstance;
-
+  /**
+   * Configuration values for a service.
+   * @param {Authenticator} userOptions.authenticator Object used to authenticate requests to the service.
+   * @param {string} [userOptions.serviceUrl] The base url to use when contacting the service.
+   *   The base url may differ between IBM Cloud regions.
+   * @param {object<string, string>} [userOptions.headers] Default headers that shall be
+   *   included with every request to the service.
+   * @param {string} [userOptions.version] The API version date to use with the service,
+   *   in "YYYY-MM-DD" format.
+   * @param {boolean} [userOptions.disableSslVerification] A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not.
+   */
   constructor(userOptions: UserOptions) {
     if (!(this instanceof BaseService)) {
       const err = 'the "new" keyword is required to create service instances';

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -128,7 +128,7 @@ export class BaseService {
   /**
    * Set the service URL to send requests to.
    *
-   * @param {string} the base URL for the service
+   * @param {string} url The base URL for the service.
    */
   public setServiceUrl(url: string): void {
     this.baseOptions.serviceUrl = url;
@@ -137,8 +137,8 @@ export class BaseService {
   /**
    * Configure the service using external configuration
    *
-   * @param {string} the name of the service. Will be used to read from external
-   * configuration
+   * @param {string} serviceName The name of the service. Will be used to read from external
+   * configuration.
    */
   protected configureService(serviceName: string): void {
     if (!serviceName) {

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -172,7 +172,7 @@ export class BaseService {
    *
    * @param {object} parameters Service request options passed in by user.
    * @param {string} parameters.options.method The http method.
-   * @param {string} [parameters.options.url] The path portion of the URL to be appended to the serviceUrl.
+   * @param {string} parameters.options.url The path portion of the URL to be appended to the serviceUrl.
    * @param {object} [parameters.options.path] The path parameters to be inserted into the URL.
    * @param {object} [parameters.options.qs] The querystring to be included in the URL.
    * @param {object} [parameters.options.body] The data to be sent as the request body.

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -53,8 +53,8 @@ export interface BaseServiceOptions extends UserOptions {
 /**
  * Common functionality shared by generated service classes.
  *
- * The base service authenticates requests via its authenticator, stores cookies, and
- * wraps responses from the service endpoint in DetailedResponse or APIException objects.
+ * The base service authenticates requests via its authenticator, and sends
+ * them to the service endpoint.
  */
 export class BaseService {
   static URL: string;

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -171,7 +171,7 @@ export class BaseService {
    * - object: the value is converted to a JSON string before insertion into the form body
    * - NodeJS.ReadableStream|Buffer|FileWithMetadata: sent as a file, with any associated metadata
    * - array: each element of the array is sent as a separate form part using any special processing as described above
-   * @param {object} parameters.defaultOptions Options that can obe overridden for individual requests.
+   * @param {object} parameters.defaultOptions
    * @param {string} parameters.defaultOptions.serviceUrl The base URL of the service.
    * @param {OutgoingHttpHeaders} parameters.defaultOptions.headers Additional headers to be passed on the request.
    * @returns {Promise<any>}

--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -12,7 +12,7 @@ const headerContentTypes: { [key: string]: string } = {
   RIFF: 'audio/wav',
   OggS: 'audio/ogg',
   ID3: 'audio/mp3',
-  '\u001aEߣ': 'audio/webm' // String for first four hex's of webm: [1A][45][DF][A3] (https://www.matroska.org/technical/specs/index.html#EBML)
+  '\u001aEߣ': 'audio/webm' // String for first four hex's of web: [1A][45][DF][A3] (https://www.matroska.org/technical/specs/index.html#EBML)
 };
 
 const filenameContentTypes: { [key: string]: string } = {
@@ -28,8 +28,8 @@ const filenameContentTypes: { [key: string]: string } = {
 /**
  * Takes the beginning of an audio file and returns the associated content-type / mime type
  *
- * @param {Buffer} buffer with at least the first 4 bytes of the file
- * @return {String|undefined} - the contentType of undefined
+ * @param {Buffer} buffer With at least the first 4 bytes of the file
+ * @return {String|undefined} The contentType of undefined
  */
 const fromHeader = (buffer: Buffer): string => {
   const headerStr = buffer

--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -48,7 +48,7 @@ const fromHeader = (buffer: Buffer): string => {
  * Note: Blob and File objects include a .type property, but we're ignoring it because it's frequently either
  * incorrect (e.g. video/ogg instead of audio/ogg) or else a different format than what's expected (e.g. audio/x-wav)
  *
- * @param {String|ReadableStream|FileObject|Buffer|File} file - string filename or url, or binary File/Blob object
+ * @param {String|ReadableStream|FileObject|Buffer|File} file String filename or url, or binary File/Blob object.
  * @return {String|undefined}
  */
 const fromFilename = (file: String | NodeJS.ReadableStream | FileObject | Buffer | File): string => {

--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -29,7 +29,7 @@ const filenameContentTypes: { [key: string]: string } = {
  * Takes the beginning of an audio file and returns the associated content-type / mime type
  *
  * @param {Buffer} buffer With at least the first 4 bytes of the file
- * @return {String|undefined} The contentType of undefined
+ * @return {String|undefined} The contentType or undefined
  */
 const fromHeader = (buffer: Buffer): string => {
   const headerStr = buffer

--- a/lib/content-type.ts
+++ b/lib/content-type.ts
@@ -12,7 +12,7 @@ const headerContentTypes: { [key: string]: string } = {
   RIFF: 'audio/wav',
   OggS: 'audio/ogg',
   ID3: 'audio/mp3',
-  '\u001aEߣ': 'audio/webm' // String for first four hex's of web: [1A][45][DF][A3] (https://www.matroska.org/technical/specs/index.html#EBML)
+  '\u001aEߣ': 'audio/webm' // String for first four hex's of webm: [1A][45][DF][A3] (https://www.matroska.org/technical/specs/index.html#EBML)
 };
 
 const filenameContentTypes: { [key: string]: string } = {

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -160,11 +160,11 @@ export function getFormat(
 }
 
 /**
- * this function builds a `form-data` object for each file parameter
- * @param {FileWithMetadata} fileParam - the file parameter
- * @param {NodeJS.ReadableStream|Buffer} fileParam.data - the data content of the file
- * @param (string) fileParam.filename - the filename of the file
- * @param {string} fileParam.contentType - the content type of the file
+ * This function builds a `form-data` object for each file parameter.
+ * @param {FileWithMetadata} fileParam The file parameter.
+ * @param {NodeJS.ReadableStream|Buffer} fileParam.data The data content of the file.
+ * @param {string} fileParam.filename The filename of the file.
+ * @param {string} fileParam.contentType The content type of the file.
  * @returns {FileObject}
  */
 export function buildRequestFileObject(
@@ -213,9 +213,9 @@ export function buildRequestFileObject(
 }
 
 /**
- * this function converts an object's keys to lower case
+ * This function converts an object's keys to lower case.
  * note: does not convert nested keys
- * @param {Object} obj - the object to convert the keys of
+ * @param {Object} obj The object to convert the keys of.
  * @returns {Object}
  */
 export function toLowerKeys(obj: Object): Object {

--- a/lib/querystring.ts
+++ b/lib/querystring.ts
@@ -5,7 +5,7 @@
  * Properly url-encoding percent characters causes it to reject the token
  * So, this is a custom qs.stringify function that properly encodes everything except watson-token, passing it along verbatim
  *
- * @param {Object} queryParams
+ * @param {Object<string, Object>} queryParams
  * @return {String}
  */
 const stringify = (queryParams: Object): string => {

--- a/lib/stream-to-promise.ts
+++ b/lib/stream-to-promise.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream';
  * Helper method that can be bound to a stream - it sets the output to utf-8, captures all of the results, and returns a promise that resolves to the final text
  * Essentially a smaller version of concat-stream wrapped in a promise
  *
- * @param {Stream} stream optional stream param for when not bound to an existing stream instance
+ * @param {Stream} stream Optional stream param for when not bound to an existing stream instance.
  * @return {Promise}
  */
 export function streamToPromise(stream: Stream): Promise<any> {

--- a/lib/stream-to-promise.ts
+++ b/lib/stream-to-promise.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream';
  * Helper method that can be bound to a stream - it sets the output to utf-8, captures all of the results, and returns a promise that resolves to the final text
  * Essentially a smaller version of concat-stream wrapped in a promise
  *
- * @param {Stream} [stream] optional stream param for when not bound to an existing stream instance
+ * @param {Stream} stream optional stream param for when not bound to an existing stream instance
  * @return {Promise}
  */
 export function streamToPromise(stream: Stream): Promise<any> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6621,9 +6621,9 @@
       }
     },
     "lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
       "dev": true
     },
     "macos-release": {

--- a/scripts/typedoc/generate_typedoc.sh
+++ b/scripts/typedoc/generate_typedoc.sh
@@ -3,4 +3,5 @@
     ./lib/base-service.ts ./lib/content-type.ts \
     ./lib/helper.ts ./lib/querystring.ts \
     ./lib/request-wrapper.ts \
-    ./lib/stream-to-promise.ts --target "ES5"
+    ./lib/stream-to-promise.ts \
+    ./auth --target "ES5"

--- a/test/unit/basic-authenticator.test.js
+++ b/test/unit/basic-authenticator.test.js
@@ -12,9 +12,9 @@ const CONFIG = {
 describe('Basic Authenticator', () => {
   it('should store the username and password on the class', () => {
     const authenticator = new BasicAuthenticator(CONFIG);
-
-    expect(authenticator.username).toBe(USERNAME);
-    expect(authenticator.password).toBe(PASSWORD);
+    expect(authenticator.authHeader).toEqual({
+      Authorization: 'Basic ZGF2ZTpncm9obA==',
+    });
   });
 
   it('should throw an error when username is not provided', () => {

--- a/test/unit/cp4d-authenticator.test.js
+++ b/test/unit/cp4d-authenticator.test.js
@@ -31,7 +31,6 @@ const getTokenSpy = jest
 describe('CP4D Authenticator', () => {
   it('should store all CONFIG options on the class', () => {
     const authenticator = new CloudPakForDataAuthenticator(CONFIG);
-
     expect(authenticator.username).toBe(CONFIG.username);
     expect(authenticator.password).toBe(CONFIG.password);
     expect(authenticator.url).toBe(CONFIG.url);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

Enhance documentation for the node-sdk-core

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] documentation is changed or added

FAQ

**Removing the implements AuthenticatorInterface` everywhere`**?:
In the typedoc it would show that the Authenticators implemented the interface twice. Which felt confusing to me. They already implement it through the Authenticator.

**The refactor of the authentication logic in the BasicAuthenticator**?
Same changes were made during commenting of the python core. Can be reversed if needed.