### PR TITLE
build: configure package to build and publish from dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage.lcov
 /.project
 .secrets.baseline
 .pre-commit-config.yaml
+dist/

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,9 @@
   "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
   "prepare": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
   "publish": [
-    "@semantic-release/npm",
+    ["@semantic-release/npm", {
+      "pkgRoot": "dist"
+    }],
     {
       "path": "@semantic-release/github"
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 cache:
   npm: false
 script:
-- npm run prepare
+- npm run build
 - npm run lint
 - npm run test-travis
 - sh scripts/typedoc/generate_typedoc.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,6 +1580,15 @@
         "@types/node": "*"
       }
     },
+    "@types/ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-Q0pVLfFSEkAnFgXF6Sbe5pJ/cZb14tNyFcBiwkIw5nJaGw8PFMXolfWsPIxG/ja7SmEHX/DjlpruRFGnG6lbjA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/isstream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@types/isstream/-/isstream-0.1.0.tgz",
@@ -1747,6 +1756,12 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -12646,6 +12661,49 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "tsc-publish": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/tsc-publish/-/tsc-publish-0.5.2.tgz",
+      "integrity": "sha512-Z/2yZSVFoeEgziTVeYc+jc6+2AygX9dnbwB6f3XuI4sSgTjoq5ggRGoTtuKcI91FzUeJq88rVZkN/VZmjbSzPw==",
+      "dev": true,
+      "requires": {
+        "@types/ignore-walk": "^3.0.1",
+        "@types/node": "^12.12.5",
+        "ansi-colors": "^4.1.1",
+        "commander": "^3.0.0",
+        "ignore-walk": "^3.0.3",
+        "strip-json-comments": "^3.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
+          "integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==",
+          "dev": true
+        },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-cloud-sdk-core",
   "version": "1.3.0",
   "description": "Core functionality to support SDKs generated with IBM's OpenAPI 3 SDK Generator.",
-  "main": "./index",
+  "main": "./dist/index",
   "repository": {
     "type": "git",
     "url": "https://github.com/IBM/node-sdk-core.git"
@@ -44,6 +44,7 @@
     "object.assign": "~4.1.0",
     "prettier": "~1.13.5",
     "semantic-release": "^15.13.24",
+    "tsc-publish": "^0.5.2",
     "tslint": "~5.10.0",
     "tslint-config-prettier": "~1.13.0",
     "tslint-eslint-rules": "^5.4.0",
@@ -92,7 +93,7 @@
     "test-travis": "jest --runInBand test/unit/",
     "report-coverage": "codecov",
     "build": "tsc",
-    "prepare": "npm run build"
+    "postversion": "tsc-publish --no-checks --dry-run"
   },
   "jest": {
     "collectCoverage": true,

--- a/test/unit/authenticator.test.js
+++ b/test/unit/authenticator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Authenticator } = require('../../auth');
+const { Authenticator } = require('../../dist/auth');
 
 describe('Authenticator', () => {
   it('should throw if "new" keyword is not used to create an instance', () => {

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -3,11 +3,11 @@
 const util = require('util');
 
 // create a mock for the read-external-sources module
-const readExternalSourcesModule = require('../../auth/utils/read-external-sources');
+const readExternalSourcesModule = require('../../dist/auth/utils/read-external-sources');
 const readExternalSourcesMock = (readExternalSourcesModule.readExternalSources = jest.fn());
 
 // mock the request wrapper
-const requestWrapperLocation = '../../lib/request-wrapper';
+const requestWrapperLocation = '../../dist/lib/request-wrapper';
 jest.mock(requestWrapperLocation);
 const { RequestWrapper } = require(requestWrapperLocation);
 const sendRequestMock = jest.fn();
@@ -19,7 +19,7 @@ RequestWrapper.mockImplementation(() => {
 });
 
 // mock the authenticator
-const noAuthLocation = '../../auth/authenticators/no-auth-authenticator';
+const noAuthLocation = '../../dist/auth/authenticators/no-auth-authenticator';
 jest.mock(noAuthLocation);
 const { NoAuthAuthenticator } = require(noAuthLocation);
 const authenticateMock = jest.fn();
@@ -31,7 +31,7 @@ NoAuthAuthenticator.mockImplementation(() => {
 });
 
 // mocks need to happen before this is imported
-const { BaseService } = require('../../lib/base-service');
+const { BaseService } = require('../../dist/lib/base-service');
 
 // constants
 const DEFAULT_URL = 'https://gateway.watsonplatform.net/test/api';

--- a/test/unit/basic-authenticator.test.js
+++ b/test/unit/basic-authenticator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { BasicAuthenticator } = require('../../auth');
+const { BasicAuthenticator } = require('../../dist/auth');
 
 const USERNAME = 'dave';
 const PASSWORD = 'grohl';

--- a/test/unit/bearer-token-authenticator.test.js
+++ b/test/unit/bearer-token-authenticator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { BearerTokenAuthenticator } = require('../../auth');
+const { BearerTokenAuthenticator } = require('../../dist/auth');
 
 describe('Bearer Token Authenticator', () => {
   const config = {

--- a/test/unit/build-request-file-object.test.js
+++ b/test/unit/build-request-file-object.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const { buildRequestFileObject } = require('../../lib/helper');
+const { buildRequestFileObject } = require('../../dist/lib/helper');
 const filepath = __dirname + '/../resources/other-file.env';
 const audioFile = __dirname + '/../resources/blank.wav';
 

--- a/test/unit/content-type.test.js
+++ b/test/unit/content-type.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const contentType = require('../../lib/content-type').default;
+const contentType = require('../../dist/lib/content-type').default;
 const fs = require('fs');
 const path = require('path');
 

--- a/test/unit/cp4d-authenticator.test.js
+++ b/test/unit/cp4d-authenticator.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { CloudPakForDataAuthenticator } = require('../../auth');
-const { Cp4dTokenManager } = require('../../auth');
+const { CloudPakForDataAuthenticator } = require('../../dist/auth');
+const { Cp4dTokenManager } = require('../../dist/auth');
 
 const USERNAME = 'danmullen';
 const PASSWORD = 'gogators';

--- a/test/unit/cp4d-token-manager.test.js
+++ b/test/unit/cp4d-token-manager.test.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-alert, no-console */
 'use strict';
 
-const { Cp4dTokenManager } = require('../../auth');
+const { Cp4dTokenManager } = require('../../dist/auth');
 
 // mock sendRequest
-jest.mock('../../lib/request-wrapper');
-const { RequestWrapper } = require('../../lib/request-wrapper');
+jest.mock('../../dist/lib/request-wrapper');
+const { RequestWrapper } = require('../../dist/lib/request-wrapper');
 const mockSendRequest = jest.fn();
 RequestWrapper.mockImplementation(() => {
   return {

--- a/test/unit/get-authenticator-from-environment.test.js
+++ b/test/unit/get-authenticator-from-environment.test.js
@@ -7,10 +7,10 @@ const {
   CloudPakForDataAuthenticator,
   IamAuthenticator,
   NoAuthAuthenticator,
-} = require('../../auth');
+} = require('../../dist/auth');
 
 // create a mock for the read-external-sources module
-const readExternalSourcesModule = require('../../auth/utils/read-external-sources');
+const readExternalSourcesModule = require('../../dist/auth/utils/read-external-sources');
 const readExternalSourcesMock = (readExternalSourcesModule.readExternalSources = jest.fn());
 
 const SERVICE_NAME = 'dummy';

--- a/test/unit/get-content-type.test.js
+++ b/test/unit/get-content-type.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const { getContentType } = require('../../lib/helper');
+const { getContentType } = require('../../dist/lib/helper');
 
 const filepath = __dirname + '/../resources/blank.wav';
 

--- a/test/unit/get-format.test.js
+++ b/test/unit/get-format.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getFormat } = require('../../lib/helper');
+const { getFormat } = require('../../dist/lib/helper');
 
 describe('getFormat', function() {
   test('should return null if params is undefined', function() {

--- a/test/unit/get-missing-params.test.js
+++ b/test/unit/get-missing-params.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getMissingParams } = require('../../lib/helper');
+const { getMissingParams } = require('../../dist/lib/helper');
 
 describe('getMissingParams', function() {
   it('should return null when both params and requires are null', function() {

--- a/test/unit/iam-authenticator.test.js
+++ b/test/unit/iam-authenticator.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { IamAuthenticator } = require('../../auth');
-const { IamTokenManager } = require('../../auth');
+const { IamAuthenticator } = require('../../dist/auth');
+const { IamTokenManager } = require('../../dist/auth');
 
 // mock the `getToken` method in the token manager - dont make any rest calls
 const fakeToken = 'iam-acess-token';

--- a/test/unit/iam-token-manager.test.js
+++ b/test/unit/iam-token-manager.test.js
@@ -1,16 +1,16 @@
 /* eslint-disable no-alert, no-console */
 'use strict';
 
-jest.mock('../../lib/request-wrapper');
-const { RequestWrapper } = require('../../lib/request-wrapper');
-const logger = require('../../lib/logger').default;
+jest.mock('../../dist/lib/request-wrapper');
+const { RequestWrapper } = require('../../dist/lib/request-wrapper');
+const logger = require('../../dist/lib/logger').default;
 
 const jwt = require('jsonwebtoken');
 jwt.decode = jest.fn(() => {
   return { exp: 100, iat: 100 };
 });
 
-const { IamTokenManager } = require('../../auth');
+const { IamTokenManager } = require('../../dist/auth');
 const mockSendRequest = jest.fn();
 
 RequestWrapper.mockImplementation(() => {

--- a/test/unit/is-empty-object.test.js
+++ b/test/unit/is-empty-object.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isEmptyObject } = require('../../lib/helper');
+const { isEmptyObject } = require('../../dist/lib/helper');
 
 describe('isEmptyObject', () => {
   it('should return true for an empty object', () => {

--- a/test/unit/is-html.test.js
+++ b/test/unit/is-html.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isHTML } = require('../../lib/helper');
+const { isHTML } = require('../../dist/lib/helper');
 
 describe('isHTML', function() {
   it('should return false on undefined', function() {

--- a/test/unit/jwt-token-manager.test.js
+++ b/test/unit/jwt-token-manager.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert, no-console */
 'use strict';
 
-const { JwtTokenManager } = require('../../auth');
+const { JwtTokenManager } = require('../../dist/auth');
 const jwt = require('jsonwebtoken');
 
 function getCurrentTime() {

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -13,12 +13,12 @@ describe('Logger', () => {
   });
 
   it('should return an instance of the logger', () => {
-    const logger = require('../../lib/logger');
+    const logger = require('../../dist/lib/logger');
     expect(logger).toBeTruthy();
   });
 
   it('no logger should be enabled', () => {
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.warn.enabled).toBe(false);
     expect(logger.verbose.enabled).toBe(false);
     expect(logger.info.enabled).toBe(false);
@@ -28,7 +28,7 @@ describe('Logger', () => {
 
   it('should enable all loggers when axios debug flag is set', () => {
     process.env.NODE_DEBUG = 'axios';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.debug.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -38,7 +38,7 @@ describe('Logger', () => {
 
   it('should enable all loggers', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core*';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.debug.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -48,7 +48,7 @@ describe('Logger', () => {
 
   it('should enable debug miniumum scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:debug';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.debug.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -58,7 +58,7 @@ describe('Logger', () => {
 
   it('should prioritize debug scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:debug,ibm-cloud-sdk-core:verbose';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.debug.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -68,7 +68,7 @@ describe('Logger', () => {
 
   it('should prioritize verbose scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:error,ibm-cloud-sdk-core:verbose';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.debug.enabled).toBe(false);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -78,7 +78,7 @@ describe('Logger', () => {
 
   it('should enable error miniumum scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:error';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.error.enabled).toBe(true);
     expect(logger.debug.enabled).toBe(false);
     expect(logger.info.enabled).toBe(false);
@@ -88,7 +88,7 @@ describe('Logger', () => {
 
   it('should enable info miniumum scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:info';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.info.enabled).toBe(true);
     expect(logger.warn.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
@@ -98,7 +98,7 @@ describe('Logger', () => {
 
   it('should enable verbose miniumum scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:verbose';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.verbose.enabled).toBe(true);
     expect(logger.debug.enabled).toBe(false);
     expect(logger.info.enabled).toBe(true);
@@ -108,7 +108,7 @@ describe('Logger', () => {
 
   it('should enable warn miniumum scope', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:warning';
-    const logger = require('../../lib/logger').default;
+    const logger = require('../../dist/lib/logger').default;
     expect(logger.warn.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.verbose.enabled).toBe(false);

--- a/test/unit/no-auth-authenticator.test.js
+++ b/test/unit/no-auth-authenticator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { NoAuthAuthenticator } = require('../../auth');
+const { NoAuthAuthenticator } = require('../../dist/auth');
 
 describe('NoAuth Authenticator', () => {
   it('should resolve Promise on authenticate', async done => {

--- a/test/unit/read-credentials-file.test.js
+++ b/test/unit/read-credentials-file.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const { constructFilepath, fileExistsAtPath, readCredentialsFile } = require('../../auth');
+const { constructFilepath, fileExistsAtPath, readCredentialsFile } = require('../../dist/auth');
 
 describe('browser scenario', () => {
   const existSync = fs.existsSync;

--- a/test/unit/read-external-sources.test.js
+++ b/test/unit/read-external-sources.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { readExternalSources } = require('../../auth');
+const { readExternalSources } = require('../../dist/auth');
 
 // constants
 const SERVICE_NAME = 'test_service';

--- a/test/unit/request-token-based-authenticator.test.js
+++ b/test/unit/request-token-based-authenticator.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { TokenRequestBasedAuthenticator } = require('../../auth');
-const { JwtTokenManager } = require('../../auth');
+const { TokenRequestBasedAuthenticator } = require('../../dist/auth');
+const { JwtTokenManager } = require('../../dist/auth');
 
 describe('Request Based Token Authenticator', () => {
   const config = {

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -14,7 +14,7 @@ mockAxiosInstance.interceptors = {
 };
 axios.default.create.mockReturnValue(mockAxiosInstance);
 
-const { RequestWrapper } = require('../../lib/request-wrapper');
+const { RequestWrapper } = require('../../dist/lib/request-wrapper');
 const requestWrapperInstance = new RequestWrapper();
 
 describe('axios', () => {

--- a/test/unit/strip-trailing-slash.test.js
+++ b/test/unit/strip-trailing-slash.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { stripTrailingSlash } = require('../../lib/helper');
+const { stripTrailingSlash } = require('../../dist/lib/helper');
 
 describe('stripTrailingSlash', function() {
   test('should strip one slash from the end of url with a single trailing slash', function() {

--- a/test/unit/to-lower-keys.test.js
+++ b/test/unit/to-lower-keys.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { toLowerKeys } = require('../../lib/helper');
+const { toLowerKeys } = require('../../dist/lib/helper');
 
 describe('toLowerKeys', () => {
   it('should convert all keys of object to lower case', () => {

--- a/test/unit/to-promise.test.js
+++ b/test/unit/to-promise.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const toPromise = require('../../lib/stream-to-promise').streamToPromise;
+const toPromise = require('../../dist/lib/stream-to-promise').streamToPromise;
 
 describe('toPromise()', () => {
   it('should resolve with results buffer as a string', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */


### PR DESCRIPTION
Similar to https://github.com/watson-developer-cloud/node-sdk/pull/990, this updates the build process for the repo to build the files to a `dist/` directory instead of inline next to the source files. I add [tsc-publish](https://npmjs.com/package/tsc-publish) (which I maintain) to then help handle getting the right files (based off the `.npmignore` file) into the `dist/` folder when you go to publish (through semantic-release). 

To validate behavior and close the loop, I then did the following:
```
$ node_modules/.bin/semantic-release --no-ci
[1:28:38 PM] [semantic-release] › ℹ  Running semantic-release version 15.13.24
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/changelog"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/git"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/git"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[1:28:39 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[1:28:39 PM] [semantic-release] › ✔  Run automated release from branch master
[1:28:41 PM] [semantic-release] › ✔  Allowed to push to the Git repository
[1:28:41 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/changelog"
[1:28:41 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/changelog"
[1:28:41 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
[1:28:41 PM] [semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://registry.npmjs.org/
[1:28:42 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
[1:28:42 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/git"
[1:28:42 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/git"
[1:28:43 PM] [semantic-release] › ℹ  Found git tag v1.3.0 associated with version 1.3.0
[1:28:43 PM] [semantic-release] › ℹ  Found 4 commits since last release
[1:28:43 PM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: update name
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: build: configure package to build and publish from dist directory
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: docs: Enhance node core comments

Refactor Basic Authenticator.
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: build: update npmignore to include some missed files (#67)
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[1:28:43 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 4 commits complete: minor release
[1:28:43 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[1:28:43 PM] [semantic-release] › ℹ  The next release version is 1.4.0
[1:28:43 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[1:28:43 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[1:28:43 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/changelog"
[1:28:43 PM] [semantic-release] [@semantic-release/changelog] › ℹ  Update /Users/mpeveler/work/github/node-sdk-core/CHANGELOG.md
[1:28:43 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/changelog"
[1:28:43 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/npm"
[1:28:43 PM] [semantic-release] [@semantic-release/npm] › ℹ  Write version 1.4.0 to package.json in /Users/mpeveler/work/github/node-sdk-core
v1.4.0

> masterodin-cloud-sdk-core@1.4.0 postversion /Users/mpeveler/work/github/node-sdk-core
> tsc-publish --no-checks --dry-run

> Running Command
> ExecCommand
>   npm run build

> masterodin-cloud-sdk-core@1.4.0 build /Users/mpeveler/work/github/node-sdk-core
> tsc

DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/.npmignore
   -> /Users/mpeveler/work/github/node-sdk-core/dist/.npmignore
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/AUTHENTICATION.md
   -> /Users/mpeveler/work/github/node-sdk-core/dist/AUTHENTICATION.md
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/CHANGELOG.md
   -> /Users/mpeveler/work/github/node-sdk-core/dist/CHANGELOG.md
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/LICENSE.md
   -> /Users/mpeveler/work/github/node-sdk-core/dist/LICENSE.md
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/MIGRATION-V1.md
   -> /Users/mpeveler/work/github/node-sdk-core/dist/MIGRATION-V1.md
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/README.md
   -> /Users/mpeveler/work/github/node-sdk-core/dist/README.md
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/test/utils/index.js
   -> /Users/mpeveler/work/github/node-sdk-core/dist/test/utils/index.js
DONE

> Running Command
> CopyCommand
   /Users/mpeveler/work/github/node-sdk-core/test/utils/unit-test-helpers.js
   -> /Users/mpeveler/work/github/node-sdk-core/dist/test/utils/unit-test-helpers.js
DONE

> Finished All Commands
> Copying and fixing package.json into ./dist
DONE

> Dry-run enabled, not running npm-publish
[1:28:51 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/npm"
[1:28:51 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/git"
[1:28:51 PM] [semantic-release] [@semantic-release/git] › ℹ  Found 3 file(s) to commit
[1:28:55 PM] [semantic-release] [@semantic-release/git] › ℹ  Prepared Git release: v1.4.0
[1:28:55 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/git"
[1:28:55 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[1:28:55 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[1:28:58 PM] [semantic-release] › ✔  Created tag v1.4.0
[1:28:58 PM] [semantic-release] › ℹ  Start step "publish" of plugin "@semantic-release/npm"
[1:28:58 PM] [semantic-release] [@semantic-release/npm] › ℹ  Publishing version 1.4.0 to npm registry
npm notice
npm notice 📦  masterodin-cloud-sdk-core@1.4.0
npm notice === Tarball Contents ===
npm notice 693B   auth/authenticators/authenticator-interface.js
npm notice 1.9kB  auth/authenticators/authenticator.js
npm notice 7.8kB  lib/base-service.js
npm notice 3.5kB  auth/authenticators/basic-authenticator.js
npm notice 3.6kB  auth/authenticators/bearer-token-authenticator.js
npm notice 3.5kB  auth/authenticators/cloud-pak-for-data-authenticator.js
npm notice 2.2kB  lib/content-type.js
npm notice 3.7kB  auth/token-managers/cp4d-token-manager.js
npm notice 3.2kB  auth/utils/get-authenticator-from-environment.js
npm notice 7.0kB  lib/helper.js
npm notice 3.3kB  auth/utils/helpers.js
npm notice 4.4kB  auth/authenticators/iam-authenticator.js
npm notice 6.0kB  auth/token-managers/iam-token-manager.js
npm notice 1.8kB  auth/authenticators/index.js
npm notice 898B   auth/index.js
npm notice 1.7kB  auth/token-managers/index.js
npm notice 1.4kB  auth/utils/index.js
npm notice 1.3kB  index.js
npm notice 1.0kB  test/utils/index.js
npm notice 6.7kB  auth/token-managers/jwt-token-manager.js
npm notice 815B   lib/logger.js
npm notice 2.0kB  auth/authenticators/no-auth-authenticator.js
npm notice 932B   lib/querystring.js
npm notice 201B   auth/utils/read-credentials-file.browser.js
npm notice 2.3kB  auth/utils/read-credentials-file.js
npm notice 3.9kB  auth/utils/read-external-sources.js
npm notice 15.0kB lib/request-wrapper.js
npm notice 949B   lib/stream-to-promise.js
npm notice 5.1kB  auth/authenticators/token-request-based-authenticator.js
npm notice 5.0kB  test/utils/unit-test-helpers.js
npm notice 2.2kB  package.json
npm notice 7.8kB  AUTHENTICATION.md
npm notice 9.0kB  CHANGELOG.md
npm notice 11.4kB LICENSE.md
npm notice 2.6kB  MIGRATION-V1.md
npm notice 3.7kB  README.md
npm notice 1.5kB  auth/authenticators/authenticator-interface.d.ts
npm notice 1.6kB  auth/authenticators/authenticator.d.ts
npm notice 5.3kB  lib/base-service.d.ts
npm notice 2.4kB  auth/authenticators/basic-authenticator.d.ts
npm notice 2.4kB  auth/authenticators/bearer-token-authenticator.d.ts
npm notice 2.6kB  auth/authenticators/cloud-pak-for-data-authenticator.d.ts
npm notice 270B   lib/content-type.d.ts
npm notice 2.4kB  auth/token-managers/cp4d-token-manager.d.ts
npm notice 1.1kB  auth/utils/get-authenticator-from-environment.d.ts
npm notice 3.2kB  lib/helper.d.ts
npm notice 1.7kB  auth/utils/helpers.d.ts
npm notice 3.4kB  auth/authenticators/iam-authenticator.d.ts
npm notice 3.0kB  auth/token-managers/iam-token-manager.d.ts
npm notice 2.3kB  auth/authenticators/index.d.ts
npm notice 709B   auth/index.d.ts
npm notice 1.4kB  auth/token-managers/index.d.ts
npm notice 1.1kB  auth/utils/index.d.ts
npm notice 954B   index.d.ts
npm notice 4.1kB  auth/token-managers/jwt-token-manager.d.ts
npm notice 134B   lib/logger.d.ts
npm notice 1.1kB  auth/authenticators/no-auth-authenticator.d.ts
npm notice 102B   lib/querystring.d.ts
npm notice 51B    auth/utils/read-credentials-file.browser.d.ts
npm notice 348B   auth/utils/read-credentials-file.d.ts
npm notice 1.1kB  auth/utils/read-external-sources.d.ts
npm notice 1.3kB  lib/request-wrapper.d.ts
npm notice 498B   lib/stream-to-promise.d.ts
npm notice 3.9kB  auth/authenticators/token-request-based-authenticator.d.ts
npm notice === Tarball Details ===
npm notice name:          masterodin-cloud-sdk-core
npm notice version:       1.4.0
npm notice package size:  40.7 kB
npm notice unpacked size: 188.3 kB
npm notice shasum:        4237bc9df9ba89e377a5b89dbb70fa2adfea10e0
npm notice integrity:     sha512-8PcidrBfS/Vjn[...]ATKCQGA1YMt8A==
npm notice total files:   64
npm notice
+ masterodin-cloud-sdk-core@1.4.0
[1:29:06 PM] [semantic-release] [@semantic-release/npm] › ℹ  Published masterodin-cloud-sdk-core@1.4.0 on https://registry.npmjs.org/
[1:29:06 PM] [semantic-release] › ✔  Completed step "publish" of plugin "@semantic-release/npm"
[1:29:06 PM] [semantic-release] › ℹ  Start step "publish" of plugin "@semantic-release/github"
[1:29:06 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication
[1:29:08 PM] [semantic-release] [@semantic-release/github] › ℹ  Published GitHub release: https://github.com/MasterOdin/node-sdk-core/releases/tag/v1.4.0
[1:29:08 PM] [semantic-release] › ✔  Completed step "publish" of plugin "@semantic-release/github"
[1:29:08 PM] [semantic-release] › ℹ  Start step "success" of plugin "@semantic-release/github"
[1:29:11 PM] [semantic-release] › ✔  Completed step "success" of plugin "@semantic-release/github"
[1:29:11 PM] [semantic-release] › ✔  Published release 1.4.0
```

to produce the [masterodin-cloud-sdk-core](https://www.npmjs.com/package/masterodin-cloud-sdk-core) package (which I will unpublish in ~70 hours) and then swapped out the `ibm-cloud-sdk-core` package with this one in `node-sdk` and successfully passed a `npm run test` there.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
