### PR TITLE
fix: use constant defined by generated sdks for url

### DIFF
--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -57,7 +57,8 @@ export interface BaseServiceOptions extends UserOptions {
  * them to the service endpoint.
  */
 export class BaseService {
-  static URL: string;
+  static DEFAULT_SERVICE_URL: string;
+  static DEFAULT_SERVICE_NAME: string;
   protected baseOptions: BaseServiceOptions;
   private authenticator: AuthenticatorInterface;
   private requestWrapperInstance;
@@ -108,7 +109,7 @@ export class BaseService {
 
     const serviceClass = this.constructor as typeof BaseService;
     this.baseOptions = extend(
-      { qs: {}, serviceUrl: serviceClass.URL },
+      { qs: {}, serviceUrl: serviceClass.DEFAULT_SERVICE_URL },
       options,
       _options
     );

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -395,5 +395,5 @@ function setupFakeService() {
   util.inherits(TestService, BaseService);
   TestService.prototype.name = DEFAULT_NAME;
   TestService.prototype.version = 'v1';
-  TestService.URL = DEFAULT_URL;
+  TestService.DEFAULT_SERVICE_URL = DEFAULT_URL;
 }


### PR DESCRIPTION
This fixes a bug in which generated SDK code would not actually use the default URL if none was provided.