### PR TITLE
fix: use consistent fields between success and error response objects

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -246,8 +246,12 @@ export class RequestWrapper {
       delete axiosError.config;
       delete axiosError.request;
 
-      error.name = axiosError.statusText;
-      error.code = axiosError.status;
+      error.statusText = axiosError.statusText;
+      error.name = axiosError.statusText; // ** deprecated **
+
+      error.status = axiosError.status;
+      error.code = axiosError.status;  // ** deprecated **
+
       error.message = parseServiceErrorMessage(axiosError.data) || axiosError.statusText;
 
       // some services bury the useful error message within 'data'


### PR DESCRIPTION
The fields `status` and `statusText` are now added to the response error, to be consistent with the fields on a successful response object. The other fields are left intact for compatibility but are marked as deprecated so we know to remove them in the next major release.