### PR TITLE
expose the `saveTokenInfo` to subclasses

### DIFF
--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -192,7 +192,7 @@ export class JwtTokenManager {
    * Save the JWT service response and the calculated expiration time to the object's state.
    *
    * @param tokenResponse - Response object from JWT service request
-   * @private
+   * @protected
    * @returns {void}
    */
   protected saveTokenInfo(tokenResponse): void {

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -105,7 +105,7 @@ export class JwtTokenManager {
       // If refresh needed, kick one off
       if (this.tokenNeedsRefresh()) {
         this.requestToken().then(tokenResponse => {
-          this.saveTokenInfo(tokenResponse.result);
+          this.saveTokenInfo(tokenResponse);
         });
       }
       // 2. use valid, managed token
@@ -161,7 +161,7 @@ export class JwtTokenManager {
     } else {
       this.requestTime = currentTime;
       return this.requestToken().then(tokenResponse => {
-        this.saveTokenInfo(tokenResponse.result);
+        this.saveTokenInfo(tokenResponse);
         this.pendingRequests.forEach(({resolve}) => {
           resolve();
         });
@@ -186,6 +186,47 @@ export class JwtTokenManager {
     const err = new Error(errMsg);
     logger.error(errMsg);
     return Promise.reject(err);
+  }
+
+  /**
+   * Save the JWT service response and the calculated expiration time to the object's state.
+   *
+   * @param tokenResponse - Response object from JWT service request
+   * @private
+   * @returns {void}
+   */
+  protected saveTokenInfo(tokenResponse): void {
+    const responseBody = tokenResponse.result || {};
+    const accessToken = responseBody[this.tokenName];
+
+    if (!accessToken) {
+      const err = 'Access token not present in response';
+      logger.error(err);
+      throw new Error(err);
+    }
+
+    // the time of expiration is found by decoding the JWT access token
+    // exp is the time of expire and iat is the time of token retrieval
+    const decodedResponse = jwt.decode(accessToken);
+    if (!decodedResponse) {
+      const err = 'Access token recieved is not a valid JWT'
+      logger.error(err);
+      throw new Error(err);
+    }
+
+    const { exp, iat } = decodedResponse;
+    // There are no required claims in JWT
+    if (!exp || !iat) {
+      this.expireTime = 0;
+      this.refreshTime = 0;
+    } else {
+      const fractionOfTtl = 0.8;
+      const timeToLive = exp - iat;
+      this.expireTime = exp;
+      this.refreshTime = exp - (timeToLive * (1.0 - fractionOfTtl));
+    }
+
+    this.tokenInfo = extend({}, responseBody);
   }
 
   /**
@@ -224,45 +265,5 @@ export class JwtTokenManager {
     this.refreshTime = currentTime + 60;
 
     return true;
-  }
-
-  /**
-   * Save the JWT service response and the calculated expiration time to the object's state.
-   *
-   * @param tokenResponse - Response object from JWT service request
-   * @private
-   * @returns {void}
-   */
-  private saveTokenInfo(tokenResponse): void {
-    const accessToken = tokenResponse[this.tokenName];
-
-    if (!accessToken) {
-      const err = 'Access token not present in response';
-      logger.error(err);
-      throw new Error(err);
-    }
-
-    // the time of expiration is found by decoding the JWT access token
-    // exp is the time of expire and iat is the time of token retrieval
-    const decodedResponse = jwt.decode(accessToken);
-    if (!decodedResponse) {
-      const err = 'Access token recieved is not a valid JWT'
-      logger.error(err);
-      throw new Error(err);
-    }
-
-    const { exp, iat } = decodedResponse;
-    // There are no required claims in JWT
-    if (!exp || !iat) {
-      this.expireTime = 0;
-      this.refreshTime = 0;
-    } else {
-      const fractionOfTtl = 0.8;
-      const timeToLive = exp - iat;
-      this.expireTime = exp;
-      this.refreshTime = exp - (timeToLive * (1.0 - fractionOfTtl));
-    }
-
-    this.tokenInfo = extend({}, tokenResponse);
   }
 }

--- a/test/unit/jwt-token-manager.test.js
+++ b/test/unit/jwt-token-manager.test.js
@@ -268,11 +268,11 @@ describe('JWT Token Manager', () => {
         .spyOn(jwt, 'decode')
         .mockImplementation(token => ({ iat: 10, exp: 100 }));
 
-      const tokenResponse = { access_token: ACCESS_TOKEN };
+      const tokenResponse = { result: { access_token: ACCESS_TOKEN } };
 
       instance.saveTokenInfo(tokenResponse);
       expect(instance.expireTime).toBe(100);
-      expect(instance.tokenInfo).toEqual(tokenResponse);
+      expect(instance.tokenInfo).toEqual(tokenResponse.result);
       decodeSpy.mockRestore();
     });
 
@@ -291,7 +291,7 @@ describe('JWT Token Manager', () => {
         .spyOn(jwt, 'decode')
         .mockImplementation(token => ({ iat: 100, exp: 200 }));
 
-      const tokenResponse = { access_token: ACCESS_TOKEN };
+      const tokenResponse = { result: { access_token: ACCESS_TOKEN } };
 
       instance.saveTokenInfo(tokenResponse);
       expect(instance.refreshTime).toBe(180);
@@ -309,11 +309,11 @@ describe('JWT Token Manager', () => {
         .spyOn(jwt, 'decode')
         .mockImplementation(token => ({ foo: 0, bar: 100 }));
 
-      const tokenResponse = { access_token: ACCESS_TOKEN };
+      const tokenResponse = { result: { access_token: ACCESS_TOKEN } };
 
       instance.saveTokenInfo(tokenResponse);
       expect(instance.expireTime).toBe(0);
-      expect(instance.tokenInfo).toEqual(tokenResponse);
+      expect(instance.tokenInfo).toEqual(tokenResponse.result);
       decodeSpy.mockRestore();
     });
   });


### PR DESCRIPTION
This changes the exposure level of the `saveTokenInfo` method to be "protected" instead of "private" so that developers implementing a subclass can override that method as needed.

Additionally, this changes `saveTokenInfo` to accept the entire response and extract the body within the method. That way, there can be subclass implementations for authentication mechanisms that include the token somewhere other than the body, like the headers.

Reviewers: let me know if you think this is a breaking change. I decided that it was not because the only "contract" change is happening for `saveTokenInfo` (the argument changed) but that method was previously marked as "private". The `getToken` method was changed but the public contract is not affected by the change. I may be missing something though.