### PR TITLE
fix: flag required params as missing when explicitly undefined

### DIFF
--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -113,8 +113,8 @@ export function getMissingParams(
     missing = requires;
   } else {
     missing = [];
-    requires.forEach((require) => {
-      if (!params[require]) {
+    requires.forEach(require => {
+      if (isMissing(params[require])) {
         missing.push(require);
       }
     });
@@ -122,6 +122,17 @@ export function getMissingParams(
   return missing.length > 0
     ? new Error('Missing required parameters: ' + missing.join(', '))
     : null;
+}
+
+/**
+ * Returns true if value is determined to be "missing". Currently defining "missing"
+ * as `undefined`, `null`, or the empty string.
+ *
+ * @param value - the parameter value
+ * @returns boolean
+ */
+function isMissing(value: any): boolean {
+  return value === undefined || value === null || value === '';
 }
 
 /**

--- a/test/unit/get-missing-params.test.js
+++ b/test/unit/get-missing-params.test.js
@@ -64,4 +64,8 @@ describe('getMissingParams', function() {
       'Missing required parameters: a, b'
     );
   });
+
+  it('should not throw an error if a required parameter is given and set to false', function() {
+    expect(getMissingParams({ a: 'a', b: false }, ['a', 'b'])).toBeNull();
+  });
 });


### PR DESCRIPTION
Currently, we are checking for "truthyness" when evaluating if required parameters have been set or not. This is flawed - when required params are set to `false`, they are incorrectly being flagged as missing.

This PR fixes that bug by explicitly checking for the `undefined` value. Test case added to support the fix.
