### PR TITLE
feat: Strip trailing slashes in sendRequest

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -21,7 +21,7 @@ import FormData = require('form-data');
 import https = require('https');
 import querystring = require('querystring');
 import { PassThrough as readableStream } from 'stream';
-import { buildRequestFileObject, getMissingParams, isEmptyObject, isFileData, isFileWithMetadata } from './helper';
+import { buildRequestFileObject, getMissingParams, isEmptyObject, isFileData, isFileWithMetadata, stripTrailingSlash } from './helper';
 import logger from './logger';
 
 const isBrowser = typeof window === 'object';
@@ -179,6 +179,8 @@ export class RequestWrapper {
     if (url && url.charAt(0) === '/') {
       url = serviceUrl + url;
     }
+
+    url = stripTrailingSlash(url);
 
     let data = body;
 

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -98,6 +98,30 @@ describe('sendRequest', () => {
     done();
   });
 
+  it('sendRequest should strip trailing slashes', async done => {
+    const parameters = {
+      defaultOptions: {
+        body: 'post=body',
+        formData: '',
+        qs: {},
+        method: 'POST',
+        url: 'https://example.ibm.com/',
+        headers: {
+          'test-header': 'test-header-value',
+        },
+        responseType: 'buffer',
+      },
+    };
+
+    mockAxiosInstance.mockResolvedValue(axiosResolveValue);
+
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual('https://example.ibm.com');
+    expect(res).toEqual(expectedResult);
+    done();
+  });
+
   it('should call formatError if request failed', async done => {
     const parameters = {
       defaultOptions: {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->
Trailing slashes weren't being removed in the sendRequest method after the service URL and path url were combined. This resolves that problem.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
