### PR TITLE
chore: bump axios to ^0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/isstream": "^0.1.0",
     "@types/jest": "^24.0.23",
     "@types/node": "~10.14.19",
-    "axios": "^0.18.0",
+    "axios": "^0.18.1",
     "axios-cookiejar-support": "^0.5.1",
     "camelcase": "^5.3.1",
     "debug": "^4.1.1",


### PR DESCRIPTION
Updates axios to ^0.18.1 in the package.json as 0.18.0 had a [CVE](https://app.snyk.io/vuln/SNYK-JS-AXIOS-174505) where it would not destroy a stream before throwing an error about it exceeding the max size, which could cause a potential DoS.

There was no other change in 0.18.1 other than fixing this bug.

Related to #93, and while a new version of this (and bumping the version cloud foundry) uses would probably fix it, sounds like rebuilds are using a package-lock.json that pins to an older version of axios.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
