### PR TITLE
chore: Remove 'extend' dependency

### DIFF
--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
@@ -72,7 +71,7 @@ export class BasicAuthenticator extends Authenticator {
    */
   public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>  {
     return new Promise((resolve) => {
-      requestOptions.headers = extend(true, {}, requestOptions.headers, this.authHeader);
+      requestOptions.headers = Object.assign({}, requestOptions.headers, this.authHeader);
       resolve();
     });
   }

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import { validateInput } from '../utils';
 import { Authenticator } from './authenticator';
 import { AuthenticateOptions } from './authenticator-interface';
@@ -77,7 +76,7 @@ export class BearerTokenAuthenticator extends Authenticator {
   public authenticate(requestOptions: AuthenticateOptions): Promise<void> {
     return new Promise((resolve) => {
       const authHeader = { Authorization: `Bearer ${this.bearerToken}` };
-      requestOptions.headers = extend(true, {}, requestOptions.headers, authHeader);
+      requestOptions.headers = Object.assign({}, requestOptions.headers, authHeader);
       resolve();
     });
   }

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import { JwtTokenManager } from '../token-managers';
 import { Authenticator } from './authenticator';
@@ -119,7 +118,7 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
   public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
     return this.tokenManager.getToken().then(token => {
       const authHeader = { Authorization: `Bearer ${token}` };
-      requestOptions.headers = extend(true, {}, requestOptions.headers, authHeader);
+      requestOptions.headers = Object.assign({}, requestOptions.headers, authHeader);
       return;
     });
   }

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import { computeBasicAuthHeader, validateInput } from '../utils';
 import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 
@@ -96,7 +95,7 @@ export class Cp4dTokenManager extends JwtTokenManager {
       options: {
         url: this.url,
         method: 'GET',
-        headers: extend(true, {}, this.headers, requiredHeaders),
+        headers: Object.assign({}, this.headers, requiredHeaders),
         rejectUnauthorized: !this.disableSslVerification,
       }
     };

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import logger from '../../lib/logger';
 import { computeBasicAuthHeader, validateInput } from '../utils';
@@ -133,7 +132,7 @@ export class IamTokenManager extends JwtTokenManager {
       options: {
         url: this.url,
         method: 'POST',
-        headers: extend(true, {}, this.headers, requiredHeaders),
+        headers: Object.assign({}, this.headers, requiredHeaders),
         form: {
           grant_type: 'urn:ibm:params:oauth:grant-type:apikey',
           apikey: this.apikey,

--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import jwt = require('jsonwebtoken');
 import logger from '../../lib/logger';
 import { TokenManager, TokenManagerOptions } from "./token-manager";
@@ -102,7 +101,7 @@ export class JwtTokenManager extends TokenManager {
       this.refreshTime = exp - (timeToLive * (1.0 - fractionOfTtl));
     }
 
-    this.tokenInfo = extend({}, responseBody);
+    this.tokenInfo = Object.assign({}, responseBody);
   }
 
 }

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -15,7 +15,6 @@
  */
 
 import camelcase = require('camelcase');
-import extend = require('extend');
 
 import {
   Authenticator,

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -15,7 +15,6 @@
  */
 
 
-import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import { AuthenticatorInterface, checkCredentials, readExternalSources } from '../auth';
 import { stripTrailingSlash } from './helper';
@@ -85,7 +84,7 @@ export class BaseService {
     }
 
     const _options = {} as BaseServiceOptions;
-    const options = extend({}, userOptions);
+    const options = Object.assign({}, userOptions);
 
     // for compatibility
     if (options.url && !options.serviceUrl) {
@@ -110,7 +109,7 @@ export class BaseService {
     }
 
     const serviceClass = this.constructor as typeof BaseService;
-    this.baseOptions = extend(
+    this.baseOptions = Object.assign(
       { qs: {}, serviceUrl: serviceClass.DEFAULT_SERVICE_URL },
       options,
       _options
@@ -159,7 +158,7 @@ export class BaseService {
       throw new Error(err);
     }
 
-    extend(
+    Object.assign(
       this.baseOptions,
       this.readOptionsFromExternalConfig(serviceName)
     );

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import extend = require('extend');
 import fileType = require('file-type');
 import { isReadable } from 'isstream';
 import { lookup } from 'mime-types';
@@ -232,7 +231,7 @@ export function buildRequestFileObject(
 export function toLowerKeys(obj: Object): Object {
   let _obj = {};
   if (obj) {
-    _obj = extend(
+    _obj = Object.assign(
       {},
       ...Object.keys(obj).map(key => ({
         [key.toLowerCase()]: obj[key]

--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -16,7 +16,6 @@
 
 import axios from 'axios';
 import axiosCookieJarSupport from 'axios-cookiejar-support';
-import extend = require('extend');
 import FormData = require('form-data');
 import https = require('https');
 import querystring = require('querystring');
@@ -61,7 +60,7 @@ export class RequestWrapper {
     };
 
     // merge valid Axios Config into default.
-    extend(true, axiosConfig, allowedAxiosConfig.reduce((reducedConfig, key) => {
+    Object.assign(axiosConfig, allowedAxiosConfig.reduce((reducedConfig, key) => {
       reducedConfig[key]=axiosOptions[key];
       return reducedConfig;
     }, {}));
@@ -131,7 +130,7 @@ export class RequestWrapper {
    * @throws {Error}
    */
   public sendRequest(parameters): Promise<any> {
-    const options = extend(true, {}, parameters.defaultOptions, parameters.options);
+    const options = Object.assign({}, parameters.defaultOptions, parameters.options);
     const { path, body, form, formData, qs, method, serviceUrl } = options;
     let { headers, url } = options;
 
@@ -166,7 +165,7 @@ export class RequestWrapper {
     url = parsePath(url, path);
 
     // Headers
-    options.headers = extend({}, options.headers);
+    options.headers = Object.assign({}, options.headers);
 
     // Convert array-valued query params to strings
     if (qs && Object.keys(qs).length > 0) {
@@ -192,7 +191,7 @@ export class RequestWrapper {
     if (formData) {
       data = multipartForm;
       // form-data generates headers that MUST be included or the request will fail
-      headers = extend(true, {}, headers, multipartForm.getHeaders());
+      headers = Object.assign({}, headers, multipartForm.getHeaders());
     }
 
     // TEMPORARY: Disabling gzipping due to bug in axios until fix is released:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,11 +1936,6 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
-    "@types/extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
-    },
     "@types/file-type": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.2.tgz",
@@ -4109,7 +4104,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
-    "@types/extend": "~3.0.0",
     "@types/file-type": "~5.2.1",
     "@types/isstream": "^0.1.0",
     "@types/node": "~10.14.19",
@@ -62,7 +61,6 @@
     "debug": "^4.1.1",
     "dotenv": "^6.2.0",
     "expect": "^26.1.0",
-    "extend": "~3.0.2",
     "file-type": "^7.7.1",
     "form-data": "^2.3.3",
     "isstream": "~0.1.2",


### PR DESCRIPTION
This commit replaces all instances of 'extend' with Object.assign and removes 'extend' as a package dependency.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
