### PR TITLE
fix: pin typescript dependency to 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14523,9 +14523,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tslint-config-prettier": "~1.13.0",
     "tslint-eslint-rules": "^5.4.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.8.3"
   },
   "dependencies": {
     "@types/file-type": "~5.2.1",


### PR DESCRIPTION
v3.9 of `typescript` includes changes that break our code. The top-level exports in `index.js` are generated without "setters", so individual components of this core module cannot be mocked in tests.

This does not impact normal operation of the code (that I'm aware of - there's reason to redefine any components when using them) but it causes issues in the generated unit tests for SDKs that rely on this package. These tests mock out individual components to isolate behavior. By pinning the dependency to 3.8.3, we can continue to mock these components.

FYI @apaparazzi0329 