### PR TITLE
feat: upgrade axios and re-enable gzipping responses

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -202,11 +202,8 @@ export class RequestWrapper {
       headers = extend(true, {}, headers, multipartForm.getHeaders());
     }
 
-    // TEMPORARY: Disabling gzipping due to bug in axios until fix is released:
-    // https://github.com/axios/axios/pull/1129
-
     // accept gzip encoded responses if Accept-Encoding is not already set
-    // headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'gzip';
+    headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'gzip';
 
     const requestParams = {
       url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2409,12 +2409,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "^1.10.0"
       }
     },
     "axios-cookiejar-support": {
@@ -4459,22 +4458,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -5113,11 +5099,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.2.0",
@@ -8517,7 +8498,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/isstream": "^0.1.0",
     "@types/node": "~10.14.19",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "^0.18.1",
+    "axios": "^0.20.0",
     "axios-cookiejar-support": "^1.0.0",
     "camelcase": "^5.3.1",
     "debug": "^4.1.1",

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -152,7 +152,7 @@ describe('sendRequest', () => {
       'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
     );
     expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-      // 'Accept-Encoding': 'gzip',
+      'Accept-Encoding': 'gzip',
       'test-header': 'test-header-value',
     });
     expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
@@ -267,7 +267,7 @@ describe('sendRequest', () => {
       'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
     );
     expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-      // 'Accept-Encoding': 'gzip',
+      'Accept-Encoding': 'gzip',
       'test-header': 'override-header-value',
       'add-header': 'add-header-value',
     });
@@ -319,7 +319,7 @@ describe('sendRequest', () => {
       'https://example.ibm.com/v1/environments'
     );
     expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
-      // 'Accept-Encoding': 'gzip',
+      'Accept-Encoding': 'gzip',
       'test-header': 'test-header-value',
       'add-header': 'add-header-value',
     });
@@ -387,7 +387,7 @@ describe('sendRequest', () => {
       'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
     );
     expect(mockAxiosInstance.mock.calls[0][0].headers).toMatchObject({
-      // 'Accept-Encoding': 'gzip',
+      'Accept-Encoding': 'gzip',
       'test-header': 'override-header-value',
       'add-header': 'add-header-value',
     });


### PR DESCRIPTION
I spent some time today reading through the `axios` docs and issue and I _think_ it should be fine to upgrade to the latest version (0.20.0). It seems to be much more actively maintained than it has been the past year or so, which makes me more comfortable about upgrading. There seem to have been [a couple of unintentional breaking changes](https://github.com/axios/axios/issues/3294#issuecomment-696601393) in this version but neither of them affect us because of how we're using the library in our code.

In addition to this version bump, I added the `gzip` encoding on responses back in, which was waiting on a fix within `axios`.