### PR TITLE
feat: add support for compressing request bodies

### DIFF
--- a/auth/utils/read-external-sources.ts
+++ b/auth/utils/read-external-sources.ts
@@ -81,13 +81,17 @@ function filterPropertiesByServiceName(envObj: any, serviceName: string): any {
     }
   });
 
-  // all env variables are parsed as strings, convert disable ssl vars to boolean
+  // all env variables are parsed as strings, convert boolean vars as needed
   if (typeof credentials.disableSsl === 'string') {
     credentials.disableSsl = credentials.disableSsl === 'true';
   }
 
   if (typeof credentials.authDisableSsl === 'string') {
     credentials.authDisableSsl = credentials.authDisableSsl === 'true';
+  }
+
+  if (typeof credentials.enableGzip === 'string') {
+    credentials.enableGzip = credentials.enableGzip === 'true';
   }
 
   return credentials;

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -146,6 +146,15 @@ export class BaseService {
   }
 
   /**
+   * Turn request body compression on or off.
+   *
+   * @param {boolean} setting Will turn it on if 'true', off if 'false'. 
+   */
+  public setEnableGzipCompression(setting: boolean): void {
+    this.requestWrapperInstance.compressRequestData = setting;
+  }
+
+  /**
    * Configure the service using external configuration
    *
    * @param {string} serviceName The name of the service. Will be used to read from external
@@ -205,14 +214,21 @@ export class BaseService {
     const properties = readExternalSources(serviceName);
 
     if (properties !== null) {
-      // the user can define two client-level variables in the credentials file: url and disableSsl
-      const { url, disableSsl } = properties;
+      // the user can define the following client-level variables in the credentials file:
+      // - url
+      // - disableSsl
+      // - enableGzip
+
+      const { url, disableSsl, enableGzip } = properties;
 
       if (url) {
         results.serviceUrl = stripTrailingSlash(url);
       }
       if (disableSsl === true) {
         results.disableSslVerification = disableSsl;
+      }
+      if (enableGzip === true) {
+        results.enableGzipCompression = enableGzip;
       }
     }
 

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -103,6 +103,22 @@ describe('Base Service', () => {
     expect(testService.baseOptions.serviceUrl).toBe(newUrl);
   });
 
+  it('should support enabling gzip compression after instantiation', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+    });
+
+    expect(testService.baseOptions.enableGzipCompression).toBeFalsy();
+
+    const on = true;
+    testService.setEnableGzipCompression(on);
+    expect(testService.requestWrapperInstance.compressRequestData).toBe(on);
+
+    const off = false;
+    testService.setEnableGzipCompression(off);
+    expect(testService.requestWrapperInstance.compressRequestData).toBe(off);
+  });
+
   it('should throw an error if an authenticator is not passed in', () => {
     expect(() => new TestService()).toThrow();
   });
@@ -374,6 +390,7 @@ describe('Base Service', () => {
     readExternalSourcesMock.mockImplementation(() => ({
       url: 'abc123.com',
       disableSsl: true,
+      enableGzip: true,
     }));
 
     testService.configureService(DEFAULT_NAME);
@@ -381,6 +398,7 @@ describe('Base Service', () => {
     expect(readExternalSourcesMock).toHaveBeenCalled();
     expect(testService.baseOptions.serviceUrl).toEqual('abc123.com');
     expect(testService.baseOptions.disableSslVerification).toEqual(true);
+    expect(testService.baseOptions.enableGzipCompression).toEqual(true);
   });
 
   it('configureService method should throw error if service name is not provided', () => {

--- a/test/unit/read-external-sources.test.js
+++ b/test/unit/read-external-sources.test.js
@@ -132,12 +132,14 @@ describe('Read External Sources Module', () => {
     expect(properties.scope).toBe(SCOPE);
   });
 
-  it('should convert disableSsl values from string to boolean', () => {
+  it('should convert certain values from string to boolean', () => {
     process.env.TEST_SERVICE_DISABLE_SSL = 'true';
     process.env.TEST_SERVICE_AUTH_DISABLE_SSL = 'true';
+    process.env.TEST_SERVICE_ENABLE_GZIP = 'true';
     const properties = readExternalSources(SERVICE_NAME);
     expect(typeof properties.disableSsl).toBe('boolean');
     expect(typeof properties.authDisableSsl).toBe('boolean');
+    expect(typeof properties.enableGzip).toBe('boolean');
   });
 });
 

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -1,6 +1,9 @@
 'use strict';
 const fs = require('fs');
 const https = require('https');
+const { Readable } = require('stream');
+const zlib = require('zlib');
+const logger = require('../../dist/lib/logger').default;
 process.env.NODE_DEBUG = 'axios';
 jest.mock('axios');
 const axios = require('axios');
@@ -48,6 +51,9 @@ describe('RequestWrapper constructor', () => {
   it('should handle scenario that no arguments are provided', () => {
     const rw = new RequestWrapper();
     expect(rw).toBeInstanceOf(RequestWrapper);
+
+    // without any arguments, the constructor should set its member variables accordingly
+    expect(rw.compressRequestData).toBe(false);
   });
 
   it('should set defaults for certain axios configurations', () => {
@@ -97,6 +103,11 @@ describe('RequestWrapper constructor', () => {
     expect(createdAxiosConfig.httpsAgent.keepAlive).toBe(true); // this is false by default
     expect(createdAxiosConfig.httpsAgent.options).toBeDefined();
     expect(createdAxiosConfig.httpsAgent.options.rejectUnauthorized).toBe(false);
+  });
+
+  it('should set `compressRequestData` based on user options', () => {
+    const rw = new RequestWrapper({ enableGzipCompression: true });
+    expect(rw.compressRequestData).toBe(true);
   });
 });
 
@@ -481,6 +492,33 @@ describe('sendRequest', () => {
     done();
   });
 
+  it('should call `gzipRequestBody` if configured to do so', async () => {
+    const parameters = {
+      defaultOptions: {
+        body: 'post=body',
+        formData: '',
+        qs: {},
+        method: 'POST',
+        url: '/trailing/slash/',
+        serviceUrl: 'https://example.ibm.com/',
+        headers: {
+          'test-header': 'test-header-value',
+        },
+        responseType: 'buffer',
+      },
+    };
+
+    requestWrapperInstance.compressRequestData = true;
+
+    mockAxiosInstance.mockResolvedValue(axiosResolveValue);
+    const gzipSpy = jest.spyOn(requestWrapperInstance, 'gzipRequestBody');
+    await requestWrapperInstance.sendRequest(parameters);
+    expect(gzipSpy).toHaveBeenCalled();
+
+    // reset the alteration of the requestWrapperInstance
+    requestWrapperInstance.compressRequestData = false;
+  });
+
   // Need to rewrite this to test instantiation with userOptions
 
   //   it('should keep parameters in options that are not explicitly set in requestwrapper', async done => {
@@ -678,5 +716,154 @@ describe('formatError', () => {
     const error = requestWrapperInstance.formatError(basicAxiosError);
     expect(error instanceof Error).toBe(true);
     expect(error.message).toBe('error in building the request');
+  });
+});
+
+describe('gzipRequestBody', () => {
+  const gzipSpy = jest.spyOn(zlib, 'gzipSync');
+  const errorLogSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  const debugLogSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+
+  afterEach(() => {
+    gzipSpy.mockClear();
+    errorLogSpy.mockClear();
+    debugLogSpy.mockClear();
+  });
+
+  it('should return unaltered data if encoding header is already set to gzip', async () => {
+    let data = 42;
+    const headers = { 'Content-Encoding': 'gzip' };
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBe(42);
+  });
+
+  it('should return unaltered data if encoding header values include gzip', async () => {
+    let data = 42;
+    const headers = { 'Content-Encoding': ['gzip', 'other-value'] };
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBe(42);
+  });
+
+  it('should return unaltered data if data is null', async () => {
+    let data = null;
+    const headers = {};
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(gzipSpy).not.toHaveBeenCalled();
+    expect(data).toBe(null);
+  });
+
+  it('should compress json data into a buffer', async () => {
+    let data = { key: 'value' };
+    const headers = {};
+
+    const jsonSpy = jest.spyOn(JSON, 'stringify');
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(jsonSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+
+    jsonSpy.mockRestore();
+  });
+
+  it('should compress array data into a buffer', async () => {
+    let data = ['request', 'body'];
+    const headers = {};
+
+    const jsonSpy = jest.spyOn(JSON, 'stringify');
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(jsonSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+
+    jsonSpy.mockRestore();
+  });
+
+  it('should compress string data into a buffer', async () => {
+    let data = 'body';
+    const headers = {};
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+  });
+
+  it('should compress number data into a buffer', async () => {
+    let data = 42;
+    const headers = {};
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+  });
+
+  it('should compress stream data into a buffer', async () => {
+    let data = Readable.from(['request body']);
+    const headers = {};
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+  });
+
+  it('should log an error and return data unaltered if data cant be stringified', async () => {
+    let data = { key: 'value' };
+    data.circle = data;
+    const headers = {};
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data.key).toBe('value');
+    expect(errorLogSpy).toHaveBeenCalled();
+    expect(errorLogSpy.mock.calls[0][0]).toBe(
+      'Error converting request body to a buffer - data will not be compressed.'
+    );
+    expect(debugLogSpy).toHaveBeenCalled();
+    expect(debugLogSpy.mock.calls[0][0].message).toMatch('Converting circular structure to JSON');
+  });
+
+  it('should log an error and return data unaltered if data cant be gzipped', async () => {
+    let data = 42;
+    const headers = {};
+
+    gzipSpy.mockImplementationOnce(() => {
+      throw new Error('bad zip');
+    });
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBe(42);
+    expect(errorLogSpy).toHaveBeenCalled();
+    expect(errorLogSpy.mock.calls[0][0]).toBe(
+      'Error compressing request body - data will not be compressed.'
+    );
+    expect(debugLogSpy).toHaveBeenCalled();
+    expect(debugLogSpy.mock.calls[0][0].message).toMatch('bad zip');
+  });
+
+  it('should not update header if data cant be gzipped', async () => {
+    let data = 42;
+    const headers = {};
+
+    gzipSpy.mockImplementationOnce(() => {
+      throw new Error('bad zip');
+    });
+
+    data = await requestWrapperInstance.gzipRequestBody(data, headers);
+    expect(data).toBe(42);
+    expect(headers['Content-Encoding']).toBeUndefined();
+    expect(errorLogSpy).toHaveBeenCalled();
+    expect(errorLogSpy.mock.calls[0][0]).toBe(
+      'Error compressing request body - data will not be compressed.'
+    );
+    expect(debugLogSpy).toHaveBeenCalled();
+    expect(debugLogSpy.mock.calls[0][0].message).toMatch('bad zip');
   });
 });


### PR DESCRIPTION
A flag can now be passed to the BaseService that will enable gzip compression on the request body data. This flag is passed down to the RequestWrapper class where the compression code lives. Note that no code needs to be changed in the BaseService - the options passed into its constructor will be carried through to the RequestWrapper. In the generated code, I am planning on attaching the flag to the options passed into the BaseService constructor.

If there is a problem during compression, the code moves alone with the request, just uncompressed. If this is not the behavior we want, I can change it.
