### PR TITLE
chore: appscan configuration file

### DIFF
--- a/appscan-config.xml
+++ b/appscan-config.xml
@@ -1,0 +1,7 @@
+<Configuration>
+  <Targets>
+    <Target path=".">
+      <Exclude>scripts/</Exclude>
+    </Target>
+  </Targets>
+</Configuration>


### PR DESCRIPTION
The changes in the `appscan-config` file will exclude the `/scripts` directory in our security scanning tool.
