### PR TITLE
fix: canonicalize iam url

### DIFF
--- a/test/unit/iam-token-manager.test.js
+++ b/test/unit/iam-token-manager.test.js
@@ -368,4 +368,48 @@ describe('iam_token_manager_v1', function() {
     expect(instance.refreshToken).toBe(REFRESH_TOKEN);
     expect(instance.getRefreshToken()).toBe(REFRESH_TOKEN);
   });
+
+  it('should use the default url if none is given', () => {
+    const instance = new IamTokenManager({
+      apikey: 'abcd-1234',
+    });
+
+    expect(instance.url).toBe('https://iam.cloud.ibm.com');
+  });
+
+  it('should accept a URL from the user if given', () => {
+    const url = 'some-url.com';
+    const instance = new IamTokenManager({
+      apikey: 'abcd-1234',
+      url,
+    });
+
+    expect(instance.url).toBe(url);
+  });
+
+  it('should remove the operation path from a user-given URL', () => {
+    const url = 'some-url.com';
+    const instance = new IamTokenManager({
+      apikey: 'abcd-1234',
+      url: url + '/identity/token',
+    });
+
+    expect(instance.url).toBe(url);
+  });
+
+  it('should add the operation path to the stored URL at request time', async () => {
+    const url = 'some-url.com';
+    const instance = new IamTokenManager({
+      apikey: 'abcd-1234',
+      url,
+    });
+
+    expect(instance.url).toBe(url);
+
+    mockSendRequest.mockImplementation(parameters => Promise.resolve(IAM_RESPONSE));
+    await instance.getToken();
+
+    const sendRequestArgs = mockSendRequest.mock.calls[0][0];
+    expect(sendRequestArgs.options.url).toBe(url + '/identity/token');
+  });
 });


### PR DESCRIPTION
This change forces canonical use of an IAM URL. The standard operation path for a token
request is now unconditionally added at request time. If a user provides a URL that
includes the path, it will be removed.

As it turns out, there were no tests around URL behavior so I added tests that capture
it, including the behavior added in this change.
