### PR TITLE
feat: support username/apikey use-case in CloudPakForDataAuthenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ coverage
 .idea
 doc/
 .vscode/
-.env
+*.env
 .eslintcache
 lib/*.js
 auth/**/*.js

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-04T19:20:35Z",
+  "generated_at": "2021-03-12T14:27:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -107,7 +107,15 @@
         "hashed_secret": "d5ff02fa48e492fac0a245ad63d1ae608e705c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 69,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -151,7 +159,31 @@
         "hashed_secret": "d5ff02fa48e492fac0a245ad63d1ae608e705c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 86,
+        "line_number": 94,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "45a15668db917c293f16e8add0f5d801889e5923",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 109,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "65e622227634e8876cfa733000233fb80c6f0473",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -161,7 +193,7 @@
         "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 84,
+        "line_number": 101,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -169,7 +201,7 @@
         "hashed_secret": "f84f793e0af9ade37c8b927bc5091e98f35bf821",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -177,7 +209,7 @@
         "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -185,7 +217,7 @@
         "hashed_secret": "99833a8b234b57b886a9aef1dba187fdd7ceece8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 128,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -193,7 +225,7 @@
         "hashed_secret": "c563e15142a4d1ab66222756647ec74606793569",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 184,
+        "line_number": 202,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -201,7 +233,7 @@
         "hashed_secret": "65e622227634e8876cfa733000233fb80c6f0473",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 203,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -306,6 +338,14 @@
         "line_number": 7,
         "type": "Secret Keyword",
         "verified_result": null
+      },
+      {
+        "hashed_secret": "0c910ad3070d996b37a1c65f542b17adc3f962bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword",
+        "verified_result": null
       }
     ],
     "test/unit/cp4d-token-manager.test.js": [
@@ -314,6 +354,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 17,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "16856d955c788df03735a24feb2e3ffefd91f3dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -373,7 +421,7 @@
         "hashed_secret": "a7ef1be18bb8d37af79f3d87761a203378bf26a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 361,
+        "line_number": 403,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -15,7 +15,6 @@
  */
 
 import { Cp4dTokenManager } from '../token-managers';
-import { validateInput } from '../utils';
 import { BaseOptions, TokenRequestBasedAuthenticator }
   from './token-request-based-authenticator';
 
@@ -23,14 +22,16 @@ import { BaseOptions, TokenRequestBasedAuthenticator }
 export interface Options extends BaseOptions {
   /** The username used to obtain a bearer token. */
   username: string;
-  /** The password used to obtain a bearer token. */
-  password: string;
+  /** The password used to obtain a bearer token [required if apikey not specified]. */
+  password?: string;
+  /** The API key used to obtain a bearer token [required if password not specified]. */
+  apikey?: string;
   /** The URL representing the Cloud Pak for Data token service endpoint. */
   url: string;
 }
 
 /**
- * The [[CloudPakForDataAuthenticator]] will use the user-supplied url, username and password values to obtain
+ * The [[CloudPakForDataAuthenticator]] will either use a username/password pair or a username/apikey pair to obtain
  * a bearer token from a token server.  When the bearer token expires, a new token is obtained from the token server.
  *
  * The bearer token will be sent as an Authorization header in the form:
@@ -39,17 +40,20 @@ export interface Options extends BaseOptions {
  */
 export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
 {
-  protected requiredOptions = ['username', 'password', 'url'];
+  protected requiredOptions = ['username', 'url'];
   protected tokenManager: Cp4dTokenManager;
   private username: string;
   private password: string;
+  private apikey: string;
+
   /**
    * Create a new [[CloudPakForDataAuthenticator]] instance.
    *
    * @param {object} options Configuration options for CloudPakForData authentication.
    * @param {string} options.url For HTTP token requests.
    * @param {string} options.username The username used to obtain a bearer token.
-   * @param {string} options.password The password used to obtain a bearer token.
+   * @param {string} [options.password] The password used to obtain a bearer token [required if apikey not specified].
+   * @param {string} [options.apikey] The API key used to obtain a bearer token [required if password not specified].
    * @param {boolean} [options.disableSslVerification] A flag that indicates
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
@@ -60,13 +64,13 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
   constructor(options: Options) {
     super(options);
 
-    validateInput(options, this.requiredOptions);
-
     this.username = options.username;
     this.password = options.password;
+    this.apikey = options.apikey;
 
     // the param names are shared between the authenticator and the token
-    // manager so we can just pass along the options object
+    // manager so we can just pass along the options object.
+    // also, the token manager will handle input validation
     this.tokenManager = new Cp4dTokenManager(options);
   }
 }

--- a/test/integration/cp4d-authenticator.test.js
+++ b/test/integration/cp4d-authenticator.test.js
@@ -1,0 +1,42 @@
+const { getAuthenticatorFromEnvironment } = require('../../dist');
+
+// Note: Only the unit tests are run by default.
+//
+// In order to test with a live CP4D server, rename "cp4dtest.env.example" to
+// "cp4dtest.env" in the test/resources folder and populate the fields.
+// Then run this command:
+// npm run jest -- test/integration/cp4d-authenticator.test.js
+
+describe('CP4D Authenticator - Integration Test', () => {
+  process.env.IBM_CREDENTIALS_FILE = __dirname + '/../resources/cp4dtest.env';
+
+  it('should retrieve a live access token with username/password', async () => {
+    // set up environment
+    const authenticator = getAuthenticatorFromEnvironment('cp4d-password-test');
+
+    // build a mock request
+    const requestOptions = {};
+
+    // authenticate the request
+    await authenticator.authenticate(requestOptions);
+
+    // check for proper authentication
+    expect(requestOptions.headers.Authorization).toBeDefined();
+    expect(requestOptions.headers.Authorization.startsWith('Bearer')).toBe(true);
+  });
+
+  it('should retrieve a live access token with username/apikey', async () => {
+    // set up environment
+    const authenticator = getAuthenticatorFromEnvironment('cp4d-apikey-test');
+
+    // build a mock request
+    const requestOptions = {};
+
+    // authenticate the request
+    await authenticator.authenticate(requestOptions);
+
+    // check for proper authentication
+    expect(requestOptions.headers.Authorization).toBeDefined();
+    expect(requestOptions.headers.Authorization.startsWith('Bearer')).toBe(true);
+  });
+});

--- a/test/resources/cp4dtest.env.example
+++ b/test/resources/cp4dtest.env.example
@@ -1,0 +1,11 @@
+CP4D_PASSWORD_TEST_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+CP4D_PASSWORD_TEST_AUTH_TYPE=cp4d
+CP4D_PASSWORD_TEST_USERNAME=<username>
+CP4D_PASSWORD_TEST_PASSWORD=<password>
+CP4D_PASSWORD_TEST_AUTH_DISABLE_SSL=true
+
+CP4D_APIKEY_TEST_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+CP4D_APIKEY_TEST_AUTH_TYPE=cp4d
+CP4D_APIKEY_TEST_USERNAME=<username>
+CP4D_APIKEY_TEST_APIKEY=<apikey>
+CP4D_APIKEY_TEST_AUTH_DISABLE_SSL=true

--- a/test/unit/cp4d-authenticator.test.js
+++ b/test/unit/cp4d-authenticator.test.js
@@ -5,6 +5,7 @@ const { Cp4dTokenManager } = require('../../dist/auth');
 
 const USERNAME = 'danmullen';
 const PASSWORD = 'gogators';
+const APIKEY = '32611';
 const URL = 'myicp.com:1234';
 const CONFIG = {
   username: USERNAME,
@@ -41,22 +42,43 @@ describe('CP4D Authenticator', () => {
     expect(authenticator.tokenManager).toBeInstanceOf(Cp4dTokenManager);
   });
 
-  it('should throw an error when username is not provided', () => {
-    expect(() => {
-      new CloudPakForDataAuthenticator({ password: PASSWORD });
-    }).toThrow();
+  it('should store apikey on the class if provided', () => {
+    const authenticator = new CloudPakForDataAuthenticator({
+      url: URL,
+      username: USERNAME,
+      apikey: APIKEY,
+    });
+
+    expect(authenticator.apikey).toBe(APIKEY);
   });
 
-  it('should throw an error when password is not provided', () => {
+  it('should throw an error when username is not provided', () => {
     expect(() => {
-      new CloudPakForDataAuthenticator({ username: USERNAME });
-    }).toThrow();
+      new CloudPakForDataAuthenticator({ url: URL, password: PASSWORD });
+    }).toThrow(/Missing required parameter/);
   });
 
   it('should throw an error when url is not provided', () => {
     expect(() => {
       new CloudPakForDataAuthenticator({ password: PASSWORD, username: USERNAME });
-    }).toThrow();
+    }).toThrow(/Missing required parameter/);
+  });
+
+  it('should throw an error when both password and apikey are missing', () => {
+    expect(() => {
+      new CloudPakForDataAuthenticator({ username: USERNAME, url: URL });
+    }).toThrow(/Exactly one of `apikey` or `password` must be specified/);
+  });
+
+  it('should throw an error when both password and apikey are present', () => {
+    expect(() => {
+      new CloudPakForDataAuthenticator({
+        username: USERNAME,
+        url: URL,
+        password: PASSWORD,
+        apikey: APIKEY,
+      });
+    }).toThrow(/Exactly one of `apikey` or `password` must be specified/);
   });
 
   it('should throw an error when username has a bad character', () => {
@@ -74,6 +96,16 @@ describe('CP4D Authenticator', () => {
       new CloudPakForDataAuthenticator({
         username: USERNAME,
         password: '{some-password}',
+        url: URL,
+      });
+    }).toThrow(/Revise these credentials/);
+  });
+
+  it('should throw an error when apikey has a bad character', () => {
+    expect(() => {
+      new CloudPakForDataAuthenticator({
+        username: USERNAME,
+        apikey: '{some-apikey}',
         url: URL,
       });
     }).toThrow(/Revise these credentials/);


### PR DESCRIPTION
This commit enhances the CP4D Authenticator to support the username/apikey use case.
With these changes, a user has the ability to construct a CP4D authenticator using
either a username/password pair or a username/apikey pair. The authenticator will
now use the official "POST /v1/authorize" operation for obtaining an access token.

I followed [the Go changes](https://github.com/IBM/go-sdk-core/pull/88/files) pretty closely but let me know if I missed something.

Phil, I hope you don't mind that I copied your commit message 🙂 