### PR TITLE
fix: persist `enableGzipCompression` setting on the base service

### DIFF
--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -152,6 +152,9 @@ export class BaseService {
    */
   public setEnableGzipCompression(setting: boolean): void {
     this.requestWrapperInstance.compressRequestData = setting;
+
+    // persist setting so that baseOptions accurately reflects the state of the flag
+    this.baseOptions.enableGzipCompression = setting;
   }
 
   /**

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -113,10 +113,12 @@ describe('Base Service', () => {
     const on = true;
     testService.setEnableGzipCompression(on);
     expect(testService.requestWrapperInstance.compressRequestData).toBe(on);
+    expect(testService.baseOptions.enableGzipCompression).toBe(on);
 
     const off = false;
     testService.setEnableGzipCompression(off);
     expect(testService.requestWrapperInstance.compressRequestData).toBe(off);
+    expect(testService.baseOptions.enableGzipCompression).toBe(off);
   });
 
   it('should throw an error if an authenticator is not passed in', () => {


### PR DESCRIPTION
When a new `BaseService` instance is created, the class settings are stored in an object
called `baseOptions`. Currently, when the `setEnableGzipCompression` method is called,
the `enableGzipCompression` setting is not changed and might no longer reflect the state
of the setting (because it is primarily tracked in the underlying `RequestWrapper` class).

This PR addresses this by persisting the setting in the `baseOptions` object when that method
is called so that the object always reflects the accurate value for the setting.