### PR TITLE
Add getQueryParam utility method to support pagination

### DIFF
--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -96,6 +96,21 @@ export function stripTrailingSlash(url: string): string {
 }
 
 /**
+ * Return a query parameter value from a URL
+ *
+ * @param {string} urlStr - the url string.
+ * @param {string} param - the name of the query parameter
+ *                     whose value should be returned
+ * @returns {string} the value of the `param` query parameter
+ * @throws if urlStr is an invalid URL
+ */
+export function getQueryParam(urlStr: string, param: string): string {
+  // The base URL is a dummy value just so we can process relative URLs
+  const url = new URL(urlStr, 'https://foo.bar');
+  return url.searchParams.get(param);
+}
+
+/**
  * Validates that all required params are provided
  * @param params - the method parameters.
  * @param requires - the required parameter names.

--- a/test/unit/get-query-param.test.js
+++ b/test/unit/get-query-param.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { getQueryParam } = require('../../dist/lib/helper');
+
+describe('getQueryParam', function() {
+  it('should return the parm value from a relative URL', function() {
+    const nextUrl = '/api/v1/offerings?start=foo&limit=10';
+    expect(getQueryParam(nextUrl, 'start')).toBe('foo');
+  });
+
+  it('should return the param value from an absolute URL', function() {
+    const nextUrl = 'https://acme.com/api/v1/offerings?start=bar&limit=10';
+    expect(getQueryParam(nextUrl, 'start')).toBe('bar');
+  });
+
+  it('should return null when the requested param is not present', function() {
+    const nextUrl = 'https://acme.com/api/v1/offerings?start=bar&limit=10';
+    expect(getQueryParam(nextUrl, 'token')).toBeNull();
+  });
+
+  it('should return null when urlStr is null', function() {
+    const nextUrl = null;
+    expect(getQueryParam(nextUrl, 'start')).toBeNull();
+  });
+
+  it('should return null when urlStr is the empty string', function() {
+    const nextUrl = '';
+    expect(getQueryParam(nextUrl, 'start')).toBeNull();
+  });
+
+  it('should return null when urlStr has no query string', function() {
+    const nextUrl = '/api/v1/offerings';
+    expect(getQueryParam(nextUrl, 'start')).toBeNull();
+  });
+
+  it('should throw and exception when urlStr is an invalid URL', function() {
+    const nextUrl = 'https://foo.bar:baz/api/v1/offerings?start=foo';
+    expect(() => {
+      getQueryParam(nextUrl, 'start');
+    }).toThrow(/Invalid URL/);
+  });
+
+  it('should return null when the query string is invalid', function() {
+    const nextUrl = '/api/v1/offerings?start%XXfoo';
+    expect(getQueryParam(nextUrl, 'start')).toBeNull();
+  });
+
+  it('should return the first value when the query string has duplicate parameters', function() {
+    const nextUrl = '/api/v1/offerings?start=foo&start=bar&limit=10';
+    expect(getQueryParam(nextUrl, 'start')).toBe('foo');
+  });
+});


### PR DESCRIPTION
This PR adds a small utility method to extract the value of a query parameter from a URL string. This will be used in the pagination support for Node.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
