### PR TITLE
fix: enable symbolic-link credentials files

### DIFF
--- a/auth/utils/read-credentials-file.ts
+++ b/auth/utils/read-credentials-file.ts
@@ -51,7 +51,12 @@ export function readCredentialsFile() {
 }
 
 export function fileExistsAtPath(filepath): boolean {
-  return fs.existsSync(filepath) && fs.lstatSync(filepath).isFile();
+  if (fs.existsSync(filepath)) {
+    const stats = fs.lstatSync(filepath);
+    return stats.isFile() || stats.isSymbolicLink();
+  }
+
+  return false;
 }
 
 export function constructFilepath(filepath): string {

--- a/test/resources/symlink-creds.txt
+++ b/test/resources/symlink-creds.txt
@@ -1,0 +1,1 @@
+ibm-credentials.env

--- a/test/unit/read-credentials-file.test.js
+++ b/test/unit/read-credentials-file.test.js
@@ -62,6 +62,11 @@ describe('read ibm credentials file', () => {
       const path = '/path/to/file/wrong-file.env';
       expect(fileExistsAtPath(path)).toBe(false);
     });
+
+    it('should return true for a symbolic link', () => {
+      const path = __dirname + '/../resources/symlink-creds.txt';
+      expect(fileExistsAtPath(path)).toBe(true);
+    });
   });
 
   describe('read credentials file', () => {


### PR DESCRIPTION
Currently, credentials files are explicitly required to real files (not symbolic links).
This was to exclude directories, not to exclude symbolic links, so it is a bug.

This PR adds explicit support for symbolic links. This should be a robust solution, as
I do not believe we want to support any of the other types the file could be (sockets,
block devices, etc).