### PR TITLE
fix: stub sdk-test-helpers in browser environments

### DIFF
--- a/lib/sdk-test-helpers.browser.ts
+++ b/lib/sdk-test-helpers.browser.ts
@@ -1,0 +1,24 @@
+// Dummy for browser
+export function checkUrlAndMethod(options, url: string, method: any) {
+  return;
+};
+
+export function checkMediaHeaders(createRequestMock, accept: string, contentType: string) {
+  return;
+};
+
+export function checkUserHeader(createRequestMock, userHeaderName: string, userHeaderValue: string) {
+  return;
+};
+
+export function checkForSuccessfulExecution(createRequestMock) {
+  return;
+};
+
+export function getOptions(createRequestMock) {
+  return;
+};
+
+export function expectToBePromise(sdkPromise) {
+  return;
+};

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "tough-cookie": "^4.0.0"
   },
   "browser": {
-    "./auth/utils/read-credentials-file": "./auth/utils/read-credentials-file.browser"
+    "./auth/utils/read-credentials-file": "./auth/utils/read-credentials-file.browser",
+    "./lib/sdk-test-helpers": "./lib/sdk-test-helpers.browser"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
The "sdk-test-helpers" file contains helper functions that generated SDKs use
in their generated unit tests. These functions are never actually needed when
running standard operational code, therefore they are never used in the browser.

The `expect` library that we use for testing has a dependency that isn't browser
friendly in certain scenarios. This causes the core and any SDKs importing it
to throw errors in these scenarios (like the React framework).

This change stubs the sdk-test-helpers in browser environments the same way we
stub the credentials file reading code. I've verified that this fix works in the problematic environments

cc @apaparazzi0329 