### PR TITLE
feat: add `BaseService.constructServiceURL` method

### DIFF
--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -61,6 +61,50 @@ export class BaseService {
 
   static DEFAULT_SERVICE_NAME: string;
 
+  /**
+   * Constructs a service URL by formatting a parameterized URL.
+   *
+   * @param {string} parameterizedUrl URL that contains variable placeholders, e.g. '{scheme}://ibm.com'.
+   * @param {Map<string, string>} defaultUrlVariables Map from variable names to default values.
+   *  Each variable in the parameterized URL must have a default value specified in this map.
+   * @param {Map<string, string>} providedUrlVariables Map from variable names to desired values.
+   *  If a variable is not provided in this map,
+   *  the default variable value will be used instead.
+   * @returns {string} The formatted URL with all variable placeholders replaced by values.
+   */
+  static constructServiceURL(
+    parameterizedUrl: string,
+    defaultUrlVariables: Map<string, string>,
+    providedUrlVariables: Map<string, string> | null
+  ): string {
+    // If null was passed, we set the variables to an empty map.
+    // This results in all default variable values being used.
+    if (providedUrlVariables === null) {
+      providedUrlVariables = new Map<string, string>();
+    }
+
+    // Verify the provided variable names.
+    providedUrlVariables.forEach((_, name) => {
+      if (!defaultUrlVariables.has(name)) {
+        throw new Error(`'${name}' is an invalid variable name.
+        Valid variable names: [${Array.from(defaultUrlVariables.keys()).sort()}].`);
+      }
+    });
+
+    // Format the URL with provided or default variable values.
+    let formattedUrl = parameterizedUrl;
+
+    defaultUrlVariables.forEach((defaultValue, name) => {
+      // Use the default variable value if none was provided.
+      const providedValue = providedUrlVariables.get(name);
+      const formatValue = providedValue !== undefined ? providedValue : defaultValue;
+
+      formattedUrl = formattedUrl.replace(`{${name}}`, formatValue);
+    });
+
+    return formattedUrl;
+  }
+
   protected baseOptions: BaseServiceOptions;
 
   private authenticator: AuthenticatorInterface;

--- a/test/unit/parameterized-url.test.js
+++ b/test/unit/parameterized-url.test.js
@@ -1,0 +1,49 @@
+const { BaseService } = require('../../dist/lib/base-service');
+
+const parameterizedUrl = '{scheme}://{domain}:{port}';
+const defaultUrlVariables = new Map([
+  ['scheme', 'http'],
+  ['domain', 'ibm.com'],
+  ['port', '9300'],
+]);
+
+describe('constructServiceURL', () => {
+  it('should use default variable values when null is passed', () => {
+    expect(BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, null)).toBe(
+      'http://ibm.com:9300'
+    );
+  });
+
+  it('should use the values provided and defaults for the rest', () => {
+    const providedUrlVariables = new Map([
+      ['scheme', 'https'],
+      ['port', '22'],
+    ]);
+
+    expect(
+      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
+    ).toBe('https://ibm.com:22');
+  });
+
+  it('should use all provided values', () => {
+    const providedUrlVariables = new Map([
+      ['scheme', 'https'],
+      ['domain', 'google.com'],
+      ['port', '22'],
+    ]);
+
+    expect(
+      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
+    ).toBe('https://google.com:22');
+  });
+
+  it('should throw an error if a provided variable name is wrong', () => {
+    const providedUrlVariables = new Map([['server', 'value']]);
+
+    expect(() =>
+      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
+    ).toThrow(
+      /'server' is an invalid variable name\.\n\s*Valid variable names: \[domain,port,scheme\]\./
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

This method can be used by an API to construct a service URL from a parameterized URL.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
