### PR TITLE
fix: change constructServiceURL from method to function

### DIFF
--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -61,50 +61,6 @@ export class BaseService {
 
   static DEFAULT_SERVICE_NAME: string;
 
-  /**
-   * Constructs a service URL by formatting a parameterized URL.
-   *
-   * @param {string} parameterizedUrl URL that contains variable placeholders, e.g. '{scheme}://ibm.com'.
-   * @param {Map<string, string>} defaultUrlVariables Map from variable names to default values.
-   *  Each variable in the parameterized URL must have a default value specified in this map.
-   * @param {Map<string, string>} providedUrlVariables Map from variable names to desired values.
-   *  If a variable is not provided in this map,
-   *  the default variable value will be used instead.
-   * @returns {string} The formatted URL with all variable placeholders replaced by values.
-   */
-  static constructServiceURL(
-    parameterizedUrl: string,
-    defaultUrlVariables: Map<string, string>,
-    providedUrlVariables: Map<string, string> | null
-  ): string {
-    // If null was passed, we set the variables to an empty map.
-    // This results in all default variable values being used.
-    if (providedUrlVariables === null) {
-      providedUrlVariables = new Map<string, string>();
-    }
-
-    // Verify the provided variable names.
-    providedUrlVariables.forEach((_, name) => {
-      if (!defaultUrlVariables.has(name)) {
-        throw new Error(`'${name}' is an invalid variable name.
-        Valid variable names: [${Array.from(defaultUrlVariables.keys()).sort()}].`);
-      }
-    });
-
-    // Format the URL with provided or default variable values.
-    let formattedUrl = parameterizedUrl;
-
-    defaultUrlVariables.forEach((defaultValue, name) => {
-      // Use the default variable value if none was provided.
-      const providedValue = providedUrlVariables.get(name);
-      const formatValue = providedValue !== undefined ? providedValue : defaultValue;
-
-      formattedUrl = formattedUrl.replace(`{${name}}`, formatValue);
-    });
-
-    return formattedUrl;
-  }
-
   protected baseOptions: BaseServiceOptions;
 
   private authenticator: AuthenticatorInterface;

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -253,7 +253,7 @@ export function toLowerKeys(obj: Object): Object {
  *  the default variable value will be used instead.
  * @returns {string} The formatted URL with all variable placeholders replaced by values.
  */
-export function constructServiceURL(
+export function constructServiceUrl(
   parameterizedUrl: string,
   defaultUrlVariables: Map<string, string>,
   providedUrlVariables: Map<string, string> | null

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -241,3 +241,47 @@ export function toLowerKeys(obj: Object): Object {
   }
   return lowerCaseObj;
 }
+
+/**
+ * Constructs a service URL by formatting a parameterized URL.
+ *
+ * @param {string} parameterizedUrl URL that contains variable placeholders, e.g. '{scheme}://ibm.com'.
+ * @param {Map<string, string>} defaultUrlVariables Map from variable names to default values.
+ *  Each variable in the parameterized URL must have a default value specified in this map.
+ * @param {Map<string, string>} providedUrlVariables Map from variable names to desired values.
+ *  If a variable is not provided in this map,
+ *  the default variable value will be used instead.
+ * @returns {string} The formatted URL with all variable placeholders replaced by values.
+ */
+export function constructServiceURL(
+  parameterizedUrl: string,
+  defaultUrlVariables: Map<string, string>,
+  providedUrlVariables: Map<string, string> | null
+): string {
+  // If null was passed, we set the variables to an empty map.
+  // This results in all default variable values being used.
+  if (providedUrlVariables === null) {
+    providedUrlVariables = new Map<string, string>();
+  }
+
+  // Verify the provided variable names.
+  providedUrlVariables.forEach((_, name) => {
+    if (!defaultUrlVariables.has(name)) {
+      throw new Error(`'${name}' is an invalid variable name.
+      Valid variable names: [${Array.from(defaultUrlVariables.keys()).sort()}].`);
+    }
+  });
+
+  // Format the URL with provided or default variable values.
+  let formattedUrl = parameterizedUrl;
+
+  defaultUrlVariables.forEach((defaultValue, name) => {
+    // Use the default variable value if none was provided.
+    const providedValue = providedUrlVariables.get(name);
+    const formatValue = providedValue !== undefined ? providedValue : defaultValue;
+
+    formattedUrl = formattedUrl.replace(`{${name}}`, formatValue);
+  });
+
+  return formattedUrl;
+}

--- a/test/unit/parameterized-url.test.js
+++ b/test/unit/parameterized-url.test.js
@@ -1,4 +1,4 @@
-const { BaseService } = require('../../dist/lib/base-service');
+const { constructServiceURL } = require('../../dist/lib/helper');
 
 const parameterizedUrl = '{scheme}://{domain}:{port}';
 const defaultUrlVariables = new Map([
@@ -9,7 +9,7 @@ const defaultUrlVariables = new Map([
 
 describe('constructServiceURL', () => {
   it('should use default variable values when null is passed', () => {
-    expect(BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, null)).toBe(
+    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, null)).toBe(
       'http://ibm.com:9300'
     );
   });
@@ -20,9 +20,9 @@ describe('constructServiceURL', () => {
       ['port', '22'],
     ]);
 
-    expect(
-      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
-    ).toBe('https://ibm.com:22');
+    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
+      'https://ibm.com:22'
+    );
   });
 
   it('should use all provided values', () => {
@@ -32,16 +32,16 @@ describe('constructServiceURL', () => {
       ['port', '22'],
     ]);
 
-    expect(
-      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
-    ).toBe('https://google.com:22');
+    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
+      'https://google.com:22'
+    );
   });
 
   it('should throw an error if a provided variable name is wrong', () => {
     const providedUrlVariables = new Map([['server', 'value']]);
 
     expect(() =>
-      BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
+      constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
     ).toThrow(
       /'server' is an invalid variable name\.\n\s*Valid variable names: \[domain,port,scheme\]\./
     );

--- a/test/unit/parameterized-url.test.js
+++ b/test/unit/parameterized-url.test.js
@@ -1,4 +1,4 @@
-const { constructServiceURL } = require('../../dist/lib/helper');
+const { constructServiceUrl } = require('../../dist/lib/helper');
 
 const parameterizedUrl = '{scheme}://{domain}:{port}';
 const defaultUrlVariables = new Map([
@@ -7,9 +7,9 @@ const defaultUrlVariables = new Map([
   ['port', '9300'],
 ]);
 
-describe('constructServiceURL', () => {
+describe('constructServiceUrl', () => {
   it('should use default variable values when null is passed', () => {
-    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, null)).toBe(
+    expect(constructServiceUrl(parameterizedUrl, defaultUrlVariables, null)).toBe(
       'http://ibm.com:9300'
     );
   });
@@ -20,7 +20,7 @@ describe('constructServiceURL', () => {
       ['port', '22'],
     ]);
 
-    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
+    expect(constructServiceUrl(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
       'https://ibm.com:22'
     );
   });
@@ -32,7 +32,7 @@ describe('constructServiceURL', () => {
       ['port', '22'],
     ]);
 
-    expect(constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
+    expect(constructServiceUrl(parameterizedUrl, defaultUrlVariables, providedUrlVariables)).toBe(
       'https://google.com:22'
     );
   });
@@ -41,7 +41,7 @@ describe('constructServiceURL', () => {
     const providedUrlVariables = new Map([['server', 'value']]);
 
     expect(() =>
-      constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
+      constructServiceUrl(parameterizedUrl, defaultUrlVariables, providedUrlVariables)
     ).toThrow(
       /'server' is an invalid variable name\.\n\s*Valid variable names: \[domain,port,scheme\]\./
     );


### PR DESCRIPTION
Now it can be used as a utility function instead of an inherited method.

An SDK class can now include a `constructServiceURL` method with a different signature than this function.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
