### PR TITLE
build: remove deprecated Node 10 version from CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- 10
 - 12
+- 14
 cache:
   npm: false
 script:


### PR DESCRIPTION
Node 10 is deprecated, so we want to test on the latest stable versions of Node, 12 and 14.