### PR TITLE
fix: remove default limit on request body length

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -51,6 +51,7 @@ export class RequestWrapper {
     // defaults here
     const axiosConfig: AxiosRequestConfig = {
       maxContentLength: Infinity,
+      maxBodyLength: Infinity,
       headers: {
         post: {
           'Content-Type': 'application/json',

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -66,6 +66,7 @@ describe('RequestWrapper constructor', () => {
     // axios instance with it
     const createdAxiosConfig = axios.default.create.mock.calls[0][0];
     expect(createdAxiosConfig.maxContentLength).toBe(Infinity);
+    expect(createdAxiosConfig.maxBodyLength).toBe(Infinity);
     expect(createdAxiosConfig.headers).toBeDefined();
     expect(createdAxiosConfig.headers.post).toBeDefined();
     expect(createdAxiosConfig.headers.put).toBeDefined();
@@ -78,10 +79,12 @@ describe('RequestWrapper constructor', () => {
   it('should override the defaults with user-provided input', () => {
     const unused = new RequestWrapper({
       maxContentLength: 100,
+      maxBodyLength: 200,
     });
 
     const createdAxiosConfig = axios.default.create.mock.calls[0][0];
     expect(createdAxiosConfig.maxContentLength).toBe(100);
+    expect(createdAxiosConfig.maxBodyLength).toBe(200);
   });
 
   it('creates a custom https agent when disableSslVerification is true', () => {


### PR DESCRIPTION
The `axios` library sets an arbitrary maximum length for request bodies and
throws an error if this length is exceeded. This has caused some confusion for
users and none of the other core libraries enforce such a limit. Services are
expected to handle request body length themselves. So this commit overrides the
default to be "Infinity", just like we do for response body limits. Users still
have the option to override this limit if they wish.