### PR TITLE
refactor: remove specific handling for "watson-token" query params

### DIFF
--- a/lib/querystring.ts
+++ b/lib/querystring.ts
@@ -1,29 +1,14 @@
-/* eslint-disable prettier/prettier, arrow-body-style */
-
 /**
- * Stringify query params, Watson-style
- *
- * Why? The server that processes auth tokens currently only accepts the *exact* string, even if it's invalid for a URL.
- * Properly url-encoding percent characters causes it to reject the token
- * So, this is a custom qs.stringify function that properly encodes everything except watson-token, passing it along verbatim
+ * Lightweight implementation for stringify-ing query params
  *
  * @param {object<string, object>} queryParams
  * @return {String}
  */
-const stringify = (queryParams: Object): string => {
-  return Object.keys(queryParams)
-    .map((key) => {
-      return (
-        `${key 
-        }=${ 
-        key === 'watson-token'
-          ? queryParams[key]
-          : encodeURIComponent(queryParams[key])}`
-      ); // the server chokes if the token is correctly url-encoded
-    })
+const stringify = (queryParams: Object): string =>
+  Object.keys(queryParams)
+    .map((key) => `${key}=${encodeURIComponent(queryParams[key])}`)
     .join('&');
-};
 
 export default {
-  stringify
+  stringify,
 };

--- a/scripts/jsdoc/template/tmpl/layout.tmpl
+++ b/scripts/jsdoc/template/tmpl/layout.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title><?js= title ?> | Watson Developer Cloud Node.js SDK Documentation</title>
+    <title><?js= title ?> | Node SDK Core Documentation</title>
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>

--- a/test/unit/querystring.test.js
+++ b/test/unit/querystring.test.js
@@ -1,0 +1,8 @@
+const { stringify } = require('../../dist/lib/querystring').default;
+
+describe('querystring', () => {
+  it('should convert params to query string format', () => {
+    const params = { foo: 'bar', baz: ['qux', 'quux'], corge: '' };
+    expect(stringify(params)).toBe('foo=bar&baz=qux%2Cquux&corge=');
+  });
+});


### PR DESCRIPTION
We currently have a special hack to handle watson tokens in a unique way.
This used to be required for Watson services but they have not used this
method of authentication in years. This is supposed to be a service-agnostic
package, so this commit refactors the code to avoid the specific handling.

I also edited a jsdoc file (even though I don't think it is used) and added
a test for this small module.