### PR TITLE
feat: add support for new ContainerAuthenticator

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-03T20:56:36Z",
+  "generated_at": "2021-08-05T19:56:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -142,15 +142,17 @@
         "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 90,
+        "line_number": 69,
         "type": "Secret Keyword",
         "verified_result": null
-      },
+      }
+    ],
+    "auth/authenticators/iam-request-based-authenticator.ts": [
       {
         "hashed_secret": "f84f793e0af9ade37c8b927bc5091e98f35bf821",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 78,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -158,7 +160,7 @@
         "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 91,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -166,7 +168,17 @@
         "hashed_secret": "99833a8b234b57b886a9aef1dba187fdd7ceece8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 109,
+        "line_number": 93,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "auth/token-managers/container-token-manager.ts": [
+      {
+        "hashed_secret": "184ee1f04a018aa3b897e085516a9b657fea0f6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 82,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -349,6 +361,16 @@
         "verified_result": null
       }
     ],
+    "test/unit/container-authenticator.test.js": [
+      {
+        "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "test/unit/cp4d-authenticator.test.js": [
       {
         "hashed_secret": "85dd3fb12cb0dcae03f1bba6fb61f4edd90d986d",
@@ -422,7 +444,17 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 77,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/unit/iam-request-based-authenticator.test.js": [
+      {
+        "hashed_secret": "43ed4c2d8375dfc89e3dc8c917f404b9481d355b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-05T19:56:02Z",
+  "generated_at": "2021-08-05T20:39:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -78,7 +78,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "24c3d19b8d127fe8f7274108156a718ec56fc6e6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 136,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -94,7 +94,7 @@
         "hashed_secret": "32e8612d8ca77c7ea8374aa7918db8e5df9252ed",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 171,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -114,7 +114,7 @@
         "hashed_secret": "32e8612d8ca77c7ea8374aa7918db8e5df9252ed",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 59,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -274,7 +274,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Authentication.md
+++ b/Authentication.md
@@ -4,6 +4,7 @@ The node-sdk-core project supports the following types of authentication:
 - Bearer Token
 - Identity and Access Management (IAM)
 - Cloud Pak for Data
+- Container
 - No Authentication
 
 The SDK user configures the appropriate type of authentication for use with service instances.
@@ -169,6 +170,41 @@ import { getAuthenticatorFromEnvironment } from 'ibm-cloud-sdk-core';
 // MY_SERVICE_PASSWORD=<password>
 // MY_SERVICE_APIKEY=<apikey>
 const cp4dAuthenticator = getAuthenticatorFromEnvironment('my-service');
+```
+
+## Container
+The `ContainerAuthenticator` will read a compute resource token from the file system (typically, a container running on a system like IKS) and will perform the necessary interactions with the IAM token service to obtain a suitable bearer token for the compute resource.  The authenticator will also obtain  a new bearer token when the current token expires.  The bearer token is then added to each outbound request in the `Authorization` header in the form:
+
+```
+   Authorization: Bearer <bearer-token>
+```
+
+### Properties
+- crTokenFilename: (optional) The name of the file containing the injected CR token value. If not specified, then `/var/run/secrets/tokens/vault-token` is used as the default value. The application must have `read` permissions on the file containing the CR token value.
+- iamProfileName: (optional) The name of the linked trusted IAM profile to be used when obtaining the IAM access token (a CR token might map to multiple IAM profiles). One of `iamProfileName` or `iamProfileId` must be specified.
+- iamProfileId: (optional) The ID of the linked trusted IAM profile to be used when obtaining the IAM access token (a CR token might map to multiple IAM profiles). One of `iamProfileName` or `iamProfileId` must be specified.
+- url: (optional) The URL representing the IAM token service endpoint.  If not specified, a suitable default value is used.
+- clientId/clientSecret: (optional) The `clientId` and `clientSecret` fields are used to form a "basic auth" Authorization header for interactions with the IAM token server. If neither field is specified, then no Authorization header will be sent with token server requests.  These fields are optional, but must be specified together.
+- disableSslVerification: (optional) A flag that indicates whether verificaton of the server's SSL certificate should be disabled or not. The default value is `false`.
+- headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests made to the IAM token service.
+
+### Programming example
+```js
+import { ContainerAuthenticator } from 'ibm-cloud-sdk-core';
+
+const authenticator = new ContainerAuthenticator({
+  iamProfileName: '{profile-name}',
+});
+```
+
+### External configuration example
+```js
+import { getAuthenticatorFromEnvironment } from 'ibm-cloud-sdk-core';
+
+// env vars
+// MY_SERVICE_AUTH_TYPE=container
+// MY_SERVICE_IAM_PROFILE_ID=my_profile_name
+const containerAuthenticator = getAuthenticatorFromEnvironment('my-service');
 ```
 
 ## No Auth Authentication

--- a/Authentication.md
+++ b/Authentication.md
@@ -173,10 +173,25 @@ const cp4dAuthenticator = getAuthenticatorFromEnvironment('my-service');
 ```
 
 ## Container
-The `ContainerAuthenticator` will read a compute resource token from the file system (typically, a container running on a system like IKS) and will perform the necessary interactions with the IAM token service to obtain a suitable bearer token for the compute resource.  The authenticator will also obtain  a new bearer token when the current token expires.  The bearer token is then added to each outbound request in the `Authorization` header in the form:
+The `ContainerAuthenticator` is intended to be used by application code
+running inside a compute resource managed by the IBM Kubernetes Service (IKS)
+in which a secure compute resource token (CR token) has been stored in a file
+within the compute resource's local file system.
+The CR token is similar to an IAM apikey except that it is managed automatically by
+the compute resource provider (IKS).
+This allows the application developer to:
+- avoid storing credentials in application code, configuraton files or a password vault
+- avoid managing or rotating credentials
 
+The `ContainerAuthenticator` will retrieve the CR token from
+the compute resource in which the application is running, and will then perform
+the necessary interactions with the IAM token service to obtain an IAM access token
+using the IAM "get token" operation with grant-type `cr-token`.
+The authenticator will repeat these steps to obtain a new IAM access token when the
+current access token expires.
+The IAM access token is added to each outbound request in the `Authorization` header in the form:
 ```
-   Authorization: Bearer <bearer-token>
+   Authorization: Bearer <IAM-access-token>
 ```
 
 ### Properties

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This library provides a set of Authenticators used to authenticate requests from
 - Bearer Token
 - IAM
 - CP4D
+- Container
 
 There are two ways to create an authenticator:
 1. Creating an instance and providing credentials programmatically

--- a/auth/authenticators/container-authenticator.ts
+++ b/auth/authenticators/container-authenticator.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2021 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContainerTokenManager } from '../token-managers';
+import { IamRequestOptions, IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
+
+/** Configuration options for IAM authentication. */
+export interface Options extends IamRequestOptions {
+  /** The file containing the compute resource token. */
+  crTokenFilename?: string;
+
+  /** The IAM profile name associated with the compute resource token. */
+  iamProfileName?: string;
+
+  /** The IAM profile ID associated with the compute resource token. */
+  iamProfileId?: string;
+}
+
+/**
+ * The [[ContainerAuthenticator]] will read a compute resource token from the file system
+ * and use this value to obtain a bearer token from the IAM token server.  When the bearer
+ * token expires, a new token is obtained from the token server.
+ *
+ * The bearer token will be sent as an Authorization header in the form:
+ *
+ *      Authorization: Bearer <bearer-token>
+ */
+export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
+  protected tokenManager: ContainerTokenManager;
+
+  private crTokenFilename: string;
+
+  private iamProfileName: string;
+
+  private iamProfileId: string;
+
+  /**
+   *
+   * Create a new [[ContainerAuthenticator]] instance.
+   *
+   * @param {object} options Configuration options for IAM authentication.
+   * @param {string} [options.crTokenFilename] The file containing the compute resource token.
+   * @param {string} [options.iamProfileName] The IAM profile name associated with the compute resource token.
+   * @param {string} [options.iamProfileId] The IAM profile ID associated with the compute resource token.
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not
+   * @param {string} [options.url] for HTTP token requests.
+   * @param {object<string, string>} options.headers to be sent with every
+   * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [options.scope] The "scope" parameter to use when fetching the bearer token from the
+   *   IAM token server.
+   * @throws {Error} When the configuration options are not valid.
+   */
+  constructor(options: Options) {
+    super(options);
+
+    // the param names are shared between the authenticator and the token
+    // manager so we can just pass along the options object
+    // the token manager will also handle the validation of required options
+    this.tokenManager = new ContainerTokenManager(options);
+
+    this.crTokenFilename = options.crTokenFilename;
+    this.iamProfileName = options.iamProfileName;
+    this.iamProfileId = options.iamProfileId;
+  }
+
+  /**
+   * Setter for the filename of the compute resource token.
+   * @param {string} scope A string containing a path to the CR token file
+   */
+  public setCrTokenFilename(crTokenFilename: string): void {
+    this.crTokenFilename = crTokenFilename;
+
+    // update properties in token manager
+    this.tokenManager.setCrTokenFilename(crTokenFilename);
+  }
+
+  /**
+   * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileName parameter
+   */
+  public setIamProfileName(iamProfileName: string): void {
+    this.iamProfileName = iamProfileName;
+
+    // update properties in token manager
+    this.tokenManager.setIamProfileName(iamProfileName);
+  }
+
+  /**
+   * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileId parameter
+   */
+  public setIamProfileId(iamProfileId: string): void {
+    this.iamProfileId = iamProfileId;
+
+    // update properties in token manager
+    this.tokenManager.setIamProfileId(iamProfileId);
+  }
+}

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -16,27 +16,12 @@
 
 import { IamTokenManager } from '../token-managers';
 import { validateInput } from '../utils';
-import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+import { IamRequestOptions, IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
 
 /** Configuration options for IAM authentication. */
-export interface Options extends BaseOptions {
+export interface Options extends IamRequestOptions {
   /** The IAM api key */
   apikey: string;
-  /**
-   * The `clientId` and `clientSecret` fields are used to form a "basic"
-   * authorization header for IAM token requests.
-   */
-  clientId?: string;
-  /**
-   * The `clientId` and `clientSecret` fields are used to form a "basic"
-   * authorization header for IAM token requests.
-   */
-  clientSecret?: string;
-
-  /**
-   * The "scope" parameter to use when fetching the bearer token from the IAM token server.
-   */
-  scope?: string;
 }
 
 /**
@@ -50,18 +35,12 @@ export interface Options extends BaseOptions {
  *
  *      Authorization: Bearer <bearer-token>
  */
-export class IamAuthenticator extends TokenRequestBasedAuthenticator {
+export class IamAuthenticator extends IamRequestBasedAuthenticator {
   protected requiredOptions = ['apikey'];
 
   protected tokenManager: IamTokenManager;
 
   private apikey: string;
-
-  private clientId: string;
-
-  private clientSecret: string;
-
-  private scope: string;
 
   /**
    *
@@ -88,39 +67,10 @@ export class IamAuthenticator extends TokenRequestBasedAuthenticator {
     validateInput(options, this.requiredOptions);
 
     this.apikey = options.apikey;
-    this.clientId = options.clientId;
-    this.clientSecret = options.clientSecret;
-    this.scope = options.scope;
 
     // the param names are shared between the authenticator and the token
     // manager so we can just pass along the options object
     this.tokenManager = new IamTokenManager(options);
-  }
-
-  /**
-   * Setter for the mutually inclusive `clientId` and the `clientSecret`.
-   * @param {string} clientId The `clientId` and `clientSecret` fields are used to form a "basic"
-   *   authorization header for IAM token requests.
-   * @param {string} clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
-   *   authorization header for IAM token requests.
-   */
-  public setClientIdAndSecret(clientId: string, clientSecret: string): void {
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-
-    // update properties in token manager
-    this.tokenManager.setClientIdAndSecret(clientId, clientSecret);
-  }
-
-  /**
-   * Setter for the "scope" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A space seperated string that makes up the scope parameter
-   */
-  public setScope(scope: string): void {
-    this.scope = scope;
-
-    // update properties in token manager
-    this.tokenManager.setScope(scope);
   }
 
   /**

--- a/auth/authenticators/iam-request-based-authenticator.ts
+++ b/auth/authenticators/iam-request-based-authenticator.ts
@@ -59,7 +59,7 @@ export class IamRequestBasedAuthenticator extends TokenRequestBasedAuthenticator
    *   whether verification of the token server's SSL certificate should be
    *   disabled or not
    * @param {string} options.url for HTTP token requests.
-   * @param {object<string, string>} options.headers to be sent with every
+   * @param {object<string, string>} options.headers to be sent with every IAM token request
    * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
    *   authorization header for IAM token requests.
    * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"

--- a/auth/authenticators/iam-request-based-authenticator.ts
+++ b/auth/authenticators/iam-request-based-authenticator.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IamRequestBasedTokenManager } from '../token-managers';
+import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+
+/** Configuration options for IAM Request based authentication. */
+export interface IamRequestOptions extends BaseOptions {
+  /**
+   * The `clientId` and `clientSecret` fields are used to form a "basic"
+   * authorization header for IAM token requests.
+   */
+  clientId?: string;
+  /**
+   * The `clientId` and `clientSecret` fields are used to form a "basic"
+   * authorization header for IAM token requests.
+   */
+  clientSecret?: string;
+
+  /**
+   * The "scope" parameter to use when fetching the bearer token from the IAM token server.
+   */
+  scope?: string;
+}
+
+/**
+ * The [[IamRequestBasedAuthenticator]] provides shared configuration and functionality
+ * for authenticators that interact with the IAM service to inherit. This authenticator
+ * is not meant for use on its own.
+ */
+export class IamRequestBasedAuthenticator extends TokenRequestBasedAuthenticator {
+  protected tokenManager: IamRequestBasedTokenManager;
+
+  protected clientId: string;
+
+  protected clientSecret: string;
+
+  protected scope: string;
+
+  /**
+   *
+   * Create a new [[IamRequestBasedAuthenticator]] instance.
+   *
+   * @param {object} options Configuration options for IAM authentication.
+   * @param {boolean} options.disableSslVerification A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not
+   * @param {string} options.url for HTTP token requests.
+   * @param {object<string, string>} options.headers to be sent with every
+   * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [options.scope] The "scope" parameter to use when fetching the bearer token from the
+   *   IAM token server.
+   * @throws {Error} When the configuration options are not valid.
+   */
+  constructor(options: IamRequestOptions) {
+    // all parameters are optional
+    options = options || ({} as IamRequestOptions);
+
+    super(options);
+
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+    this.scope = options.scope;
+
+    this.tokenManager = new IamRequestBasedTokenManager(options);
+  }
+
+  /**
+   * Setter for the mutually inclusive `clientId` and the `clientSecret`.
+   * @param {string} clientId The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} clientSecret The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   */
+  public setClientIdAndSecret(clientId: string, clientSecret: string): void {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+
+    // update properties in token manager
+    this.tokenManager.setClientIdAndSecret(clientId, clientSecret);
+  }
+
+  /**
+   * Setter for the "scope" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A space seperated string that makes up the scope parameter
+   */
+  public setScope(scope: string): void {
+    this.scope = scope;
+
+    // update properties in token manager
+    this.tokenManager.setScope(scope);
+  }
+}

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -44,4 +44,5 @@ export { BearerTokenAuthenticator } from './bearer-token-authenticator';
 export { CloudPakForDataAuthenticator } from './cloud-pak-for-data-authenticator';
 export { IamAuthenticator } from './iam-authenticator';
 export { NoAuthAuthenticator } from './no-auth-authenticator';
+export { IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
 export { TokenRequestBasedAuthenticator } from './token-request-based-authenticator';

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -21,6 +21,7 @@
  * Basic Authentication
  * Bearer Token
  * Identity and Access Management (IAM)
+ * Container (IKS, etc)
  * Cloud Pak for Data
  * No Authentication
  *
@@ -34,6 +35,7 @@
  *   BearerTokenAuthenticator: Authenticator for passing supplied bearer token to service endpoint.
  *   CloudPakForDataAuthenticator: Authenticator for passing CP4D authentication information to service endpoint.
  *   IAMAuthenticator: Authenticator for passing IAM authentication information to service endpoint.
+ *   ContainerAuthenticator: Authenticator for passing IAM authentication to a service, based on a token living on the container.
  *   NoAuthAuthenticator: Performs no authentication. Useful for testing purposes.
  */
 
@@ -43,6 +45,7 @@ export { BasicAuthenticator } from './basic-authenticator';
 export { BearerTokenAuthenticator } from './bearer-token-authenticator';
 export { CloudPakForDataAuthenticator } from './cloud-pak-for-data-authenticator';
 export { IamAuthenticator } from './iam-authenticator';
+export { ContainerAuthenticator } from './container-authenticator';
 export { NoAuthAuthenticator } from './no-auth-authenticator';
 export { IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
 export { TokenRequestBasedAuthenticator } from './token-request-based-authenticator';

--- a/auth/token-managers/container-token-manager.ts
+++ b/auth/token-managers/container-token-manager.ts
@@ -84,7 +84,7 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
 
   /**
    * Setter for the filename of the compute resource token.
-   * @param {string} scope A string containing a path to the CR token file
+   * @param {string} crTokenFilename A string containing a path to the CR token file
    */
   public setCrTokenFilename(crTokenFilename: string): void {
     this.crTokenFilename = crTokenFilename;
@@ -92,7 +92,7 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
 
   /**
    * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileName parameter
+   * @param {string} iamProfileName A string that makes up the iamProfileName parameter
    */
   public setIamProfileName(iamProfileName: string): void {
     this.iamProfileName = iamProfileName;
@@ -100,7 +100,7 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
 
   /**
    * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileId parameter
+   * @param {string} iamProfileId A string that makes up the iamProfileId parameter
    */
   public setIamProfileId(iamProfileId: string): void {
     this.iamProfileId = iamProfileId;

--- a/auth/token-managers/container-token-manager.ts
+++ b/auth/token-managers/container-token-manager.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import logger from '../../lib/logger';
+import { atLeastOne, readCrTokenFile } from '../utils';
+import { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-based-token-manager';
+
+const DEFAULT_CR_TOKEN_FILEPATH = '/var/run/secrets/tokens/vault-token';
+
+/** Configuration options for IAM token retrieval. */
+interface Options extends IamRequestOptions {
+  crTokenFilename?: string;
+  iamProfileName?: string;
+  iamProfileId?: string;
+}
+
+/**
+ * The ContainerTokenManager retrieves a compute resource token from a file on the container. This token
+ * is used to perform the necessary interactions with the IAM token service to obtain and store a suitable
+ * bearer (access) token.
+ */
+export class ContainerTokenManager extends IamRequestBasedTokenManager {
+  private crTokenFilename: string;
+
+  private iamProfileName: string;
+
+  private iamProfileId: string;
+
+  /**
+   *
+   * Create a new [[ContainerTokenManager]] instance.
+   *
+   * @param {object} options Configuration options.
+   * @param {string} [crTokenFilename='/var/run/secrets/tokens/vault-token'] The file containing the compute resource token.
+   * @param {string} [iamProfileName] The IAM profile name associated with the compute resource token.
+   * @param {string} [iamProfileId] The IAM profile ID associated with the compute resource token.
+   * @param {string} [options.clientId] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [options.clientSecret] The `clientId` and `clientSecret` fields are used to form a "basic"
+   *   authorization header for IAM token requests.
+   * @param {string} [url='https://iam.cloud.ibm.com'] The IAM endpoint for token requests.
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
+   *   whether verification of the token server's SSL certificate should be
+   *   disabled or not.
+   * @param {object<string, string>} [options.headers] Headers to be sent with every
+   *   outbound HTTP requests to token services.
+   * @constructor
+   */
+  constructor(options: Options) {
+    // all parameters are optional
+    options = options || ({} as Options);
+
+    super(options);
+
+    if (!atLeastOne(options.iamProfileId, options.iamProfileName)) {
+      throw new Error('At least one of `iamProfileName` or `iamProfileId` must be specified.');
+    }
+
+    this.crTokenFilename = options.crTokenFilename || DEFAULT_CR_TOKEN_FILEPATH;
+
+    if (options.iamProfileName) {
+      this.iamProfileName = options.iamProfileName;
+    }
+    if (options.iamProfileId) {
+      this.iamProfileId = options.iamProfileId;
+    }
+
+    // construct form data for the cr token use case of iam token management
+    this.formData.grant_type = 'urn:ibm:params:oauth:grant-type:cr-token';
+  }
+
+  /**
+   * Setter for the filename of the compute resource token.
+   * @param {string} scope A string containing a path to the CR token file
+   */
+  public setCrTokenFilename(crTokenFilename: string): void {
+    this.crTokenFilename = crTokenFilename;
+  }
+
+  /**
+   * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileName parameter
+   */
+  public setIamProfileName(iamProfileName: string): void {
+    this.iamProfileName = iamProfileName;
+  }
+
+  /**
+   * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileId parameter
+   */
+  public setIamProfileId(iamProfileId: string): void {
+    this.iamProfileId = iamProfileId;
+  }
+
+  /**
+   * Request an IAM token using a compute resource token.
+   *
+   * @returns {Promise}
+   */
+  protected async requestToken(): Promise<any> {
+    const crToken = getCrToken(this.crTokenFilename);
+    this.formData.cr_token = crToken;
+
+    // these member variables can be reset, set them in the form data right
+    // before making the request to ensure they're up to date
+    if (this.iamProfileName) {
+      this.formData.profile_name = this.iamProfileName;
+    }
+    if (this.iamProfileId) {
+      this.formData.profile_id = this.iamProfileId;
+    }
+
+    return super.requestToken();
+  }
+}
+
+function getCrToken(filename: string): string {
+  logger.debug(`Attempting to read CR token from file: ${filename}`);
+
+  // moving the actual read to another file to isolate usage of node-only packages like `fs`
+  return readCrTokenFile(filename);
+}

--- a/auth/token-managers/container-token-manager.ts
+++ b/auth/token-managers/container-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * Copyright 2021 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/token-managers/index.ts
+++ b/auth/token-managers/index.ts
@@ -20,18 +20,21 @@
  *
  * Identity and Access Management (IAM)
  * Cloud Pak for Data
+ * Container (IKS, etc)
  *
  * The token managers sit inside of an authenticator and do the work to retrieve
  * tokens where as the authenticators add these tokens to the actual request.
  *
  * classes:
- *   IamTokenManager: Token Manager of CloudPak for data.
- *   Cp4dTokenManager: Authenticator for passing IAM authentication information to service endpoint.
+ *   IamTokenManager: Token Manager of IAM via apikey.
+ *   Cp4dTokenManager: Token Manager of CloudPak for data.
+ *   ContainerTokenManager: Token manager of IAM via compute resource token.
  *   JwtTokenManager: A class for shared functionality for parsing, storing, and requesting JWT tokens.
  */
 
 export { IamTokenManager } from './iam-token-manager';
 export { Cp4dTokenManager } from './cp4d-token-manager';
+export { ContainerTokenManager } from './container-token-manager';
 export { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-based-token-manager';
 export { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 export { TokenManager, TokenManagerOptions } from './token-manager';

--- a/auth/utils/file-reading-helpers.browser.ts
+++ b/auth/utils/file-reading-helpers.browser.ts
@@ -2,3 +2,7 @@
 export function readCredentialsFile() {
   return {};
 }
+
+export function readCrTokenFile() {
+  return '';
+}

--- a/auth/utils/file-reading-helpers.ts
+++ b/auth/utils/file-reading-helpers.ts
@@ -77,17 +77,19 @@ export function readCrTokenFile(filepath: string): string {
   }
 
   let token: string = '';
-  if (fileExistsAtPath(filepath)) {
+  const fileExists = fileExistsAtPath(filepath);
+  if (fileExists) {
     token = fs.readFileSync(filepath, 'utf8');
     logger.debug(`Successfully read CR token from file: ${filepath}`);
-  } else {
-    logger.error(`Expected to find CR token file but the file does not exist: ${filepath}`);
-    throw new Error(`File does not exist: ${filepath}`);
   }
 
   if (token === '') {
-    logger.error(`Expected to read CR token from file but the file is empty: ${filepath}`);
-    throw new Error(`No token could be read from file: '${filepath}'`);
+    if (fileExists) {
+      logger.error(`Expected to read CR token from file but the file is empty: ${filepath}`);
+    } else {
+      logger.error(`Expected to find CR token file but the file does not exist: ${filepath}`);
+    }
+    throw new Error(`Unable to retrieve the CR token value from file: ${filepath}`);
   }
 
   return token;

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -20,6 +20,7 @@ import {
   BearerTokenAuthenticator,
   CloudPakForDataAuthenticator,
   IamAuthenticator,
+  ContainerAuthenticator,
   NoAuthAuthenticator,
 } from '../authenticators';
 
@@ -63,10 +64,12 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
     delete credentials.authDisableSsl;
   }
 
-  // default the auth type to `iam` if authType is undefined, or not a string
+  // in the situation where the auth type is not provided:
+  // if an apikey is provided, default to IAM
+  // if not, default to container auth
   let { authType } = credentials;
   if (!authType || typeof authType !== 'string') {
-    authType = 'iam';
+    authType = credentials.apikey ? 'iam' : 'container';
   }
 
   // create and return the appropriate authenticator
@@ -88,6 +91,9 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
       break;
     case 'iam':
       authenticator = new IamAuthenticator(credentials);
+      break;
+    case 'container':
+      authenticator = new ContainerAuthenticator(credentials);
       break;
     default:
       throw new Error(`Invalid value for AUTH_TYPE: ${authType}`);

--- a/auth/utils/helpers.ts
+++ b/auth/utils/helpers.ts
@@ -116,3 +116,16 @@ export function removeSuffix(str: string, suffix: string): string {
 
   return str;
 }
+
+/**
+ * Check for at least one of two elements being defined.
+ * Returns true if a or b is defined. Returns false if
+ * both are undefined.
+ *
+ * @param {any} a - The first object
+ * @param {any} b - The second object
+ * @returns {boolean}
+ */
+export function atLeastOne(a: any, b: any): boolean {
+  return Boolean(a || b);
+}

--- a/auth/utils/index.ts
+++ b/auth/utils/index.ts
@@ -24,6 +24,6 @@
  */
 
 export * from './helpers';
-export * from './read-credentials-file';
+export * from './file-reading-helpers';
 export { getAuthenticatorFromEnvironment } from './get-authenticator-from-environment';
 export { readExternalSources } from './read-external-sources';

--- a/auth/utils/read-external-sources.ts
+++ b/auth/utils/read-external-sources.ts
@@ -19,7 +19,7 @@
 import camelcase = require('camelcase');
 import isEmpty = require('lodash.isempty');
 import logger from '../../lib/logger';
-import { readCredentialsFile } from './read-credentials-file';
+import { readCredentialsFile } from './file-reading-helpers';
 
 /**
  * Read properties stored in external sources like Environment Variables,

--- a/test/resources/vault-token
+++ b/test/resources/vault-token
@@ -1,0 +1,1 @@
+my-cr-token-123

--- a/test/unit/container-authenticator.test.js
+++ b/test/unit/container-authenticator.test.js
@@ -1,0 +1,105 @@
+const { ContainerAuthenticator } = require('../../dist/auth');
+const { ContainerTokenManager } = require('../../dist/auth');
+
+// mock the `getToken` method in the token manager - dont make any rest calls
+const fakeToken = 'iam-acess-token';
+const mockedTokenManager = new ContainerTokenManager({ iamProfileName: 'some-name' });
+
+const getTokenSpy = jest
+  .spyOn(mockedTokenManager, 'getToken')
+  .mockImplementation(() => Promise.resolve(fakeToken));
+
+describe('Container Authenticator', () => {
+  const config = {
+    crTokenFilename: '/path/to/file',
+    iamProfileName: 'some-name',
+    iamProfileId: 'some-id',
+    url: 'iam.staging.com',
+    clientId: 'my-id',
+    clientSecret: 'my-secret',
+    disableSslVerification: true,
+    headers: {
+      'X-My-Header': 'some-value',
+    },
+    scope: 'A B C D',
+  };
+
+  it('should store all config options on the class', () => {
+    const authenticator = new ContainerAuthenticator(config);
+
+    expect(authenticator.crTokenFilename).toBe(config.crTokenFilename);
+    expect(authenticator.iamProfileName).toBe(config.iamProfileName);
+    expect(authenticator.iamProfileId).toBe(config.iamProfileId);
+    expect(authenticator.url).toBe(config.url);
+    expect(authenticator.clientId).toBe(config.clientId);
+    expect(authenticator.clientSecret).toBe(config.clientSecret);
+    expect(authenticator.disableSslVerification).toBe(config.disableSslVerification);
+    expect(authenticator.headers).toEqual(config.headers);
+    expect(authenticator.scope).toEqual(config.scope);
+
+    // should also create a token manager
+    expect(authenticator.tokenManager).toBeInstanceOf(ContainerTokenManager);
+  });
+
+  it('should throw an error when neither iamProfileName nor iamProfileId is provided', () => {
+    expect(() => {
+      const unused = new ContainerAuthenticator();
+    }).toThrow('At least one of `iamProfileName` or `iamProfileId` must be specified.');
+  });
+
+  it('should re-set crTokenFilename using the setter', () => {
+    const authenticator = new ContainerAuthenticator({ iamProfileName: config.iamProfileName });
+    expect(authenticator.crTokenFilename).toBeUndefined();
+    // the default is set on the token manager
+    expect(authenticator.tokenManager.crTokenFilename).toBeDefined();
+    expect(authenticator.tokenManager.crTokenFilename).not.toBe(config.crTokenFilename);
+
+    authenticator.setCrTokenFilename(config.crTokenFilename);
+    expect(authenticator.crTokenFilename).toEqual(config.crTokenFilename);
+
+    // also, verify that the underlying token manager has been updated
+    expect(authenticator.tokenManager.crTokenFilename).toEqual(config.crTokenFilename);
+  });
+
+  it('should re-set iamProfileName using the setter', () => {
+    const authenticator = new ContainerAuthenticator({ iamProfileName: 'test' });
+    expect(authenticator.iamProfileName).not.toBe(config.iamProfileName);
+    expect(authenticator.tokenManager.iamProfileName).not.toBe(config.iamProfileName);
+
+    authenticator.setIamProfileName(config.iamProfileName);
+    expect(authenticator.iamProfileName).toEqual(config.iamProfileName);
+
+    // also, verify that the underlying token manager has been updated
+    expect(authenticator.tokenManager.iamProfileName).toEqual(config.iamProfileName);
+  });
+
+  it('should re-set iamProfileId using the setter', () => {
+    const authenticator = new ContainerAuthenticator({ iamProfileName: config.iamProfileName });
+    expect(authenticator.iamProfileId).toBeUndefined();
+    expect(authenticator.tokenManager.iamProfileId).toBeUndefined();
+
+    authenticator.setIamProfileId(config.iamProfileId);
+    expect(authenticator.iamProfileId).toEqual(config.iamProfileId);
+
+    // also, verify that the underlying token manager has been updated
+    expect(authenticator.tokenManager.iamProfileId).toEqual(config.iamProfileId);
+  });
+
+  // "end to end" style test, to make sure this authenticator ingregates properly with parent classes
+  it('should update the options and resolve with `null` when `authenticate` is called', async () => {
+    const authenticator = new ContainerAuthenticator({ iamProfileName: config.iamProfileName });
+
+    // override the created token manager with the mocked one
+    authenticator.tokenManager = mockedTokenManager;
+
+    const options = { headers: { 'X-Some-Header': 'user-supplied header' } };
+    const result = await authenticator.authenticate(options);
+
+    expect(result).toBeUndefined();
+    expect(options.headers.Authorization).toBe(`Bearer ${fakeToken}`);
+    expect(getTokenSpy).toHaveBeenCalled();
+
+    // verify that the original options are kept intact
+    expect(options.headers['X-Some-Header']).toBe('user-supplied header');
+  });
+});

--- a/test/unit/container-token-manager.test.js
+++ b/test/unit/container-token-manager.test.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const { ContainerTokenManager } = require('../../dist/auth');
-let { getCrToken } = require('../../dist/auth/utils');
 const { RequestWrapper } = require('../../dist/lib/request-wrapper');
 const logger = require('../../dist/lib/logger').default;
 

--- a/test/unit/container-token-manager.test.js
+++ b/test/unit/container-token-manager.test.js
@@ -1,0 +1,128 @@
+/* eslint-disable no-alert, no-console */
+
+const path = require('path');
+const { ContainerTokenManager } = require('../../dist/auth');
+let { getCrToken } = require('../../dist/auth/utils');
+const { RequestWrapper } = require('../../dist/lib/request-wrapper');
+const logger = require('../../dist/lib/logger').default;
+
+// make sure no actual requests are sent
+jest.mock('../../dist/lib/request-wrapper');
+const sendRequestMock = jest.fn();
+RequestWrapper.mockImplementation(() => ({
+  sendRequest: sendRequestMock,
+}));
+
+const CR_TOKEN_FILENAME = '/path/to/file';
+const IAM_PROFILE_NAME = 'some-name';
+const IAM_PROFILE_ID = 'some-id';
+
+describe('Container Token Manager', () => {
+  afterAll(() => {
+    sendRequestMock.mockRestore();
+  });
+
+  describe('constructor', () => {
+    it('should throw an error neither `iamProfileId` nor `iamProfileName` are not provided', () => {
+      expect(() => new ContainerTokenManager()).toThrow(
+        'At least one of `iamProfileName` or `iamProfileId` must be specified.'
+      );
+    });
+
+    // use default filename
+    it('should use default filename if none is given', () => {
+      const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
+      expect(instance.crTokenFilename).toBe('/var/run/secrets/tokens/vault-token');
+    });
+
+    it('should set given values', () => {
+      const instance = new ContainerTokenManager({
+        crTokenFilename: CR_TOKEN_FILENAME,
+        iamProfileName: IAM_PROFILE_NAME,
+        iamProfileId: IAM_PROFILE_ID,
+      });
+
+      expect(instance.crTokenFilename).toBe(CR_TOKEN_FILENAME);
+      expect(instance.iamProfileName).toBe(IAM_PROFILE_NAME);
+      expect(instance.iamProfileId).toBe(IAM_PROFILE_ID);
+    });
+
+    it('should initialize form data', () => {
+      const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
+
+      const { formData } = instance;
+      expect(formData).toBeDefined();
+      expect(formData.grant_type).toBe('urn:ibm:params:oauth:grant-type:cr-token');
+    });
+  });
+
+  describe('setters', () => {
+    it('should set crTokenFilename with the setter', () => {
+      const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
+      expect(instance.crTokenFilename).toBe('/var/run/secrets/tokens/vault-token');
+
+      instance.setCrTokenFilename(CR_TOKEN_FILENAME);
+      expect(instance.crTokenFilename).toBe(CR_TOKEN_FILENAME);
+    });
+
+    it('should set iamProfileName with the setter', () => {
+      const instance = new ContainerTokenManager({ iamProfileName: 'test' });
+      expect(instance.iamProfileName).toBe('test');
+      expect(instance.iamProfileName).not.toBe(IAM_PROFILE_NAME);
+
+      instance.setIamProfileName(IAM_PROFILE_NAME);
+      expect(instance.iamProfileName).toBe(IAM_PROFILE_NAME);
+    });
+
+    it('should set iamProfileId with the setter', () => {
+      const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
+      expect(instance.iamProfileId).toBeUndefined();
+
+      instance.setIamProfileId(IAM_PROFILE_ID);
+      expect(instance.iamProfileId).toBe(IAM_PROFILE_ID);
+    });
+  });
+
+  describe('requestToken', () => {
+    const pathToTestToken = path.join(__dirname, '/../resources/vault-token');
+
+    it('should add all form data, including the cr token read from a file', async () => {
+      jest.spyOn(logger, 'debug').mockImplementation(() => {});
+
+      const instance = new ContainerTokenManager({
+        crTokenFilename: pathToTestToken,
+        iamProfileName: IAM_PROFILE_NAME,
+      });
+
+      await instance.requestToken();
+
+      expect(instance.formData.profile_name).toBe(IAM_PROFILE_NAME);
+      expect(instance.formData.profile_id).toBeUndefined(); // should not be set if not present
+      expect(instance.formData.cr_token).toBe('my-cr-token-123');
+
+      // expect file reading utils and logger to both be called
+      expect(logger.debug).toHaveBeenCalledWith(
+        `Attempting to read CR token from file: ${pathToTestToken}`
+      );
+    });
+
+    it('should not add iamProfileName to form data if not set', async () => {
+      // the inverse of this test is tested above
+      const firstValue = 'test';
+
+      const instance = new ContainerTokenManager({
+        crTokenFilename: pathToTestToken,
+        iamProfileId: firstValue,
+      });
+
+      // verify that form data is set from constructor or setters
+      instance.setIamProfileId(IAM_PROFILE_ID);
+
+      await instance.requestToken();
+
+      expect(instance.formData.profile_name).toBeUndefined();
+      expect(instance.formData.profile_id).toBe(IAM_PROFILE_ID);
+      expect(instance.formData.profile_id).not.toBe(firstValue);
+    });
+  });
+});

--- a/test/unit/file-reading-helpers.test.js
+++ b/test/unit/file-reading-helpers.test.js
@@ -150,7 +150,7 @@ describe('Read CR Token File', () => {
     const filename = '/path/to/nowhere/';
     expect(() => {
       const token = readCrTokenFile(filename);
-    }).toThrow(`File does not exist: ${filename}`);
+    }).toThrow(`Unable to retrieve the CR token value from file: ${filename}`);
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
       `Expected to find CR token file but the file does not exist: ${filename}`
@@ -161,7 +161,7 @@ describe('Read CR Token File', () => {
     const filename = `${__dirname}/../resources/empty-file`;
     expect(() => {
       const token = readCrTokenFile(filename);
-    }).toThrow(`No token could be read from file: '${filename}'`);
+    }).toThrow(`Unable to retrieve the CR token value from file: ${filename}`);
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
       `Expected to read CR token from file but the file is empty: ${filename}`

--- a/test/unit/iam-authenticator.test.js
+++ b/test/unit/iam-authenticator.test.js
@@ -43,7 +43,7 @@ describe('IAM Authenticator', () => {
     }).toThrow();
   });
 
-  it('should throw an error when username has a bad character', () => {
+  it('should throw an error when apikey has a bad character', () => {
     expect(() => {
       const unused = new IamAuthenticator({ apikey: '"<your-apikey>"' });
     }).toThrow(/Revise these credentials/);

--- a/test/unit/iam-authenticator.test.js
+++ b/test/unit/iam-authenticator.test.js
@@ -49,7 +49,7 @@ describe('IAM Authenticator', () => {
     }).toThrow(/Revise these credentials/);
   });
 
-  it('should update the options and resolve with `null`', async (done) => {
+  it('should update the options and resolve with `null` when `authenticate` is called', async () => {
     const authenticator = new IamAuthenticator({ apikey: 'testjustanapikey' });
 
     // override the created token manager with the mocked one
@@ -67,7 +67,6 @@ describe('IAM Authenticator', () => {
     // verify the scope param wasn't set
     expect(authenticator.scope).toBeUndefined();
     expect(authenticator.tokenManager.scope).toBeUndefined();
-    done();
   });
 
   it('should re-set the client id and secret using the setter', () => {

--- a/test/unit/iam-request-based-authenticator.test.js
+++ b/test/unit/iam-request-based-authenticator.test.js
@@ -1,0 +1,56 @@
+const { IamRequestBasedAuthenticator, IamRequestBasedTokenManager } = require('../../dist/auth');
+
+const SCOPE = 'some-scope';
+const CLIENT_ID = 'some-id';
+const CLIENT_SECRET = 'some-secret';
+
+describe('IAM Request Based Authenticator', () => {
+  describe('constructor', () => {
+    it('should store all config options on the class', () => {
+      const authenticator = new IamRequestBasedAuthenticator({
+        scope: SCOPE,
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+      });
+
+      expect(authenticator.clientId).toBe(CLIENT_ID);
+      expect(authenticator.clientSecret).toBe(CLIENT_SECRET);
+      expect(authenticator.scope).toEqual(SCOPE);
+
+      // should also create a token manager
+      expect(authenticator.tokenManager).toBeInstanceOf(IamRequestBasedTokenManager);
+    });
+  });
+
+  describe('setters', () => {
+    it('should re-set the scope using the setter', () => {
+      const authenticator = new IamRequestBasedAuthenticator();
+      expect(authenticator.scope).toBeUndefined();
+
+      expect(authenticator.tokenManager.scope).toBeUndefined();
+
+      authenticator.setScope(SCOPE);
+      expect(authenticator.scope).toEqual(SCOPE);
+
+      // also, verify that the underlying token manager has been updated
+      expect(authenticator.tokenManager.scope).toEqual(SCOPE);
+    });
+
+    it('should re-set the client id and secret using the setter', () => {
+      const authenticator = new IamRequestBasedAuthenticator();
+      expect(authenticator.clientId).toBeUndefined();
+      expect(authenticator.clientSecret).toBeUndefined();
+
+      expect(authenticator.tokenManager.clientId).toBeUndefined();
+      expect(authenticator.tokenManager.clientSecret).toBeUndefined();
+
+      authenticator.setClientIdAndSecret(CLIENT_ID, CLIENT_SECRET);
+      expect(authenticator.clientId).toEqual(CLIENT_ID);
+      expect(authenticator.clientSecret).toEqual(CLIENT_SECRET);
+
+      // also, verify that the underlying token manager has been updated
+      expect(authenticator.tokenManager.clientId).toEqual(CLIENT_ID);
+      expect(authenticator.tokenManager.clientSecret).toEqual(CLIENT_SECRET);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds an authenticator and token manager for the new "container" flavor of authentication. This style retrieves a compute resource token from the file system and uses that to retrieve an IAM access token, which is used to authenticate with the service.

Note: I realized that I refactored the IAM token manager but not the authenticator. It really should be both, so as part of this PR I refactored the authenticator to match the refactoring in the token manager.