### PR TITLE
feat: add method `getHttpClient` to get underlying axios instance of base service

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-13T17:45:41Z",
+  "generated_at": "2021-08-17T20:14:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -522,7 +522,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.43.dss",
+  "version": "0.13.1+ibm.40.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -163,6 +163,14 @@ export class BaseService {
   }
 
   /**
+   * Get the Axios instance set on the service.
+   * All requests will be made using this instance.
+   */
+  public getHttpClient() {
+    return this.requestWrapperInstance.getHttpClient();
+  }
+
+  /**
    * Configure the service using external configuration
    *
    * @param {string} serviceName The name of the service. Will be used to read from external

--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -342,6 +342,10 @@ export class RequestWrapper {
     return error;
   }
 
+  public getHttpClient() {
+    return this.axiosInstance;
+  }
+
   private async gzipRequestBody(data: any, headers: OutgoingHttpHeaders): Promise<Buffer | any> {
     // skip compression if user has set the encoding header to gzip
     const contentSetToGzip =

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -11,9 +11,11 @@ const requestWrapperLocation = '../../dist/lib/request-wrapper';
 jest.mock(requestWrapperLocation);
 const { RequestWrapper } = require(requestWrapperLocation);
 const sendRequestMock = jest.fn();
+const getHttpClientMock = jest.fn().mockImplementation(() => 'axios');
 
 RequestWrapper.mockImplementation(() => ({
   sendRequest: sendRequestMock,
+  getHttpClient: getHttpClientMock,
 }));
 
 // mock the authenticator
@@ -48,6 +50,7 @@ describe('Base Service', () => {
   afterEach(() => {
     // clear and the metadata attached to the mocks
     sendRequestMock.mockClear();
+    getHttpClientMock.mockClear();
     RequestWrapper.mockClear();
     // also, reset the implementation of the readExternalSourcesMock
     readExternalSourcesMock.mockReset();
@@ -127,6 +130,18 @@ describe('Base Service', () => {
     });
 
     expect(testService.getAuthenticator()).toEqual(AUTHENTICATOR);
+  });
+
+  it('should return the stored, underlying axios instance with getHttpClient', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+    });
+
+    const httpClient = testService.getHttpClient();
+
+    // the request wrapper instance is mocked to return the literal string 'axios'
+    expect(httpClient).toEqual('axios');
+    expect(getHttpClientMock).toHaveBeenCalled();
   });
 
   it('should store disableSslVerification when set', () => {

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -786,6 +786,13 @@ describe('formatError', () => {
   });
 });
 
+describe('getHttpClient', () => {
+  it('should return the axios instance', () => {
+    const client = requestWrapperInstance.getHttpClient();
+    expect(client).toEqual(mockAxiosInstance);
+  });
+});
+
 describe('gzipRequestBody', () => {
   const gzipSpy = jest.spyOn(zlib, 'gzipSync');
   const errorLogSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});


### PR DESCRIPTION
This new method is added to the base service class so that all initialized SDK client objects
have access to the underlying axios instance used to make requests. This instance is currently
hidden as a private class member. This functionality is already supported in the other language
cores, so this brings feature parity