### PR TITLE
build: add 'npm run all' command to simplify project builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,15 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -988,9 +997,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
-      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.7.0.tgz",
+      "integrity": "sha512-diY0qMPyQjfu4rDu3kDhJ9qIZadIm4IISO3RJSv9ajYUWJUCO0AykbgzLcg1xclxtXgzY583u3gAv66M6zz5SA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.6.0",
@@ -1020,19 +1029,19 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.7.0.tgz",
-      "integrity": "sha512-G7sgccWRYQMwcHJXkDY/sDxbXeKiZkFQqUtzBCwmrzCNj2GQf3VygQ4T/BFL2crLVpIbenkE/c0ErhYOte2MPw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.8.0.tgz",
+      "integrity": "sha512-qeLZZLotNkoq+it6F+xahydkkbnvSK0iDjlXFo3jNTB+Ss0qIbYQb9V/soKLMkgGw8Q2sHjY5YEXiA47IVPp4A==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.24.0",
+        "@octokit/types": "^6.25.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
-      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
+      "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
@@ -1063,15 +1072,15 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.9.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.0.tgz",
-      "integrity": "sha512-VrmrE8gjpuOoDAGjrQq2j9ZhOE6LxaqxaQg0yMrrEnnQZy2ZcAnr5qbVfKsMF0up/48PRV/VFS/2GSMhA7nTdA==",
+      "version": "18.9.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.1.tgz",
+      "integrity": "sha512-idZ3e5PqXVWOhtZYUa546IDHTHjkGZbj3tcJsN0uhCy984KD865e8GB2WbYDc2ZxFuJRiyd0AftpL2uPNhF+UA==",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.5.0",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.7.0"
+        "@octokit/plugin-rest-endpoint-methods": "5.8.0"
       }
     },
     "@octokit/types": {
@@ -1412,6 +1421,12 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -1471,13 +1486,13 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
+      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.30.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -1497,55 +1512,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-      "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
+      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1565,12 +1580,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/types": "4.30.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -2017,16 +2032,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       }
     },
     "bser": {
@@ -2115,9 +2130,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true
     },
     "capture-exit": {
@@ -2414,9 +2429,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -2820,9 +2835,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-      "integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==",
+      "version": "1.3.822",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
+      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
       "dev": true
     },
     "emittery": {
@@ -3118,9 +3133,9 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
-      "integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -3193,26 +3208,26 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
-      "integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+      "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.5",
+        "eslint-import-resolver-node": "^0.3.6",
         "eslint-module-utils": "^2.6.2",
         "find-up": "^2.0.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.4.0",
+        "is-core-module": "^2.6.0",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.3",
+        "object.values": "^1.1.4",
         "pkg-up": "^2.0.0",
         "read-pkg-up": "^3.0.0",
         "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.9.0"
+        "tsconfig-paths": "^3.11.0"
       },
       "dependencies": {
         "debug": {
@@ -3419,9 +3434,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -3751,9 +3766,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3835,9 +3850,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4106,9 +4121,9 @@
       }
     },
     "globals": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4485,10 +4500,13 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.3.tgz",
-      "integrity": "sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-boolean-object": {
       "version": "1.1.2",
@@ -4522,9 +4540,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -5524,12 +5542,12 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
@@ -6026,9 +6044,9 @@
       }
     },
     "nock": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.2.tgz",
-      "integrity": "sha512-BDjokoeGZnBghmvwCcDJ1yM5TDRMRAJfGi1xIzX5rKTlifbyx1oRpAVl3aNhEA3kGbUSEPD7gBLmwVdnQibrIA==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.3.tgz",
+      "integrity": "sha512-YKj0rKQWMGiiIO+Y65Ut8OEgYM3PplLU2+GAhnPmqZdBd6z5IskgdBqWmjzA6lH3RF0S2a3wiAlrMOF5Iv2Jeg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -6099,19 +6117,19 @@
       }
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "normalize-package-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
+        "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
@@ -6140,35 +6158,35 @@
       "dev": true
     },
     "npm": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.20.5.tgz",
-      "integrity": "sha512-vRyu1V79n5BzKn4vkanag1xEjEMLIZ48Ry1V7IyAvHQHi8syOEiYWvUMxNpeDk+e8JKAKCNG3lIYJDm3pM8VMQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.21.1.tgz",
+      "integrity": "sha512-k7XQNHGHAp0VowMMUMRMtntxWatNad9hhYrelUKDPvZ++DBxvofA8QTNPiuMKtx8CBOFA8iJ4aizhbx6ZYVfzQ==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "^2.8.0",
+        "@npmcli/arborist": "^2.8.2",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^2.2.0",
+        "@npmcli/map-workspaces": "^1.0.4",
         "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.5",
+        "@npmcli/run-script": "^1.8.6",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
+        "cacache": "^15.3.0",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
+        "fastest-levenshtein": "^1.0.12",
         "glob": "^7.1.7",
         "graceful-fs": "^4.2.8",
         "hosted-git-info": "^4.0.2",
         "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
+        "init-package-json": "^2.0.4",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
         "libnpmaccess": "^4.0.2",
         "libnpmdiff": "^2.0.4",
         "libnpmexec": "^2.0.1",
@@ -6180,7 +6198,7 @@
         "libnpmsearch": "^3.1.1",
         "libnpmteam": "^2.0.3",
         "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.4",
+        "make-fetch-happen": "^9.1.0",
         "minipass": "^3.1.3",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -6200,13 +6218,13 @@
         "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
+        "read-package-json": "^4.0.1",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar": "^6.1.6",
+        "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^1.0.4",
@@ -6215,8 +6233,13 @@
         "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
+        "@gar/promisify": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/arborist": {
-          "version": "2.8.0",
+          "version": "2.8.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6249,7 +6272,6 @@
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
             "ssri": "^8.0.1",
-            "tar": "^6.1.0",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
           }
@@ -6279,6 +6301,15 @@
             "ansi-styles": "^4.3.0"
           }
         },
+        "@npmcli/fs": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.0.1",
+            "semver": "^7.3.5"
+          }
+        },
         "@npmcli/git": {
           "version": "2.1.0",
           "bundled": true,
@@ -6304,7 +6335,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6360,13 +6391,12 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.5",
+          "version": "1.8.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "infer-owner": "^1.0.4",
             "node-gyp": "^7.1.0",
             "read-package-json-fast": "^2.0.1"
           }
@@ -6539,16 +6569,12 @@
           "bundled": true,
           "dev": true
         },
-        "byte-size": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "cacache": {
-          "version": "15.2.0",
+          "version": "15.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/fs": "^1.0.0",
             "@npmcli/move-file": "^1.0.1",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -6846,6 +6872,11 @@
           "bundled": true,
           "dev": true
         },
+        "fastest-levenshtein": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
@@ -7045,7 +7076,7 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7053,7 +7084,7 @@
             "npm-package-arg": "^8.1.2",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "^3.0.1",
+            "read-package-json": "^4.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
@@ -7078,7 +7109,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.5.0",
+          "version": "2.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7168,11 +7199,6 @@
         },
         "just-diff-apply": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "leven": {
-          "version": "3.1.0",
           "bundled": true,
           "dev": true
         },
@@ -7306,7 +7332,7 @@
           }
         },
         "make-fetch-happen": {
-          "version": "9.0.4",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7324,7 +7350,7 @@
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.2",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^5.0.0",
+            "socks-proxy-agent": "^6.0.0",
             "ssri": "^8.0.0"
           }
         },
@@ -7525,12 +7551,12 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -7710,11 +7736,6 @@
           "bundled": true,
           "dev": true
         },
-        "path-parse": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
         "performance-now": {
           "version": "2.1.0",
           "bundled": true,
@@ -7796,7 +7817,7 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "3.0.1",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7888,15 +7909,6 @@
             }
           }
         },
-        "resolve": {
-          "version": "1.20.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -7939,7 +7951,7 @@
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
@@ -7953,13 +7965,13 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4",
-            "socks": "^2.3.3"
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
@@ -7986,7 +7998,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.9",
+          "version": "3.0.10",
           "bundled": true,
           "dev": true
         },
@@ -8068,7 +8080,7 @@
           }
         },
         "tar": {
-          "version": "6.1.6",
+          "version": "6.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10325,20 +10337,21 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==",
+          "version": "12.20.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.21.tgz",
+          "integrity": "sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==",
           "dev": true
         }
       }
     },
     "tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "requires": {
-        "json5": "^2.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       }
@@ -10763,9 +10776,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "test-travis": "jest --runInBand test/unit/",
     "report-coverage": "codecov",
     "build": "tsc",
-    "postversion": "tsc-publish --no-checks --dry-run"
+    "postversion": "tsc-publish --no-checks --dry-run",
+    "all": "npm run build && npm run test && npm run lint"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
This PR makes a simple change to package.json to add the "all" script (e.g. `npm run all`) which will build, unit test and lint-check the project.