### PR TITLE
perf: use maxContentLength -1 instead of Infinity

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -70,7 +70,7 @@ export class RequestWrapper {
     // to 'application/x-www-form-urlencoded'. This causes problems, so overriding the
     // defaults here
     const axiosConfig: AxiosRequestConfig = {
-      maxContentLength: Infinity,
+      maxContentLength: -1,
       maxBodyLength: Infinity,
       headers: {
         post: {

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -70,7 +70,7 @@ describe('RequestWrapper constructor', () => {
     // the constructor puts together a config object and creates the
     // axios instance with it
     const createdAxiosConfig = axios.default.create.mock.calls[0][0];
-    expect(createdAxiosConfig.maxContentLength).toBe(Infinity);
+    expect(createdAxiosConfig.maxContentLength).toBe(-1);
     expect(createdAxiosConfig.maxBodyLength).toBe(Infinity);
     expect(createdAxiosConfig.headers).toBeDefined();
     expect(createdAxiosConfig.headers.post).toBeDefined();


### PR DESCRIPTION
I stumbled across https://github.com/axios/axios/issues/2829 when investigating a performance issue in our SDK that extends the core. The performance issue described in that issue can be avoided by using `-1` instead of `Infinity` to set a preference for having no `maxContentLength`.

Since the purpose of `Infinity` here is to have no limit, using `-1` should make no difference to the expected behaviour, but it does avoid the performance problem (at least until such time as axios have a fix for it). In the profiling of my particular scenario having `maxContentLength` enabled was causing 25% of all ticks to be spent in `Buffer` `concat` which was having a dramatic performance impact.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included - updated default value test
- [ ] documentation is changed or added
