### PR TITLE
build: avoid ansi-regex vuln alerts

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,0 +1,6 @@
+[
+    {
+        "cve": "CVE-2021-3807",
+        "alwaysOmit": true
+    }
+]


### PR DESCRIPTION
This PR configures the CRA scan to avoid  the ansi-regex vulnerability alert.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
