### PR TITLE
feat: add authenticationType method to authenticators

### DIFF
--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -45,4 +45,9 @@ export interface AuthenticatorInterface {
    *   authentication information will be added to.
    */
   authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+
+  /**
+   * Returns a string that indicates the authentication type.
+   */
+  authenticationType(): string;
 }

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -24,6 +24,23 @@ import { AuthenticateOptions, AuthenticatorInterface } from './authenticator-int
  */
 export class Authenticator implements AuthenticatorInterface {
   /**
+   * Constants that define the various authenticator types.
+   */
+  static AUTHTYPE_BASIC = 'basic';
+
+  static AUTHTYPE_BEARERTOKEN = 'bearertoken';
+
+  static AUTHTYPE_IAM = 'iam';
+
+  static AUTHTYPE_CONTAINER = 'container';
+
+  static AUTHTYPE_CP4D = 'cp4d';
+
+  static AUTHTYPE_NOAUTH = 'noauth';
+
+  static AUTHTYPE_UNKNOWN = 'unknown';
+
+  /**
    * Create a new Authenticator instance.
    *
    * @throws {Error} The `new` keyword was not used to create construct the
@@ -47,5 +64,20 @@ export class Authenticator implements AuthenticatorInterface {
   public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
     const error = new Error('Should be implemented by subclass!');
     return Promise.reject(error);
+  }
+
+  /**
+   * Retrieves the authenticator's type.
+   * The returned value will be the same string that is used
+   * when configuring an instance of the authenticator with the
+   * "<service_name>_AUTH_TYPE" configuration property
+   * (e.g. "basic", "iam", etc.).
+   * This function should be overridden in each authenticator
+   * implementation class that extends this class.
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_UNKNOWN;
   }
 }

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -75,4 +75,14 @@ export class BasicAuthenticator extends Authenticator {
       resolve();
     });
   }
+
+  /**
+   * Returns the authenticator's type ('basic').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_BASIC;
+  }
 }

--- a/auth/authenticators/bearer-token-authenticator.ts
+++ b/auth/authenticators/bearer-token-authenticator.ts
@@ -82,4 +82,14 @@ export class BearerTokenAuthenticator extends Authenticator {
       resolve();
     });
   }
+
+  /**
+   * Returns the authenticator's type ('bearertoken').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_BEARERTOKEN;
+  }
 }

--- a/auth/authenticators/cloud-pak-for-data-authenticator.ts
+++ b/auth/authenticators/cloud-pak-for-data-authenticator.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Authenticator } from './authenticator';
 import { Cp4dTokenManager } from '../token-managers';
 import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
 
@@ -74,5 +75,15 @@ export class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
     // manager so we can just pass along the options object.
     // also, the token manager will handle input validation
     this.tokenManager = new Cp4dTokenManager(options);
+  }
+
+  /**
+   * Returns the authenticator's type ('cp4d').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_CP4D;
   }
 }

--- a/auth/authenticators/container-authenticator.ts
+++ b/auth/authenticators/container-authenticator.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Authenticator } from './authenticator';
 import { ContainerTokenManager } from '../token-managers';
 import { IamRequestOptions, IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
 
@@ -112,5 +113,15 @@ export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
 
     // update properties in token manager
     this.tokenManager.setIamProfileId(iamProfileId);
+  }
+
+  /**
+   * Returns the authenticator's type ('container').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_CONTAINER;
   }
 }

--- a/auth/authenticators/iam-authenticator.ts
+++ b/auth/authenticators/iam-authenticator.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Authenticator } from './authenticator';
 import { IamTokenManager } from '../token-managers';
 import { validateInput } from '../utils';
 import { IamRequestOptions, IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
@@ -81,5 +82,15 @@ export class IamAuthenticator extends IamRequestBasedAuthenticator {
    */
   public getRefreshToken(): string {
     return this.tokenManager.getRefreshToken();
+  }
+
+  /**
+   * Returns the authenticator's type ('iam').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_IAM;
   }
 }

--- a/auth/authenticators/no-auth-authenticator.ts
+++ b/auth/authenticators/no-auth-authenticator.ts
@@ -29,4 +29,13 @@ export class NoAuthAuthenticator extends Authenticator {
     // immediately proceed to request. it will probably fail
     return Promise.resolve();
   }
+
+  /**
+   * Returns the authenticator's type ('noauth').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_NOAUTH;
+  }
 }

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -82,22 +82,22 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
 
   // fold authType to lower case for case insensitivity
   switch (authType.toLowerCase()) {
-    case 'noauth':
+    case Authenticator.AUTHTYPE_NOAUTH:
       authenticator = new NoAuthAuthenticator();
       break;
-    case 'basic':
+    case Authenticator.AUTHTYPE_BASIC:
       authenticator = new BasicAuthenticator(credentials);
       break;
-    case 'bearertoken':
+    case Authenticator.AUTHTYPE_BEARERTOKEN:
       authenticator = new BearerTokenAuthenticator(credentials);
       break;
-    case 'cp4d':
+    case Authenticator.AUTHTYPE_CP4D:
       authenticator = new CloudPakForDataAuthenticator(credentials);
       break;
-    case 'iam':
+    case Authenticator.AUTHTYPE_IAM:
       authenticator = new IamAuthenticator(credentials);
       break;
-    case 'container':
+    case Authenticator.AUTHTYPE_CONTAINER:
       authenticator = new ContainerAuthenticator(credentials);
       break;
     default:

--- a/test/unit/basic-authenticator.test.js
+++ b/test/unit/basic-authenticator.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { BasicAuthenticator } = require('../../dist/auth');
+const { Authenticator, BasicAuthenticator } = require('../../dist/auth');
 
 const USERNAME = 'dave';
 const PASSWORD = 'grohl';
@@ -26,6 +26,7 @@ const CONFIG = {
 describe('Basic Authenticator', () => {
   it('should store the username and password on the class', () => {
     const authenticator = new BasicAuthenticator(CONFIG);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_BASIC);
     expect(authenticator.authHeader).toEqual({
       Authorization: 'Basic ZGF2ZTpncm9obA==',
     });

--- a/test/unit/bearer-token-authenticator.test.js
+++ b/test/unit/bearer-token-authenticator.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { BearerTokenAuthenticator } = require('../../dist/auth');
+const { Authenticator, BearerTokenAuthenticator } = require('../../dist/auth');
 
 describe('Bearer Token Authenticator', () => {
   const config = {
@@ -24,6 +24,7 @@ describe('Bearer Token Authenticator', () => {
   it('should store the bearer token on the class', () => {
     const authenticator = new BearerTokenAuthenticator(config);
 
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_BEARERTOKEN);
     expect(authenticator.bearerToken).toBe(config.bearerToken);
   });
 

--- a/test/unit/container-authenticator.test.js
+++ b/test/unit/container-authenticator.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { ContainerAuthenticator } = require('../../dist/auth');
+const { Authenticator, ContainerAuthenticator } = require('../../dist/auth');
 const { ContainerTokenManager } = require('../../dist/auth');
 
 // mock the `getToken` method in the token manager - dont make any rest calls
@@ -43,6 +43,7 @@ describe('Container Authenticator', () => {
   it('should store all config options on the class', () => {
     const authenticator = new ContainerAuthenticator(config);
 
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CONTAINER);
     expect(authenticator.crTokenFilename).toBe(config.crTokenFilename);
     expect(authenticator.iamProfileName).toBe(config.iamProfileName);
     expect(authenticator.iamProfileId).toBe(config.iamProfileId);

--- a/test/unit/cp4d-authenticator.test.js
+++ b/test/unit/cp4d-authenticator.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { CloudPakForDataAuthenticator } = require('../../dist/auth');
+const { Authenticator, CloudPakForDataAuthenticator } = require('../../dist/auth');
 const { Cp4dTokenManager } = require('../../dist/auth');
 
 const USERNAME = 'danmullen';
@@ -46,6 +46,7 @@ const getTokenSpy = jest
 describe('CP4D Authenticator', () => {
   it('should store all CONFIG options on the class', () => {
     const authenticator = new CloudPakForDataAuthenticator(CONFIG);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CP4D);
     expect(authenticator.username).toBe(CONFIG.username);
     expect(authenticator.password).toBe(CONFIG.password);
     expect(authenticator.url).toBe(CONFIG.url);

--- a/test/unit/get-authenticator-from-environment.test.js
+++ b/test/unit/get-authenticator-from-environment.test.js
@@ -16,6 +16,7 @@
 
 const {
   getAuthenticatorFromEnvironment,
+  Authenticator,
   BasicAuthenticator,
   BearerTokenAuthenticator,
   CloudPakForDataAuthenticator,
@@ -53,6 +54,7 @@ describe('Get Authenticator From Environment Module', () => {
     setUpNoAuthPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(NoAuthAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_NOAUTH);
     expect(readExternalSourcesMock).toHaveBeenCalled();
   });
 
@@ -60,36 +62,42 @@ describe('Get Authenticator From Environment Module', () => {
     setUpBasicPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(BasicAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_BASIC);
   });
 
   it('should get bearer token authenticator', () => {
     setUpBearerTokenPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(BearerTokenAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_BEARERTOKEN);
   });
 
   it('should get iam authenticator', () => {
     setUpIamPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_IAM);
   });
 
   it('should get cp4d authenticator', () => {
     setUpCp4dPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CP4D);
   });
 
   it('should get container authenticator', () => {
     setUpContainerPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(ContainerAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CONTAINER);
   });
 
   it('should throw away service properties and use auth properties', () => {
     setUpAuthPropsPayload();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_IAM);
     expect(authenticator.apikey).toBe(APIKEY);
     expect(authenticator.disableSslVerification).toBe(true);
     expect(authenticator.url).toBe(TOKEN_URL);
@@ -99,6 +107,7 @@ describe('Get Authenticator From Environment Module', () => {
     readExternalSourcesMock.mockImplementation(() => ({ iamProfileName: IAM_PROFILE_NAME }));
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(ContainerAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CONTAINER);
     expect(authenticator.iamProfileName).toBe(IAM_PROFILE_NAME);
   });
 
@@ -106,6 +115,7 @@ describe('Get Authenticator From Environment Module', () => {
     readExternalSourcesMock.mockImplementation(() => ({ apikey: APIKEY }));
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_IAM);
     expect(authenticator.apikey).toBe(APIKEY);
   });
 
@@ -120,6 +130,7 @@ describe('Get Authenticator From Environment Module', () => {
     setUpIamPayloadWithScope();
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_IAM);
     expect(authenticator.scope).toBe('jon snow');
   });
 });

--- a/test/unit/iam-authenticator.test.js
+++ b/test/unit/iam-authenticator.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { IamAuthenticator } = require('../../dist/auth');
+const { Authenticator, IamAuthenticator } = require('../../dist/auth');
 const { IamTokenManager } = require('../../dist/auth');
 
 // mock the `getToken` method in the token manager - dont make any rest calls
@@ -41,6 +41,7 @@ describe('IAM Authenticator', () => {
   it('should store all config options on the class', () => {
     const authenticator = new IamAuthenticator(config);
 
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_IAM);
     expect(authenticator.apikey).toBe(config.apikey);
     expect(authenticator.url).toBe(config.url);
     expect(authenticator.clientId).toBe(config.clientId);

--- a/test/unit/no-auth-authenticator.test.js
+++ b/test/unit/no-auth-authenticator.test.js
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-const { NoAuthAuthenticator } = require('../../dist/auth');
+const { Authenticator, NoAuthAuthenticator } = require('../../dist/auth');
 
 describe('NoAuth Authenticator', () => {
   it('should resolve Promise on authenticate', async () => {
     const authenticator = new NoAuthAuthenticator();
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_NOAUTH);
     const result = await authenticator.authenticate({});
 
     expect(result).toBeUndefined();


### PR DESCRIPTION
This commit adds a new method ('authenticationType') to
the Authenticator base class, AuthenticatorInterface,
and each authenticator implementation (subclasses of
Authenticator).
The function will return a string indicating the
authenticator type ('basic', 'iam', etc.).
This brings the node core in line with the Go and Jave
cores where the authenticators already support a similar
method.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
