### PR TITLE
fix: use correct authenticator type constants

### DIFF
--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -28,7 +28,7 @@ export class Authenticator implements AuthenticatorInterface {
    */
   static AUTHTYPE_BASIC = 'basic';
 
-  static AUTHTYPE_BEARERTOKEN = 'bearertoken';
+  static AUTHTYPE_BEARERTOKEN = 'bearerToken';
 
   static AUTHTYPE_IAM = 'iam';
 
@@ -36,7 +36,7 @@ export class Authenticator implements AuthenticatorInterface {
 
   static AUTHTYPE_CP4D = 'cp4d';
 
-  static AUTHTYPE_NOAUTH = 'noauth';
+  static AUTHTYPE_NOAUTH = 'noAuth';
 
   static AUTHTYPE_UNKNOWN = 'unknown';
 

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -74,34 +74,29 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
     authType = credentials.authtype;
   }
   if (!authType || typeof authType !== 'string') {
-    authType = credentials.apikey ? 'iam' : 'container';
+    authType = credentials.apikey ? Authenticator.AUTHTYPE_IAM : Authenticator.AUTHTYPE_CONTAINER;
   }
 
-  // create and return the appropriate authenticator
+  // Create and return the appropriate authenticator.
   let authenticator;
 
-  // fold authType to lower case for case insensitivity
-  switch (authType.toLowerCase()) {
-    case Authenticator.AUTHTYPE_NOAUTH:
-      authenticator = new NoAuthAuthenticator();
-      break;
-    case Authenticator.AUTHTYPE_BASIC:
-      authenticator = new BasicAuthenticator(credentials);
-      break;
-    case Authenticator.AUTHTYPE_BEARERTOKEN:
-      authenticator = new BearerTokenAuthenticator(credentials);
-      break;
-    case Authenticator.AUTHTYPE_CP4D:
-      authenticator = new CloudPakForDataAuthenticator(credentials);
-      break;
-    case Authenticator.AUTHTYPE_IAM:
-      authenticator = new IamAuthenticator(credentials);
-      break;
-    case Authenticator.AUTHTYPE_CONTAINER:
-      authenticator = new ContainerAuthenticator(credentials);
-      break;
-    default:
-      throw new Error(`Invalid value for AUTH_TYPE: ${authType}`);
+  // Compare the authType against our constants case-insensitively to
+  // determine which authenticator type needs to be constructed.
+  authType = authType.toLowerCase();
+  if (authType === Authenticator.AUTHTYPE_NOAUTH.toLowerCase()) {
+    authenticator = new NoAuthAuthenticator();
+  } else if (authType === Authenticator.AUTHTYPE_BASIC.toLowerCase()) {
+    authenticator = new BasicAuthenticator(credentials);
+  } else if (authType === Authenticator.AUTHTYPE_BEARERTOKEN.toLowerCase()) {
+    authenticator = new BearerTokenAuthenticator(credentials);
+  } else if (authType === Authenticator.AUTHTYPE_CP4D.toLowerCase()) {
+    authenticator = new CloudPakForDataAuthenticator(credentials);
+  } else if (authType === Authenticator.AUTHTYPE_IAM.toLowerCase()) {
+    authenticator = new IamAuthenticator(credentials);
+  } else if (authType === Authenticator.AUTHTYPE_CONTAINER.toLowerCase()) {
+    authenticator = new ContainerAuthenticator(credentials);
+  } else {
+    throw new Error(`Invalid value for AUTH_TYPE: ${authType}`);
   }
 
   return authenticator;

--- a/test/unit/get-authenticator-from-environment.test.js
+++ b/test/unit/get-authenticator-from-environment.test.js
@@ -144,7 +144,7 @@ function setUpNoAuthPayload() {
 
 function setUpBasicPayload() {
   readExternalSourcesMock.mockImplementation(() => ({
-    authtype: 'basic',
+    authtype: 'bAsIC',
     username: 'a',
     password: 'b',
   }));
@@ -152,7 +152,7 @@ function setUpBasicPayload() {
 
 function setUpBearerTokenPayload() {
   readExternalSourcesMock.mockImplementation(() => ({
-    authType: 'bearerToken',
+    authType: 'BeaRerToken',
     bearerToken: 'a',
   }));
 }
@@ -174,7 +174,7 @@ function setUpIamPayloadWithScope() {
 
 function setUpCp4dPayload() {
   readExternalSourcesMock.mockImplementation(() => ({
-    authtype: 'cp4d',
+    authtype: 'cP4d',
     username: 'a',
     password: 'b',
     authUrl: TOKEN_URL,
@@ -193,7 +193,7 @@ function setUpAuthPropsPayload() {
 
 function setUpContainerPayload() {
   readExternalSourcesMock.mockImplementation(() => ({
-    authType: 'container',
+    authType: 'conTAINer',
     crTokenFilename: '/path/to/file',
     iamProfileName: IAM_PROFILE_NAME,
     iamProfileId: 'some-id',


### PR DESCRIPTION
This PR corrects a couple of authtype constants that were introduced in the previous PR to be aligned with the rest of the core libraries.

##### Checklist

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
