### PR TITLE
feat(VpcInstanceAuthenticator): add support for new VPC authentication flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-20T22:02:49Z",
+  "generated_at": "2021-10-21T17:16:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-20T21:45:37Z",
+  "generated_at": "2021-10-20T22:02:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -78,7 +78,7 @@
         "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
+        "line_number": 418,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 456,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -276,7 +276,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 49,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-21T17:16:33Z",
+  "generated_at": "2021-10-27T20:42:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -78,7 +78,7 @@
         "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 430,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 456,
+        "line_number": 468,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Authentication.md
+++ b/Authentication.md
@@ -382,7 +382,7 @@ const service = new ExampleServiceV1(options);
 External configuration:
 ```
 export EXAMPLE_SERVICE_AUTH_TYPE=vpc
-export EXAMPLE_SERVICE_IAM_PROFILE_CRN=abc-123
+export EXAMPLE_SERVICE_IAM_PROFILE_CRN=crn:iam-profile-123
 ```
 Application code:
 ```js

--- a/Authentication.md
+++ b/Authentication.md
@@ -343,12 +343,6 @@ The IAM access token is added to each outbound request in the `Authorization` he
 - url: (optional) The VPC Instance Metadata Service's base URL.  
 The default value of this property is `http://169.254.169.254`, and should not need to be specified in normal situations.
 
-- disableSslVerification: (optional) A flag that indicates whether verificaton of the server's SSL 
-certificate should be disabled or not. The default value is `false`.
-
-- headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
-made to the IAM token service.
-
 Usage Notes:
 1. At most one of `iamProfileCrn` or `iamProfileId` may be specified.  The specified value must map
 to a trusted IAM profile that has been linked to the compute resource (virtual server instance).

--- a/Authentication.md
+++ b/Authentication.md
@@ -4,6 +4,7 @@ The node-sdk-core project supports the following types of authentication:
 - Bearer Token Authentication
 - Identity and Access Management (IAM) Authentication
 - Container Authentication
+- VPC Instance Authentication
 - Cloud Pak for Data Authentication
 - No Authentication
 
@@ -14,12 +15,11 @@ which authentication types are supported for that service.
 
 The node-sdk-core allows an authenticator to be specified in one of two ways:
 1. programmatically - the SDK user invokes the appropriate function(s) to create an instance of the 
-desired authenticator and then passes the authenticator instance when constructing an instance of the service client.
+desired authenticator and then passes the authenticator instance when constructing an instance of the service.
 2. configuration - the SDK user provides external configuration information (in the form of environment variables
-or a credentials file) to indicate the type of authenticator, along with the configuration of the necessary properties
-for that authenticator.
-The SDK user then invokes the configuration-based service client constructor method
-to construct an instance of the authenticator and service client that reflect the external configuration information.
+or a credentials file) to indicate the type of authenticator , along with the configuration of the necessary properties
+for that authenticator.  The SDK user then invokes the configuration-based authenticator factory to construct an instance
+of the authenticator that is described in the external configuration information.
 
 The sections below will provide detailed information for each authenticator
 which will include the following:
@@ -299,6 +299,90 @@ External configuration:
 ```
 export EXAMPLE_SERVICE_AUTH_TYPE=container
 export EXAMPLE_SERVICE_IAM_PROFILE_NAME=iam-user123
+```
+Application code:
+```js
+const ExampleServiceV1 = require('<sdk-package-name>/example-service/v1');
+
+const options = {
+  serviceName: 'example_service',
+};
+
+const service = ExampleServiceV1.newInstance(options);
+
+// 'service' can now be used to invoke operations.
+```
+
+
+## VPC Instance Authentication
+The `VpcInstanceAuthenticator` is intended to be used by application code
+running inside a VPC-managed compute resource (virtual server instance) that has been configured
+to use the "compute resource identity" feature.
+The compute resource identity feature allows you to assign a trusted IAM profile to the compute resource as its "identity".
+This, in turn, allows applications running within the compute resource to take on this identity when interacting with
+IAM-secured IBM Cloud services.
+This results in a simplified security model that allows the application developer to:
+- avoid storing credentials in application code, configuraton files or a password vault
+- avoid managing or rotating credentials
+
+The `VpcInstanceAuthenticator` will invoke the appropriate operations on the compute resource's locally-available
+VPC Instance Metadata Service to (1) retrieve an instance identity token
+and then (2) exchange that instance identity token for an IAM access token.
+The authenticator will repeat these steps to obtain a new IAM access token whenever the current access token expires.
+The IAM access token is added to each outbound request in the `Authorization` header in the form:
+```
+   Authorization: Bearer <IAM-access-token>
+```
+
+### Properties
+
+- iamProfileCrn: (optional) the crn of the linked trusted IAM profile to be used when obtaining the IAM access token.
+
+- iamProfileId: (optional) the id of the linked trusted IAM profile to be used when obtaining the IAM access token.
+
+- url: (optional) The VPC Instance Metadata Service's base URL.  
+The default value of this property is `http://169.254.169.254`, and should not need to be specified in normal situations.
+
+- disableSslVerification: (optional) A flag that indicates whether verificaton of the server's SSL 
+certificate should be disabled or not. The default value is `false`.
+
+- headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
+made to the IAM token service.
+
+Usage Notes:
+1. At most one of `iamProfileCrn` or `iamProfileId` may be specified.  The specified value must map
+to a trusted IAM profile that has been linked to the compute resource (virtual server instance).
+
+2. If both `iamProfileCrn` and `iamProfileId` are specified, then an error occurs.
+
+3. If neither `iamProfileCrn` nor `iamProfileId` are specified, then the default trusted profile linked to the 
+compute resource will be used to perform the IAM token exchange.
+If no default trusted profile is defined for the compute resource, then an error occurs.
+
+
+### Programming example
+```js
+const { VpcInstanceAuthenticator } = require('ibm-cloud-sdk-core');
+const ExampleServiceV1 = require('<sdk-package-name>/example-service/v1');
+
+const authenticator = new VpcInstanceAuthenticator({
+  iamProfileCrn: 'abc-123',
+});
+
+const options = {
+  authenticator,
+};
+
+const service = new ExampleServiceV1(options);
+
+// 'service' can now be used to invoke operations.
+```
+
+### Configuration example
+External configuration:
+```
+export EXAMPLE_SERVICE_AUTH_TYPE=vpc
+export EXAMPLE_SERVICE_IAM_PROFILE_CRN=abc-123
 ```
 Application code:
 ```js

--- a/Authentication.md
+++ b/Authentication.md
@@ -366,7 +366,7 @@ const { VpcInstanceAuthenticator } = require('ibm-cloud-sdk-core');
 const ExampleServiceV1 = require('<sdk-package-name>/example-service/v1');
 
 const authenticator = new VpcInstanceAuthenticator({
-  iamProfileCrn: 'abc-123',
+  iamProfileCrn: 'crn:iam-profile-123',
 });
 
 const options = {

--- a/Authentication.md
+++ b/Authentication.md
@@ -18,7 +18,7 @@ The node-sdk-core allows an authenticator to be specified in one of two ways:
 desired authenticator and then passes the authenticator instance when constructing an instance of the service.
 2. configuration - the SDK user provides external configuration information (in the form of environment variables
 or a credentials file) to indicate the type of authenticator, along with the configuration of the necessary properties
-for that authenticator.  The SDK user then invokes the configuration-based authenticator factory to construct an instance
+for that authenticator. The SDK user then invokes the configuration-based authenticator factory to construct an instance
 of the authenticator that is described in the external configuration information.
 
 The sections below will provide detailed information for each authenticator

--- a/Authentication.md
+++ b/Authentication.md
@@ -17,7 +17,7 @@ The node-sdk-core allows an authenticator to be specified in one of two ways:
 1. programmatically - the SDK user invokes the appropriate function(s) to create an instance of the 
 desired authenticator and then passes the authenticator instance when constructing an instance of the service.
 2. configuration - the SDK user provides external configuration information (in the form of environment variables
-or a credentials file) to indicate the type of authenticator , along with the configuration of the necessary properties
+or a credentials file) to indicate the type of authenticator, along with the configuration of the necessary properties
 for that authenticator.  The SDK user then invokes the configuration-based authenticator factory to construct an instance
 of the authenticator that is described in the external configuration information.
 

--- a/Authentication.md
+++ b/Authentication.md
@@ -165,6 +165,15 @@ form:
 - url: (optional) The base endpoint URL of the IAM token service.
 The default value of this property is the "prod" IAM token service endpoint
 (`https://iam.cloud.ibm.com`).
+Make sure that you use an IAM token service endpoint that is appropriate for the
+location of the service being used by your application.
+For example, if you are using an instance of a service in the "production" environment
+(e.g. `https://resource-controller.cloud.ibm.com`),
+then the default "prod" IAM token service endpoint should suffice.
+However, if your application is using an instance of a service in the "staging" environment
+(e.g. `https://resource-controller.test.cloud.ibm.com`),
+then you would also need to configure the authenticator to use the IAM token service "staging"
+endpoint as well (`https://iam.test.cloud.ibm.com`).
 
 - clientId/clientSecret: (optional) The `clientId` and `clientSecret` fields are used to form a
 "basic auth" Authorization header for interactions with the IAM token server. If neither field
@@ -257,6 +266,15 @@ One of `iamProfileName` or `iamProfileId` must be specified.
 - url: (optional) The base endpoint URL of the IAM token service.
 The default value of this property is the "prod" IAM token service endpoint
 (`https://iam.cloud.ibm.com`).
+Make sure that you use an IAM token service endpoint that is appropriate for the
+location of the service being used by your application.
+For example, if you are using an instance of a service in the "production" environment
+(e.g. `https://resource-controller.cloud.ibm.com`),
+then the default "prod" IAM token service endpoint should suffice.
+However, if your application is using an instance of a service in the "staging" environment
+(e.g. `https://resource-controller.test.cloud.ibm.com`),
+then you would also need to configure the authenticator to use the IAM token service "staging"
+endpoint as well (`https://iam.test.cloud.ibm.com`).
 
 - clientId/clientSecret: (optional) The `clientId` and `clientSecret` fields are used to form a 
 "basic auth" Authorization header for interactions with the IAM token service. If neither field 

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -38,6 +38,8 @@ export class Authenticator implements AuthenticatorInterface {
 
   static AUTHTYPE_NOAUTH = 'noAuth';
 
+  static AUTHTYPE_VPC = 'vpc';
+
   static AUTHTYPE_UNKNOWN = 'unknown';
 
   /**

--- a/auth/authenticators/container-authenticator.ts
+++ b/auth/authenticators/container-authenticator.ts
@@ -84,7 +84,7 @@ export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
 
   /**
    * Setter for the filename of the compute resource token.
-   * @param {string} scope A string containing a path to the CR token file
+   * @param {string} A string containing a path to the CR token file
    */
   public setCrTokenFilename(crTokenFilename: string): void {
     this.crTokenFilename = crTokenFilename;
@@ -95,7 +95,7 @@ export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
 
   /**
    * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileName parameter
+   * @param {string} A string that makes up the iamProfileName parameter
    */
   public setIamProfileName(iamProfileName: string): void {
     this.iamProfileName = iamProfileName;
@@ -106,7 +106,7 @@ export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
 
   /**
    * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileId parameter
+   * @param {string} A string that makes up the iamProfileId parameter
    */
   public setIamProfileId(iamProfileId: string): void {
     this.iamProfileId = iamProfileId;

--- a/auth/authenticators/index.ts
+++ b/auth/authenticators/index.ts
@@ -22,6 +22,7 @@
  * Bearer Token
  * Identity and Access Management (IAM)
  * Container (IKS, etc)
+ * VPC Instance
  * Cloud Pak for Data
  * No Authentication
  *
@@ -36,6 +37,7 @@
  *   CloudPakForDataAuthenticator: Authenticator for passing CP4D authentication information to service endpoint.
  *   IAMAuthenticator: Authenticator for passing IAM authentication information to service endpoint.
  *   ContainerAuthenticator: Authenticator for passing IAM authentication to a service, based on a token living on the container.
+ *   VpcInstanceAuthenticator: Authenticator that uses the VPC Instance Metadata Service API to retrieve an IAM token.
  *   NoAuthAuthenticator: Performs no authentication. Useful for testing purposes.
  */
 
@@ -49,3 +51,4 @@ export { ContainerAuthenticator } from './container-authenticator';
 export { NoAuthAuthenticator } from './no-auth-authenticator';
 export { IamRequestBasedAuthenticator } from './iam-request-based-authenticator';
 export { TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+export { VpcInstanceAuthenticator } from './vpc-instance-authenticator';

--- a/auth/authenticators/vpc-instance-authenticator.ts
+++ b/auth/authenticators/vpc-instance-authenticator.ts
@@ -75,7 +75,7 @@ export class VpcInstanceAuthenticator extends TokenRequestBasedAuthenticator {
   }
 
   /**
-   * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
+   * Setter for the "profile_crn" parameter to use when fetching the bearer token from the IAM token server.
    * @param {string} scope A string that makes up the iamProfileCrn parameter
    */
   public setIamProfileCrn(iamProfileCrn: string): void {

--- a/auth/authenticators/vpc-instance-authenticator.ts
+++ b/auth/authenticators/vpc-instance-authenticator.ts
@@ -87,7 +87,7 @@ export class VpcInstanceAuthenticator extends TokenRequestBasedAuthenticator {
 
   /**
    * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileId parameter
+   * @param {string} A string that makes up the iamProfileId parameter
    */
   public setIamProfileId(iamProfileId: string): void {
     this.iamProfileId = iamProfileId;

--- a/auth/authenticators/vpc-instance-authenticator.ts
+++ b/auth/authenticators/vpc-instance-authenticator.ts
@@ -76,7 +76,7 @@ export class VpcInstanceAuthenticator extends TokenRequestBasedAuthenticator {
 
   /**
    * Setter for the "profile_crn" parameter to use when fetching the bearer token from the IAM token server.
-   * @param {string} scope A string that makes up the iamProfileCrn parameter
+   * @param {string} A string that makes up the iamProfileCrn parameter
    */
   public setIamProfileCrn(iamProfileCrn: string): void {
     this.iamProfileCrn = iamProfileCrn;

--- a/auth/authenticators/vpc-instance-authenticator.ts
+++ b/auth/authenticators/vpc-instance-authenticator.ts
@@ -48,16 +48,12 @@ export class VpcInstanceAuthenticator extends TokenRequestBasedAuthenticator {
    *
    * @param {object} [options] Configuration options for VpcInstance authentication.
    * @param {string} [options.iamProfileCrn] The CRN of the linked trusted IAM profile to be used as the identity of the compute resource.
-   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    At most one of iamProfileCrn or iamProfileId may be specified.
    *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
    * @param {string} [options.iamProfileId] The ID of the linked trusted IAM profile to be used when obtaining the IAM access token.
-   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    At most one of iamProfileCrn or iamProfileId may be specified.
    *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
    * @param {string} [options.url] The VPC Instance Metadata Service's base endpoint URL. Default value: "http://169.254.169.254"
-   * @param {boolean} [options.disableSslVerification] A flag that indicates
-   *    whether verification of the token server's SSL certificate should be
-   *    disabled or not
-   * @param {object<string, string>} [options.headers] to be sent with every.
    */
   constructor(options: Options) {
     // all parameters are optional

--- a/auth/authenticators/vpc-instance-authenticator.ts
+++ b/auth/authenticators/vpc-instance-authenticator.ts
@@ -1,0 +1,112 @@
+/**
+ * (C) Copyright IBM Corp. 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Authenticator } from './authenticator';
+import { VpcInstanceTokenManager } from '../token-managers';
+import { BaseOptions, TokenRequestBasedAuthenticator } from './token-request-based-authenticator';
+
+/** Configuration options for VpcInstance authentication. */
+export interface Options extends BaseOptions {
+  /** The CRN of the linked trusted IAM profile to be used as the identity of the compute resource */
+  iamProfileCrn?: string;
+  /** The ID of the linked trusted IAM profile to be used when obtaining the IAM access token */
+  iamProfileId?: string;
+}
+
+/**
+ * The [[VpcInstanceAuthenticator]] implements an authentication scheme in which it retrieves an "instance identity token"
+ * and exchanges that for an IAM access token using the VPC Instance Metadata Service API which is available on the local
+ * compute resource (VM). The instance identity token is similar to an IAM apikey, except that it is managed automatically
+ * by the compute resource provider (VPC).
+ *
+ * The resulting IAM access token is then added to outbound requests in an Authorization header
+ *
+ *      Authorization: Bearer <access-token>
+ */
+export class VpcInstanceAuthenticator extends TokenRequestBasedAuthenticator {
+  protected tokenManager: VpcInstanceTokenManager;
+
+  private iamProfileCrn: string;
+
+  private iamProfileId: string;
+
+  /**
+   * Create a new [[VpcInstanceAuthenticator]] instance.
+   *
+   * @param {object} [options] Configuration options for VpcInstance authentication.
+   * @param {string} [options.iamProfileCrn] The CRN of the linked trusted IAM profile to be used as the identity of the compute resource.
+   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
+   * @param {string} [options.iamProfileId] The ID of the linked trusted IAM profile to be used when obtaining the IAM access token.
+   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
+   * @param {string} [options.url] The VPC Instance Metadata Service's base endpoint URL. Default value: "http://169.254.169.254"
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
+   *    whether verification of the token server's SSL certificate should be
+   *    disabled or not
+   * @param {object<string, string>} [options.headers] to be sent with every.
+   */
+  constructor(options: Options) {
+    // all parameters are optional
+    options = options || ({} as Options);
+
+    super(options);
+
+    if (options.iamProfileCrn) {
+      this.iamProfileCrn = options.iamProfileCrn;
+    }
+    if (options.iamProfileId) {
+      this.iamProfileId = options.iamProfileId;
+    }
+
+    // the param names are shared between the authenticator and the token
+    // manager so we can just pass along the options object.
+    // also, the token manager will handle input validation
+    this.tokenManager = new VpcInstanceTokenManager(options);
+  }
+
+  /**
+   * Setter for the "profile_name" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileCrn parameter
+   */
+  public setIamProfileCrn(iamProfileCrn: string): void {
+    this.iamProfileCrn = iamProfileCrn;
+
+    // update properties in token manager
+    this.tokenManager.setIamProfileCrn(iamProfileCrn);
+  }
+
+  /**
+   * Setter for the "profile_id" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} scope A string that makes up the iamProfileId parameter
+   */
+  public setIamProfileId(iamProfileId: string): void {
+    this.iamProfileId = iamProfileId;
+
+    // update properties in token manager
+    this.tokenManager.setIamProfileId(iamProfileId);
+  }
+
+  /**
+   * Returns the authenticator's type ('vpc').
+   *
+   * @returns a string that indicates the authenticator's type
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public authenticationType(): string {
+    return Authenticator.AUTHTYPE_VPC;
+  }
+}

--- a/auth/token-managers/index.ts
+++ b/auth/token-managers/index.ts
@@ -21,6 +21,7 @@
  * Identity and Access Management (IAM)
  * Cloud Pak for Data
  * Container (IKS, etc)
+ * VPC Instance
  *
  * The token managers sit inside of an authenticator and do the work to retrieve
  * tokens where as the authenticators add these tokens to the actual request.
@@ -29,6 +30,7 @@
  *   IamTokenManager: Token Manager of IAM via apikey.
  *   Cp4dTokenManager: Token Manager of CloudPak for data.
  *   ContainerTokenManager: Token manager of IAM via compute resource token.
+ *   VpcInstanceTokenManager: Token manager of VPC Instance Metadata Service API tokens.
  *   JwtTokenManager: A class for shared functionality for parsing, storing, and requesting JWT tokens.
  */
 
@@ -38,3 +40,4 @@ export { ContainerTokenManager } from './container-token-manager';
 export { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-based-token-manager';
 export { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 export { TokenManager, TokenManagerOptions } from './token-manager';
+export { VpcInstanceTokenManager } from './vpc-instance-token-manager';

--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -52,7 +52,7 @@ export class VpcInstanceTokenManager extends JwtTokenManager {
    *
    * @param {object} [options] Configuration options.
    * @param {string} [options.iamProfileCrn] The CRN of the linked trusted IAM profile to be used as the identity of the compute resource.
-   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    At most one of iamProfileCRN or iamProfileID may be specified.
    *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
    * @param {string} [options.iamProfileId] The ID of the linked trusted IAM profile to be used when obtaining the IAM access token.
    *    At most one of IAMProfileCRN or IAMProfileID may be specified.

--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -1,0 +1,172 @@
+/**
+ * (C) Copyright IBM Corp. 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import extend = require('extend');
+import logger from '../../lib/logger';
+import { atMostOne } from '../utils';
+import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
+
+const DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254';
+const METADATA_SERVICE_VERSION = '2021-09-20';
+
+/** Configuration options for CP4D token retrieval. */
+interface Options extends JwtTokenManagerOptions {
+  /** The CRN of the linked trusted IAM profile to be used as the identity of the compute resource */
+  iamProfileCrn?: string;
+  /** The ID of the linked trusted IAM profile to be used when obtaining the IAM access token */
+  iamProfileId?: string;
+}
+
+// this interface is a representation of the response received from
+// the VPC "create_access_token" and "create_iam_token" operations.
+export interface VpcTokenResponse {
+  access_token: string;
+  created_at: string;
+  expires_at: string;
+  expires_in: string;
+}
+
+/**
+ * Token Manager for VPC Instance Authentication.
+ */
+export class VpcInstanceTokenManager extends JwtTokenManager {
+  private iamProfileCrn: string;
+
+  private iamProfileId: string;
+
+  /**
+   * Create a new [[VpcInstanceTokenManager]] instance.
+   *
+   * @param {object} [options] Configuration options.
+   * @param {string} [options.iamProfileCrn] The CRN of the linked trusted IAM profile to be used as the identity of the compute resource.
+   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
+   * @param {string} [options.iamProfileId] The ID of the linked trusted IAM profile to be used when obtaining the IAM access token.
+   *    At most one of IAMProfileCRN or IAMProfileID may be specified.
+   *    If neither one is specified, then the default IAM profile defined for the compute resource will be used.
+   * @param {string} [options.url] The VPC Instance Metadata Service's base endpoint URL. Default value: "http://169.254.169.254"
+   * @param {boolean} [options.disableSslVerification] A flag that indicates
+   *    whether verification of the token server's SSL certificate should be
+   *    disabled or not.
+   * @param {object<string, string>} [options.headers] Headers to be sent with every
+   *    outbound HTTP requests to token services.
+   * @constructor
+   */
+  constructor(options: Options) {
+    // all parameters are optional
+    options = options || ({} as Options);
+
+    super(options);
+
+    if (!atMostOne(options.iamProfileId, options.iamProfileCrn)) {
+      throw new Error('At most one of `iamProfileId` or `iamProfileCrn` may be specified.');
+    }
+
+    this.url = options.url || DEFAULT_IMS_ENDPOINT;
+
+    if (options.iamProfileCrn) {
+      this.iamProfileCrn = options.iamProfileCrn;
+    }
+    if (options.iamProfileId) {
+      this.iamProfileId = options.iamProfileId;
+    }
+  }
+
+  /**
+   * Setter for the "trusted_profile" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} iamProfileCrn A string that makes up the iamProfileCrn parameter
+   */
+  public setIamProfileCrn(iamProfileCrn: string): void {
+    this.iamProfileCrn = iamProfileCrn;
+  }
+
+  /**
+   * Setter for the "trusted_profile" parameter to use when fetching the bearer token from the IAM token server.
+   * @param {string} iamProfileId A string that makes up the iamProfileId parameter
+   */
+  public setIamProfileId(iamProfileId: string): void {
+    this.iamProfileId = iamProfileId;
+  }
+
+  protected async requestToken(): Promise<any> {
+    const instanceIdentityToken: string = await this.getInstanceIdentityToken();
+
+    // these cannot be overwritten
+    const requiredHeaders = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${instanceIdentityToken}`,
+    };
+
+    const parameters = {
+      options: {
+        url: `${this.url}/instance_identity/v1/iam_token`,
+        qs: {
+          version: METADATA_SERVICE_VERSION,
+        },
+        body: {
+          trusted_profile: this.iamProfileId || this.iamProfileCrn, // if neither are given, this will remain undefined
+        },
+        method: 'POST',
+        headers: extend(true, {}, this.headers, requiredHeaders),
+        rejectUnauthorized: !this.disableSslVerification,
+      },
+    };
+
+    logger.debug(`Invoking VPC 'create_iam_token' operation: ${parameters.options.url}`);
+
+    return this.requestWrapperInstance.sendRequest(parameters);
+  }
+
+  private async getInstanceIdentityToken(): Promise<string> {
+    // these cannot be overwritten
+    const requiredHeaders = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'Metadata-Flavor': 'ibm',
+    };
+
+    const parameters = {
+      options: {
+        url: `${this.url}/instance_identity/v1/token`,
+        qs: {
+          version: METADATA_SERVICE_VERSION,
+        },
+        body: {
+          expires_in: 300,
+        },
+        method: 'PUT',
+        headers: extend(true, {}, this.headers, requiredHeaders),
+        rejectUnauthorized: !this.disableSslVerification,
+      },
+    };
+
+    let token: string = null;
+    try {
+      logger.debug(`Invoking VPC 'create_access_token' operation: ${parameters.options.url}`);
+      const response = await this.requestWrapperInstance.sendRequest(parameters);
+      logger.debug(`Returned from VPC 'create_access_token' operation.`);
+
+      const responseBody: VpcTokenResponse = response.result || {};
+      token = responseBody.access_token;
+    } catch (err) {
+      logger.debug(`Caught exception from VPC 'create_access_token' operation: ${err.message}`);
+      throw err;
+    }
+
+    return token;
+  }
+}

--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -21,7 +21,7 @@ import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 const DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254';
 const METADATA_SERVICE_VERSION = '2021-09-20';
 
-/** Configuration options for CP4D token retrieval. */
+/** Configuration options for VPC token retrieval. */
 interface Options extends JwtTokenManagerOptions {
   /** The CRN of the linked trusted IAM profile to be used as the identity of the compute resource */
   iamProfileCrn?: string;

--- a/auth/utils/get-authenticator-from-environment.ts
+++ b/auth/utils/get-authenticator-from-environment.ts
@@ -22,6 +22,7 @@ import {
   IamAuthenticator,
   ContainerAuthenticator,
   NoAuthAuthenticator,
+  VpcInstanceAuthenticator,
 } from '../authenticators';
 
 import { readExternalSources } from './read-external-sources';
@@ -95,6 +96,8 @@ export function getAuthenticatorFromEnvironment(serviceName: string): Authentica
     authenticator = new IamAuthenticator(credentials);
   } else if (authType === Authenticator.AUTHTYPE_CONTAINER.toLowerCase()) {
     authenticator = new ContainerAuthenticator(credentials);
+  } else if (authType === Authenticator.AUTHTYPE_VPC.toLowerCase()) {
+    authenticator = new VpcInstanceAuthenticator(credentials);
   } else {
     throw new Error(`Invalid value for AUTH_TYPE: ${authType}`);
   }

--- a/auth/utils/helpers.ts
+++ b/auth/utils/helpers.ts
@@ -129,3 +129,16 @@ export function removeSuffix(str: string, suffix: string): string {
 export function atLeastOne(a: any, b: any): boolean {
   return Boolean(a || b);
 }
+
+/**
+ * Verify that both properties are not specified.
+ * Returns true if only a, only b, or neither is defined.
+ * Returns false if both are defined.
+ *
+ * @param {any} a - The first object
+ * @param {any} b - The second object
+ * @returns {boolean}
+ */
+export function atMostOne(a: any, b: any): boolean {
+  return Boolean(!(a && b));
+}

--- a/test/unit/get-authenticator-from-environment.test.js
+++ b/test/unit/get-authenticator-from-environment.test.js
@@ -22,6 +22,7 @@ const {
   CloudPakForDataAuthenticator,
   IamAuthenticator,
   ContainerAuthenticator,
+  VpcInstanceAuthenticator,
   NoAuthAuthenticator,
 } = require('../../dist/auth');
 
@@ -91,6 +92,13 @@ describe('Get Authenticator From Environment Module', () => {
     const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
     expect(authenticator).toBeInstanceOf(ContainerAuthenticator);
     expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_CONTAINER);
+  });
+
+  it('should get vpc instance authenticator', () => {
+    setUpVpcInstancePayload();
+    const authenticator = getAuthenticatorFromEnvironment(SERVICE_NAME);
+    expect(authenticator).toBeInstanceOf(VpcInstanceAuthenticator);
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_VPC);
   });
 
   it('should throw away service properties and use auth properties', () => {
@@ -196,6 +204,13 @@ function setUpContainerPayload() {
     authType: 'conTAINer',
     crTokenFilename: '/path/to/file',
     iamProfileName: IAM_PROFILE_NAME,
+    iamProfileId: 'some-id',
+  }));
+}
+
+function setUpVpcInstancePayload() {
+  readExternalSourcesMock.mockImplementation(() => ({
+    authType: 'vPc',
     iamProfileId: 'some-id',
   }));
 }

--- a/test/unit/vpc-instance-authenticator.test.js
+++ b/test/unit/vpc-instance-authenticator.test.js
@@ -29,10 +29,6 @@ describe('VPC Instance Authenticator', () => {
   const config = {
     iamProfileId: 'some-id',
     url: 'someurl.com',
-    disableSslVerification: true,
-    headers: {
-      'X-My-Header': 'some-value',
-    },
   };
 
   it('should store all config options on the class', () => {
@@ -42,8 +38,6 @@ describe('VPC Instance Authenticator', () => {
     expect(authenticator.iamProfileCrn).not.toBeDefined();
     expect(authenticator.iamProfileId).toBe(config.iamProfileId);
     expect(authenticator.url).toBe(config.url);
-    expect(authenticator.disableSslVerification).toBe(config.disableSslVerification);
-    expect(authenticator.headers).toEqual(config.headers);
 
     // should also create a token manager
     expect(authenticator.tokenManager).toBeInstanceOf(VpcInstanceTokenManager);
@@ -89,14 +83,11 @@ describe('VPC Instance Authenticator', () => {
     // override the created token manager with the mocked one
     authenticator.tokenManager = mockedTokenManager;
 
-    const options = { headers: { 'X-Some-Header': 'user-supplied header' } };
+    const options = {};
     const result = await authenticator.authenticate(options);
 
     expect(result).toBeUndefined();
     expect(options.headers.Authorization).toBe(`Bearer ${fakeToken}`);
     expect(getTokenSpy).toHaveBeenCalled();
-
-    // verify that the original options are kept intact
-    expect(options.headers['X-Some-Header']).toBe('user-supplied header');
   });
 });

--- a/test/unit/vpc-instance-authenticator.test.js
+++ b/test/unit/vpc-instance-authenticator.test.js
@@ -82,7 +82,7 @@ describe('VPC Instance Authenticator', () => {
     expect(authenticator.tokenManager.iamProfileId).toEqual(config.iamProfileId);
   });
 
-  // "end to end" style test, to make sure this authenticator ingregates properly with parent classes
+  // "end to end" style test, to make sure this authenticator integrates properly with parent classes
   it('should update the options and resolve with `null` when `authenticate` is called', async () => {
     const authenticator = new VpcInstanceAuthenticator({ iamProfileCrn: config.iamProfileCrn });
 

--- a/test/unit/vpc-instance-authenticator.test.js
+++ b/test/unit/vpc-instance-authenticator.test.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { Authenticator, VpcInstanceAuthenticator } = require('../../dist/auth');
+const { VpcInstanceTokenManager } = require('../../dist/auth');
+
+// mock the `getToken` method in the token manager - dont make any rest calls
+const fakeToken = 'iam-acess-token';
+const mockedTokenManager = new VpcInstanceTokenManager();
+
+const getTokenSpy = jest
+  .spyOn(mockedTokenManager, 'getToken')
+  .mockImplementation(() => Promise.resolve(fakeToken));
+
+describe('VPC Instance Authenticator', () => {
+  const config = {
+    iamProfileId: 'some-id',
+    url: 'someurl.com',
+    disableSslVerification: true,
+    headers: {
+      'X-My-Header': 'some-value',
+    },
+  };
+
+  it('should store all config options on the class', () => {
+    const authenticator = new VpcInstanceAuthenticator(config);
+
+    expect(authenticator.authenticationType()).toEqual(Authenticator.AUTHTYPE_VPC);
+    expect(authenticator.iamProfileCrn).not.toBeDefined();
+    expect(authenticator.iamProfileId).toBe(config.iamProfileId);
+    expect(authenticator.url).toBe(config.url);
+    expect(authenticator.disableSslVerification).toBe(config.disableSslVerification);
+    expect(authenticator.headers).toEqual(config.headers);
+
+    // should also create a token manager
+    expect(authenticator.tokenManager).toBeInstanceOf(VpcInstanceTokenManager);
+  });
+
+  it('should throw an error when both iamProfileCrn and iamProfileId are provided', () => {
+    expect(() => {
+      const unused = new VpcInstanceAuthenticator({
+        iamProfileCrn: 'crn',
+        iamProfileId: 'id',
+      });
+    }).toThrow('At most one of `iamProfileId` or `iamProfileCrn` may be specified.');
+  });
+
+  it('should re-set iamProfileCrn using the setter', () => {
+    const authenticator = new VpcInstanceAuthenticator({ iamProfileCrn: 'test' });
+    expect(authenticator.iamProfileCrn).not.toBe(config.iamProfileCrn);
+    expect(authenticator.tokenManager.iamProfileCrn).not.toBe(config.iamProfileCrn);
+
+    authenticator.setIamProfileCrn(config.iamProfileCrn);
+    expect(authenticator.iamProfileCrn).toEqual(config.iamProfileCrn);
+
+    // also, verify that the underlying token manager has been updated
+    expect(authenticator.tokenManager.iamProfileCrn).toEqual(config.iamProfileCrn);
+  });
+
+  it('should re-set iamProfileId using the setter', () => {
+    const authenticator = new VpcInstanceAuthenticator();
+    expect(authenticator.iamProfileId).toBeUndefined();
+    expect(authenticator.tokenManager.iamProfileId).toBeUndefined();
+
+    authenticator.setIamProfileId(config.iamProfileId);
+    expect(authenticator.iamProfileId).toEqual(config.iamProfileId);
+
+    // also, verify that the underlying token manager has been updated
+    expect(authenticator.tokenManager.iamProfileId).toEqual(config.iamProfileId);
+  });
+
+  // "end to end" style test, to make sure this authenticator ingregates properly with parent classes
+  it('should update the options and resolve with `null` when `authenticate` is called', async () => {
+    const authenticator = new VpcInstanceAuthenticator({ iamProfileCrn: config.iamProfileCrn });
+
+    // override the created token manager with the mocked one
+    authenticator.tokenManager = mockedTokenManager;
+
+    const options = { headers: { 'X-Some-Header': 'user-supplied header' } };
+    const result = await authenticator.authenticate(options);
+
+    expect(result).toBeUndefined();
+    expect(options.headers.Authorization).toBe(`Bearer ${fakeToken}`);
+    expect(getTokenSpy).toHaveBeenCalled();
+
+    // verify that the original options are kept intact
+    expect(options.headers['X-Some-Header']).toBe('user-supplied header');
+  });
+});

--- a/test/unit/vpc-instance-token-manager.test.js
+++ b/test/unit/vpc-instance-token-manager.test.js
@@ -106,7 +106,6 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters.options).toBeDefined();
       expect(parameters.options.url).toBe('123.345.567/instance_identity/v1/token');
       expect(parameters.options.method).toBe('PUT');
-      expect(parameters.options.rejectUnauthorized).toBe(true);
 
       expect(parameters.options.qs).toBeDefined();
       expect(parameters.options.qs.version).toBe('2021-09-20');
@@ -158,7 +157,6 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters.options).toBeDefined();
       expect(parameters.options.url).toBe('123.345.567/instance_identity/v1/iam_token');
       expect(parameters.options.method).toBe('POST');
-      expect(parameters.options.rejectUnauthorized).toBe(true);
 
       expect(parameters.options.qs).toBeDefined();
       expect(parameters.options.qs.version).toBe('2021-09-20');

--- a/test/unit/vpc-instance-token-manager.test.js
+++ b/test/unit/vpc-instance-token-manager.test.js
@@ -184,7 +184,8 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters).toBeDefined();
       expect(parameters.options).toBeDefined();
       expect(parameters.options.body).toBeDefined();
-      expect(parameters.options.body.trusted_profile).toBe('some-crn');
+      expect(parameters.options.body.trusted_profile).toBeDefined();
+      expect(parameters.options.body.trusted_profile.crn).toBe('some-crn');
     });
 
     it('should set trusted profile to iam profile id, if set', async () => {
@@ -195,7 +196,8 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters).toBeDefined();
       expect(parameters.options).toBeDefined();
       expect(parameters.options.body).toBeDefined();
-      expect(parameters.options.body.trusted_profile).toBe('some-id');
+      expect(parameters.options.body.trusted_profile).toBeDefined();
+      expect(parameters.options.body.trusted_profile.id).toBe('some-id');
     });
   });
 });

--- a/test/unit/vpc-instance-token-manager.test.js
+++ b/test/unit/vpc-instance-token-manager.test.js
@@ -1,0 +1,203 @@
+/* eslint-disable no-alert, no-console */
+
+/**
+ * Copyright 2021 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const { VpcInstanceTokenManager } = require('../../dist/auth');
+const { RequestWrapper } = require('../../dist/lib/request-wrapper');
+const logger = require('../../dist/lib/logger').default;
+
+// make sure no actual requests are sent
+jest.mock('../../dist/lib/request-wrapper');
+const TOKEN = 'abc123';
+const sendRequestMock = jest.fn().mockImplementation(() => ({ result: { access_token: TOKEN } }));
+RequestWrapper.mockImplementation(() => ({
+  sendRequest: sendRequestMock,
+}));
+
+const debugLogSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+
+const IAM_PROFILE_CRN = 'some-crn';
+const IAM_PROFILE_ID = 'some-id';
+
+describe('VPC Instance Token Manager', () => {
+  afterAll(() => {
+    sendRequestMock.mockRestore();
+  });
+
+  afterEach(() => {
+    debugLogSpy.mockClear();
+    sendRequestMock.mockClear();
+  });
+
+  describe('constructor', () => {
+    it('should throw an error when both `iamProfileId` are `iamProfileCrn` are provided', () => {
+      expect(
+        () =>
+          new VpcInstanceTokenManager({
+            iamProfileCrn: IAM_PROFILE_CRN,
+            iamProfileId: IAM_PROFILE_ID,
+          })
+      ).toThrow('At most one of `iamProfileId` or `iamProfileCrn` may be specified.');
+    });
+
+    it('should use default url if none is given', () => {
+      const instance = new VpcInstanceTokenManager();
+      expect(instance.url).toBe('http://169.254.169.254');
+    });
+
+    it('should set given profile crn', () => {
+      const instance = new VpcInstanceTokenManager({
+        iamProfileCrn: IAM_PROFILE_CRN,
+      });
+
+      expect(instance.iamProfileCrn).toBe(IAM_PROFILE_CRN);
+    });
+
+    it('should set given profile id', () => {
+      const instance = new VpcInstanceTokenManager({
+        iamProfileId: IAM_PROFILE_ID,
+      });
+
+      expect(instance.iamProfileId).toBe(IAM_PROFILE_ID);
+    });
+  });
+
+  describe('setters', () => {
+    it('should set iamProfileCrn with the setter', () => {
+      const instance = new VpcInstanceTokenManager({ iamProfileCrn: 'test' });
+      expect(instance.iamProfileCrn).toBe('test');
+      expect(instance.iamProfileCrn).not.toBe(IAM_PROFILE_CRN);
+
+      instance.setIamProfileCrn(IAM_PROFILE_CRN);
+      expect(instance.iamProfileCrn).toBe(IAM_PROFILE_CRN);
+    });
+
+    it('should set iamProfileId with the setter', () => {
+      const instance = new VpcInstanceTokenManager();
+      expect(instance.iamProfileId).toBeUndefined();
+
+      instance.setIamProfileId(IAM_PROFILE_ID);
+      expect(instance.iamProfileId).toBe(IAM_PROFILE_ID);
+    });
+  });
+
+  describe('getInstanceIdentityToken', () => {
+    it('should correctly construct headers and request parameters', async () => {
+      const instance = new VpcInstanceTokenManager({ url: '123.345.567' });
+      await instance.getInstanceIdentityToken();
+
+      const parameters = sendRequestMock.mock.calls[0][0];
+      expect(parameters).toBeDefined();
+      expect(parameters.options).toBeDefined();
+      expect(parameters.options.url).toBe('123.345.567/instance_identity/v1/token');
+      expect(parameters.options.method).toBe('PUT');
+      expect(parameters.options.rejectUnauthorized).toBe(true);
+
+      expect(parameters.options.qs).toBeDefined();
+      expect(parameters.options.qs.version).toBe('2021-09-20');
+
+      expect(parameters.options.body).toBeDefined();
+      expect(parameters.options.body.expires_in).toBe(300);
+
+      expect(parameters.options.headers).toBeDefined();
+      expect(parameters.options.headers['Content-Type']).toBe('application/json');
+      expect(parameters.options.headers.Accept).toBe('application/json');
+      expect(parameters.options.headers['Metadata-Flavor']).toBe('ibm');
+    });
+
+    it('should make the request then extract and return the token', async () => {
+      const instance = new VpcInstanceTokenManager({ url: '123.345.567' });
+      const token = await instance.getInstanceIdentityToken();
+      expect(token).toBe(TOKEN);
+      expect(sendRequestMock).toHaveBeenCalled();
+
+      // verify logs
+      expect(debugLogSpy.mock.calls[0][0]).toBe(
+        "Invoking VPC 'create_access_token' operation: 123.345.567/instance_identity/v1/token"
+      );
+      expect(debugLogSpy.mock.calls[1][0]).toBe(
+        "Returned from VPC 'create_access_token' operation."
+      );
+    });
+
+    it('should throw an error and log when the request fails', async () => {
+      const instance = new VpcInstanceTokenManager({ url: '123.345.567' });
+
+      sendRequestMock.mockImplementationOnce(() => Promise.reject(new Error('This is an error.')));
+
+      await expect(instance.getInstanceIdentityToken()).rejects.toThrow('This is an error.');
+
+      expect(debugLogSpy.mock.calls[1][0]).toBe(
+        "Caught exception from VPC 'create_access_token' operation: This is an error."
+      );
+    });
+  });
+
+  describe('requestToken', () => {
+    it('should correctly construct headers and request parameters', async () => {
+      const instance = new VpcInstanceTokenManager({ url: '123.345.567' });
+      await instance.requestToken();
+
+      const parameters = sendRequestMock.mock.calls[1][0];
+      expect(parameters).toBeDefined();
+      expect(parameters.options).toBeDefined();
+      expect(parameters.options.url).toBe('123.345.567/instance_identity/v1/iam_token');
+      expect(parameters.options.method).toBe('POST');
+      expect(parameters.options.rejectUnauthorized).toBe(true);
+
+      expect(parameters.options.qs).toBeDefined();
+      expect(parameters.options.qs.version).toBe('2021-09-20');
+
+      expect(parameters.options.body).toBeDefined();
+      // if neither the profile id or crn is set, this should be undefined
+      expect(parameters.options.body.trusted_profile).toBeUndefined();
+
+      expect(parameters.options.headers).toBeDefined();
+      expect(parameters.options.headers['Content-Type']).toBe('application/json');
+      expect(parameters.options.headers.Accept).toBe('application/json');
+      expect(parameters.options.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+
+      // check logs
+      expect(debugLogSpy.mock.calls[2][0]).toBe(
+        "Invoking VPC 'create_iam_token' operation: 123.345.567/instance_identity/v1/iam_token"
+      );
+    });
+
+    it('should set trusted profile to iam profile crn, if set', async () => {
+      const instance = new VpcInstanceTokenManager({ iamProfileCrn: 'some-crn' });
+      await instance.requestToken();
+
+      const parameters = sendRequestMock.mock.calls[1][0];
+      expect(parameters).toBeDefined();
+      expect(parameters.options).toBeDefined();
+      expect(parameters.options.body).toBeDefined();
+      expect(parameters.options.body.trusted_profile).toBe('some-crn');
+    });
+
+    it('should set trusted profile to iam profile id, if set', async () => {
+      const instance = new VpcInstanceTokenManager({ iamProfileId: 'some-id' });
+      await instance.requestToken();
+
+      const parameters = sendRequestMock.mock.calls[1][0];
+      expect(parameters).toBeDefined();
+      expect(parameters.options).toBeDefined();
+      expect(parameters.options.body).toBeDefined();
+      expect(parameters.options.body.trusted_profile).toBe('some-id');
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces the VpcInstanceAuthenticator.
This authenticator implements the authentication flow
within a VPC-managed compute resource that is configured to
use the compute resource identity feature.
This involves the use of the compute resource's local
VPC Instance Metadata Service API to retrieve an instance identity
token, and then exchange that token for an IAM access token.
The IAM access token is then used to authenticate outbound REST
API requests by adding an Authorization containing the access token.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
