### PR TITLE
fix(VpcInstanceAuthenticator): omit request body for default profile scenario

### DIFF
--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -108,11 +108,15 @@ export class VpcInstanceTokenManager extends JwtTokenManager {
     const instanceIdentityToken: string = await this.getInstanceIdentityToken();
 
     // construct request body
-    const body = {} as CreateIamTokenBody;
+    let body: CreateIamTokenBody;
     if (this.iamProfileId) {
-      body.trusted_profile = { id: this.iamProfileId };
+      body = {
+        trusted_profile: { id: this.iamProfileId },
+      };
     } else if (this.iamProfileCrn) {
-      body.trusted_profile = { crn: this.iamProfileCrn };
+      body = {
+        trusted_profile: { crn: this.iamProfileCrn },
+      };
     }
 
     const parameters = {

--- a/test/unit/vpc-instance-token-manager.test.js
+++ b/test/unit/vpc-instance-token-manager.test.js
@@ -45,7 +45,7 @@ describe('VPC Instance Token Manager', () => {
   });
 
   describe('constructor', () => {
-    it('should throw an error when both `iamProfileId` are `iamProfileCrn` are provided', () => {
+    it('should throw an error when both `iamProfileId` and `iamProfileCrn` are provided', () => {
       expect(
         () =>
           new VpcInstanceTokenManager({
@@ -161,9 +161,8 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters.options.qs).toBeDefined();
       expect(parameters.options.qs.version).toBe('2021-09-20');
 
-      expect(parameters.options.body).toBeDefined();
-      // if neither the profile id or crn is set, this should be undefined
-      expect(parameters.options.body.trusted_profile).toBeUndefined();
+      // if neither the profile id or crn is set, then the body should be undefined
+      expect(parameters.options.body).toBeUndefined();
 
       expect(parameters.options.headers).toBeDefined();
       expect(parameters.options.headers['Content-Type']).toBe('application/json');


### PR DESCRIPTION
This PR fixes a small problem in the VPC instance token manager related to the "default profile" scenario.
Previously, the token manager would send an empty request body (i.e. `{ }`) if both `iamProfileId` and `iamProfileCrn` were both unspecified.  This would cause a 400 Bad Request to be returned by the VPC Instance Metadata Service.
The fix is to simply avoid sending a request body at all for this scenario.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
