### PR TITLE
fix: don't always convert bytes to text in streamToPromise

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -442,7 +442,8 @@ export class RequestWrapper {
 
     try {
       if (isStream(data)) {
-        reqBuffer = Buffer.from(await streamToPromise(data));
+        const streamData = await streamToPromise(data);
+        reqBuffer = Buffer.isBuffer(streamData) ? streamData : Buffer.from(streamData);
       } else if (data.toString && data.toString() !== '[object Object]' && !Array.isArray(data)) {
         // this handles pretty much any primitive that isnt a JSON object or array
         reqBuffer = Buffer.from(data.toString());

--- a/lib/stream-to-promise.ts
+++ b/lib/stream-to-promise.ts
@@ -17,7 +17,8 @@
 import { Stream } from 'stream';
 
 /**
- * Helper method that can be bound to a stream - it sets the output to utf-8, captures all of the results, and returns a promise that resolves to the final text
+ * Helper method that can be bound to a stream - it captures all of the results, and returns a promise that resolves to the final buffer
+ * or array of text chunks
  * Essentially a smaller version of concat-stream wrapped in a promise
  *
  * @param {Stream} stream Optional stream param for when not bound to an existing stream instance.
@@ -32,7 +33,7 @@ export function streamToPromise(stream: Stream): Promise<any> {
         results.push(result);
       })
       .on('end', () => {
-        resolve(Buffer.isBuffer(results[0]) ? Buffer.concat(results).toString() : results);
+        resolve(Buffer.isBuffer(results[0]) ? Buffer.concat(results) : results);
       })
       .on('error', reject);
   });


### PR DESCRIPTION
`streamToPromise` calls `toString()` on the `concat`ed `Buffer` which [defaults to `utf-8` encoding](https://nodejs.org/api/buffer.html#buftostringencoding-start-end) and consequently can mangle non `utf-8` content. This problem surfaced via https://github.com/IBM/cloudant-node-sdk/issues/546.

* Remove `toString()` call when using `Buffer` type.

The problem is resolved by _not_ calling `toString()` as the `Buffer` bytes may be passed as-is to the server for a byte stream. In cases where the stream is using `string` or `objectMode` _not_ `Buffer` then the existing `Buffer.isBuffer(results[0])` check puts the chunk as-is into the `results` array (i.e. it is an array of strings or objects).

* Update doc in streamToPromise to indicate it is not always text.
* Add test for binary type stream.
* Update assertions for `Buffer` streams to assert length and checksums.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
