### PR TITLE
fix: bump dependencies to avoid vulnerability alerts

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,6 +1,2 @@
 [
-    {
-        "cve": "CVE-2021-3807",
-        "alwaysOmit": true
-    }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,23 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.16.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/code-frame/-/code-frame-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcode-frame%2F-%2Fcode-frame-7.16.0.tgz",
+      "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.16.0"
       }
     },
     "@babel/compat-data": {
       "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/compat-data/-/compat-data-7.16.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcompat-data%2F-%2Fcompat-data-7.16.4.tgz",
+      "integrity": "sha1-CB1rvDNuxcJDXGNGsq4fuYtaxo4=",
       "dev": true
     },
     "@babel/core": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
-      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/core/-/core-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcore%2F-%2Fcore-7.16.0.tgz",
+      "integrity": "sha1-xP9EBG9f4xBSXMnrTvUUfwxTdNQ=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
@@ -41,18 +41,18 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json5/-/json5-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson5%2F-%2Fjson5-2.2.0.tgz",
+          "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.16.0"
+            "minimist": "^1.2.5"
           }
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map/-/source-map-0.5.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -60,8 +60,8 @@
     },
     "@babel/generator": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/generator/-/generator-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fgenerator%2F-%2Fgenerator-7.16.0.tgz",
+      "integrity": "sha1-1A89HVB15i01ALzLZ/PaqKlSZbI=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0",
@@ -71,7 +71,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map/-/source-map-0.5.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -79,8 +79,8 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
-      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-compilation-targets%2F-%2Fhelper-compilation-targets-7.16.3.tgz",
+      "integrity": "sha1-W0gM0T9oNj327E3IrI4toRNjy/A=",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
@@ -91,8 +91,8 @@
     },
     "@babel/helper-function-name": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-function-name%2F-%2Fhelper-function-name-7.16.0.tgz",
+      "integrity": "sha1-t90Hl9ALv+5PB+nE6lsOMMi7FIE=",
       "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.16.0",
@@ -102,8 +102,8 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-get-function-arity%2F-%2Fhelper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha1-AIjHSGspqctdlIsaHeRttm4InPo=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -111,8 +111,8 @@
     },
     "@babel/helper-hoist-variables": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-hoist-variables%2F-%2Fhelper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha1-TJAjwvHe9+KP9G/B2802o5vqqBo=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -120,8 +120,8 @@
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-      "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-member-expression-to-functions%2F-%2Fhelper-member-expression-to-functions-7.16.0.tgz",
+      "integrity": "sha1-KShwQO/Rl8d2Nu91GI6B2ovM1aQ=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -129,8 +129,8 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-module-imports%2F-%2Fhelper-module-imports-7.16.0.tgz",
+      "integrity": "sha1-kFOOYLZy7PG0SPX09UM9N+eaPsM=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -138,8 +138,8 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-      "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-module-transforms%2F-%2Fhelper-module-transforms-7.16.0.tgz",
+      "integrity": "sha1-HIKo3UyzRXdQLr0pCWmbGUw+m7U=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
@@ -154,8 +154,8 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-optimise-call-expression%2F-%2Fhelper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha1-zs2xRdcMVAlrFWT46fEM19GTszg=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -163,14 +163,14 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-plugin-utils%2F-%2Fhelper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha1-WsgizpfuxGdBq3ClF5ceRDpwxak=",
       "dev": true
     },
     "@babel/helper-replace-supers": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-      "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-replace-supers%2F-%2Fhelper-replace-supers-7.16.0.tgz",
+      "integrity": "sha1-cwVejTz5vLqN21XK2T/tyGD2jxc=",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.16.0",
@@ -181,8 +181,8 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-simple-access%2F-%2Fhelper-simple-access-7.16.0.tgz",
+      "integrity": "sha1-IdaidiDjg+N1NM9sELugGab5BRc=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -190,8 +190,8 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-split-export-declaration%2F-%2Fhelper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha1-KWcvQ2Y+k23zcKrrIr7ds7rsdDg=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
@@ -199,19 +199,19 @@
     },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-validator-identifier%2F-%2Fhelper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-validator-option%2F-%2Fhelper-validator-option-7.14.5.tgz",
+      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM=",
       "dev": true
     },
     "@babel/helpers": {
       "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
-      "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/helpers/-/helpers-7.16.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelpers%2F-%2Fhelpers-7.16.3.tgz",
+      "integrity": "sha1-J/xk9AuZbnB03HMSjD5cPn9VxDw=",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.0",
@@ -221,8 +221,8 @@
     },
     "@babel/highlight": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/highlight/-/highlight-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhighlight%2F-%2Fhighlight-7.16.0.tgz",
+      "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
       "requires": {
         "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
@@ -231,16 +231,16 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/chalk/-/chalk-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -249,31 +249,26 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-convert/-/color-convert-1.9.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-convert%2F-%2Fcolor-convert-1.9.3.tgz",
+          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-name/-/color-name-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-name%2F-%2Fcolor-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-color/-/supports-color-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -282,14 +277,14 @@
     },
     "@babel/parser": {
       "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/parser/-/parser-7.16.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fparser%2F-%2Fparser-7.16.4.tgz",
+      "integrity": "sha1-1fkvV88sdP/ps3mBwOcv7nMRNy4=",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-async-generators%2F-%2Fplugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -297,8 +292,8 @@
     },
     "@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-bigint%2F-%2Fplugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -306,8 +301,8 @@
     },
     "@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-class-properties%2F-%2Fplugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -315,8 +310,8 @@
     },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-import-meta%2F-%2Fplugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -324,8 +319,8 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-json-strings%2F-%2Fplugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -333,8 +328,8 @@
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-logical-assignment-operators%2F-%2Fplugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -342,8 +337,8 @@
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-nullish-coalescing-operator%2F-%2Fplugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -351,8 +346,8 @@
     },
     "@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-numeric-separator%2F-%2Fplugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -360,8 +355,8 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-object-rest-spread%2F-%2Fplugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -369,8 +364,8 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-optional-catch-binding%2F-%2Fplugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -378,8 +373,8 @@
     },
     "@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-optional-chaining%2F-%2Fplugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -387,8 +382,8 @@
     },
     "@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-top-level-await%2F-%2Fplugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -396,8 +391,8 @@
     },
     "@babel/plugin-syntax-typescript": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
-      "integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fplugin-syntax-typescript%2F-%2Fplugin-syntax-typescript-7.16.0.tgz",
+      "integrity": "sha1-L+6xPZM0zFguqREdNQb3cxdBebs=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -405,30 +400,19 @@
     },
     "@babel/template": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/template/-/template-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftemplate%2F-%2Ftemplate-7.16.0.tgz",
+      "integrity": "sha1-0Wo16/TNdOICCDNW+rId2JNj3dY=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/parser": "^7.16.0",
         "@babel/types": "^7.16.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
       "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/traverse/-/traverse-7.16.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftraverse%2F-%2Ftraverse-7.16.3.tgz",
+      "integrity": "sha1-9j6Kk4zBt4D2bZ7TxU9TLKLRR4c=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
@@ -442,27 +426,18 @@
         "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/globals/-/globals-11.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglobals%2F-%2Fglobals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
           "dev": true
         }
       }
     },
     "@babel/types": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/types/-/types-7.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftypes%2F-%2Ftypes-7.16.0.tgz",
+      "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.15.7",
@@ -471,14 +446,14 @@
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40bcoe%2Fv8-coverage%2F-%2Fv8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
       "dev": true
     },
     "@commitlint/cli": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-12.1.4.tgz",
-      "integrity": "sha512-ZR1WjXLvqEffYyBPT0XdnSxtt3Ty1TMoujEtseW5o3vPnkA1UNashAMjQVg/oELqfaiAMnDw8SERPMN0e/0kLg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/cli/-/cli-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fcli%2F-%2Fcli-12.1.4.tgz",
+      "integrity": "sha1-r02d08ASLHs5ph+hzSq7rQQi2+A=",
       "dev": true,
       "requires": {
         "@commitlint/format": "^12.1.4",
@@ -494,14 +469,14 @@
     },
     "@commitlint/config-conventional": {
       "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.6.0.tgz",
-      "integrity": "sha512-1Gnv5p3tc1VsEK25oTIRBO86czLtX6s/jeLNPAQRzdCnyEmsxkbx/sfoUJ1dwv7v8W++xckVnnuvdZv2Hp8yCw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/config-conventional/-/config-conventional-7.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fconfig-conventional%2F-%2Fconfig-conventional-7.6.0.tgz",
+      "integrity": "sha1-89xmvznjtif91vWsPQUQ3Q3Tj5Q=",
       "dev": true
     },
     "@commitlint/ensure": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-12.1.4.tgz",
-      "integrity": "sha512-MxHIBuAG9M4xl33qUfIeMSasbv3ktK0W+iygldBxZOL4QSYC2Gn66pZAQMnV9o3V+sVFHoAK2XUKqBAYrgbEqw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/ensure/-/ensure-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fensure%2F-%2Fensure-12.1.4.tgz",
+      "integrity": "sha1-KHri3MXMsIbnSXBbG9m9uZdzBW8=",
       "dev": true,
       "requires": {
         "@commitlint/types": "^12.1.4",
@@ -510,14 +485,14 @@
     },
     "@commitlint/execute-rule": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-12.1.4.tgz",
-      "integrity": "sha512-h2S1j8SXyNeABb27q2Ok2vD1WfxJiXvOttKuRA9Or7LN6OQoC/KtT3844CIhhWNteNMu/wE0gkTqGxDVAnJiHg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/execute-rule/-/execute-rule-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fexecute-rule%2F-%2Fexecute-rule-12.1.4.tgz",
+      "integrity": "sha1-mXOwLpd5rb8VIq6awgekgV7HPeE=",
       "dev": true
     },
     "@commitlint/format": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-12.1.4.tgz",
-      "integrity": "sha512-h28ucMaoRjVvvgS6Bdf85fa/+ZZ/iu1aeWGCpURnQV7/rrVjkhNSjZwGlCOUd5kDV1EnZ5XdI7L18SUpRjs26g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/format/-/format-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fformat%2F-%2Fformat-12.1.4.tgz",
+      "integrity": "sha1-2y1GQYpq5XyQ5ff2Xf9G8CZdnyQ=",
       "dev": true,
       "requires": {
         "@commitlint/types": "^12.1.4",
@@ -526,8 +501,8 @@
     },
     "@commitlint/is-ignored": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-12.1.4.tgz",
-      "integrity": "sha512-uTu2jQU2SKvtIRVLOzMQo3KxDtO+iJ1p0olmncwrqy4AfPLgwoyCP2CiULq5M7xpR3+dE3hBlZXbZTQbD7ycIw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/is-ignored/-/is-ignored-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fis-ignored%2F-%2Fis-ignored-12.1.4.tgz",
+      "integrity": "sha1-TEMLw7NhqpvlzU3bJSwVWYcOp7w=",
       "dev": true,
       "requires": {
         "@commitlint/types": "^12.1.4",
@@ -536,8 +511,8 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -547,8 +522,8 @@
     },
     "@commitlint/lint": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-12.1.4.tgz",
-      "integrity": "sha512-1kZ8YDp4to47oIPFELUFGLiLumtPNKJigPFDuHt2+f3Q3IKdQ0uk53n3CPl4uoyso/Og/EZvb1mXjFR/Yce4cA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/lint/-/lint-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Flint%2F-%2Flint-12.1.4.tgz",
+      "integrity": "sha1-hWt/0rLmNnuDbLhKEvHBs8DkDSI=",
       "dev": true,
       "requires": {
         "@commitlint/is-ignored": "^12.1.4",
@@ -559,8 +534,8 @@
     },
     "@commitlint/load": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-12.1.4.tgz",
-      "integrity": "sha512-Keszi0IOjRzKfxT+qES/n+KZyLrxy79RQz8wWgssCboYjKEp+wC+fLCgbiMCYjI5k31CIzIOq/16J7Ycr0C0EA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/load/-/load-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fload%2F-%2Fload-12.1.4.tgz",
+      "integrity": "sha1-48LbwOfY2Sj1emh4vXIZkJ/ArKs=",
       "dev": true,
       "requires": {
         "@commitlint/execute-rule": "^12.1.4",
@@ -574,14 +549,14 @@
     },
     "@commitlint/message": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-12.1.4.tgz",
-      "integrity": "sha512-6QhalEKsKQ/Y16/cTk5NH4iByz26fqws2ub+AinHPtM7Io0jy4e3rym9iE+TkEqiqWZlUigZnTwbPvRJeSUBaA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/message/-/message-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fmessage%2F-%2Fmessage-12.1.4.tgz",
+      "integrity": "sha1-OJXtzAcJ3spZRfPVX16pWp8fRG0=",
       "dev": true
     },
     "@commitlint/parse": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-12.1.4.tgz",
-      "integrity": "sha512-yqKSAsK2V4X/HaLb/yYdrzs6oD/G48Ilt0EJ2Mp6RJeWYxG14w/Out6JrneWnr/cpzemyN5hExOg6+TB19H/Lw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/parse/-/parse-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fparse%2F-%2Fparse-12.1.4.tgz",
+      "integrity": "sha1-ugPVTSTvhPb9L/McXpmYsi19CqE=",
       "dev": true,
       "requires": {
         "@commitlint/types": "^12.1.4",
@@ -591,8 +566,8 @@
     },
     "@commitlint/read": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-12.1.4.tgz",
-      "integrity": "sha512-TnPQSJgD8Aod5Xeo9W4SaYKRZmIahukjcCWJ2s5zb3ZYSmj6C85YD9cR5vlRyrZjj78ItLUV/X4FMWWVIS38Jg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/read/-/read-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fread%2F-%2Fread-12.1.4.tgz",
+      "integrity": "sha1-VS/aQu8YXVtXi+tvYmpfiygt46Y=",
       "dev": true,
       "requires": {
         "@commitlint/top-level": "^12.1.4",
@@ -603,8 +578,8 @@
     },
     "@commitlint/resolve-extends": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-12.1.4.tgz",
-      "integrity": "sha512-R9CoUtsXLd6KSCfsZly04grsH6JVnWFmVtWgWs1KdDpdV+G3TSs37tColMFqglpkx3dsWu8dsPD56+D9YnJfqg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/resolve-extends/-/resolve-extends-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fresolve-extends%2F-%2Fresolve-extends-12.1.4.tgz",
+      "integrity": "sha1-51jtfc35QmGLn2A6fCimQPaggCo=",
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
@@ -615,8 +590,8 @@
     },
     "@commitlint/rules": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-12.1.4.tgz",
-      "integrity": "sha512-W8m6ZSjg7RuIsIfzQiFHa48X5mcPXeKT9yjBxVmjHvYfS2FDBf1VxCQ7vO0JTVIdV4ohjZ0eKg/wxxUuZHJAZg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/rules/-/rules-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Frules%2F-%2Frules-12.1.4.tgz",
+      "integrity": "sha1-DhQbCMqj173EiqeEuqi6/z79ZNs=",
       "dev": true,
       "requires": {
         "@commitlint/ensure": "^12.1.4",
@@ -627,23 +602,62 @@
     },
     "@commitlint/to-lines": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-12.1.4.tgz",
-      "integrity": "sha512-TParumvbi8bdx3EdLXz2MaX+e15ZgoCqNUgqHsRLwyqLUTRbqCVkzrfadG1UcMQk8/d5aMbb327ZKG3Q4BRorw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/to-lines/-/to-lines-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Fto-lines%2F-%2Fto-lines-12.1.4.tgz",
+      "integrity": "sha1-yqWC2/Eh83egWIu2TiXEhUhDzSU=",
       "dev": true
     },
     "@commitlint/top-level": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-12.1.4.tgz",
-      "integrity": "sha512-d4lTJrOT/dXlpY+NIt4CUl77ciEzYeNVc0VFgUQ6VA+b1rqYD2/VWFjBlWVOrklxtSDeKyuEhs36RGrppEFAvg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/top-level/-/top-level-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Ftop-level%2F-%2Ftop-level-12.1.4.tgz",
+      "integrity": "sha1-ltXHFb/Bvfht/PEbZ/ws92WMem4=",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-up/-/find-up-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-5.0.0.tgz",
+          "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/locate-path/-/locate-path-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-6.0.0.tgz",
+          "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-limit/-/p-limit-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-3.1.0.tgz",
+          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-locate/-/p-locate-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-5.0.0.tgz",
+          "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
       }
     },
     "@commitlint/types": {
       "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.4.tgz",
-      "integrity": "sha512-KRIjdnWNUx6ywz+SJvjmNCbQKcKP6KArhjZhY2l+CWKxak0d77SOjggkMwFTiSgLODOwmuLTbarR2ZfWPiPMlw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@commitlint/types/-/types-12.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40commitlint%2Ftypes%2F-%2Ftypes-12.1.4.tgz",
+      "integrity": "sha1-lhil3ImR+1jm3m7YnXv3Evp0un4=",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"
@@ -651,8 +665,8 @@
     },
     "@es-joy/jsdoccomment": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.6.0.tgz",
-      "integrity": "sha512-zT1EtysKMITJ7vE4RvOJqitxk/Str6It8hq+fykxkwLuTyzgak+TnVuVSIyovT/qrEz3i46ypCSXgNtIDYwNOg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@es-joy/jsdoccomment/-/jsdoccomment-0.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40es-joy%2Fjsdoccomment%2F-%2Fjsdoccomment-0.6.0.tgz",
+      "integrity": "sha1-iSaoGE3wlohg+MabO/xS76auqjA=",
       "dev": true,
       "requires": {
         "comment-parser": "^1.1.5",
@@ -662,8 +676,8 @@
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@eslint/eslintrc/-/eslintrc-0.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40eslint%2Feslintrc%2F-%2Feslintrc-0.4.3.tgz",
+      "integrity": "sha1-nkKYHvA1vrPdSa3ResuW6P9vOUw=",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -679,16 +693,16 @@
       "dependencies": {
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ignore/-/ignore-4.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fignore%2F-%2Fignore-4.0.6.tgz",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         }
       }
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@humanwhocodes/config-array/-/config-array-0.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40humanwhocodes%2Fconfig-array%2F-%2Fconfig-array-0.5.0.tgz",
+      "integrity": "sha1-FAeWfUxu7Nc4j4Os8er00Mbljvk=",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -698,14 +712,14 @@
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40humanwhocodes%2Fobject-schema%2F-%2Fobject-schema-1.2.1.tgz",
+      "integrity": "sha1-tSBSnsIdjllFoYUd/Rwy6U45/0U=",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40istanbuljs%2Fload-nyc-config%2F-%2Fload-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -713,80 +727,32 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        }
       }
     },
     "@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@istanbuljs/schema/-/schema-0.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40istanbuljs%2Fschema%2F-%2Fschema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
       "dev": true
     },
     "@jest/console": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.3.1.tgz",
-      "integrity": "sha512-RkFNWmv0iui+qsOr/29q9dyfKTTT5DCuP31kUwg7rmOKPT/ozLeGLKJKVIiOfbiKyleUZKIrHwhmiZWVe8IMdw==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/console/-/console-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Fconsole%2F-%2Fconsole-27.4.2.tgz",
+      "integrity": "sha1-epVhLTjAB921KO5Eb+Xl54Xmhc4=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.3.1",
-        "jest-util": "^27.3.1",
+        "jest-message-util": "^27.4.2",
+        "jest-util": "^27.4.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -798,81 +764,90 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
+          }
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
           }
         }
       }
     },
     "@jest/core": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.3.1.tgz",
-      "integrity": "sha512-DMNE90RR5QKx0EA+wqe3/TNEwiRpOkhshKNxtLxd4rt3IZpCt+RSL+FoJsGeblRZmqdK4upHA/mKKGPPRAifhg==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/core/-/core-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Fcore%2F-%2Fcore-27.4.5.tgz",
+      "integrity": "sha1-yuLcNCWXgvSGbGYGw7SAzOkg7Uw=",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.3.1",
-        "@jest/reporters": "^27.3.1",
-        "@jest/test-result": "^27.3.1",
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/console": "^27.4.2",
+        "@jest/reporters": "^27.4.5",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.3.0",
-        "jest-config": "^27.3.1",
-        "jest-haste-map": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.3.1",
-        "jest-resolve-dependencies": "^27.3.1",
-        "jest-runner": "^27.3.1",
-        "jest-runtime": "^27.3.1",
-        "jest-snapshot": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-validate": "^27.3.1",
-        "jest-watcher": "^27.3.1",
+        "jest-changed-files": "^27.4.2",
+        "jest-config": "^27.4.5",
+        "jest-haste-map": "^27.4.5",
+        "jest-message-util": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-resolve-dependencies": "^27.4.5",
+        "jest-runner": "^27.4.5",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
+        "jest-watcher": "^27.4.2",
         "micromatch": "^4.0.4",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -884,54 +859,72 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "@jest/environment": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.3.1.tgz",
-      "integrity": "sha512-BCKCj4mOVLme6Tanoyc9k0ultp3pnmuyHw73UHRPeeZxirsU/7E3HC4le/VDb/SMzE1JcPnto+XBKFOcoiJzVw==",
+      "version": "27.4.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/environment/-/environment-27.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Fenvironment%2F-%2Fenvironment-27.4.4.tgz",
+      "integrity": "sha1-Zuvrx5Zz2EqtKdK7cKjFHmwpu00=",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.3.0"
+        "jest-mock": "^27.4.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -943,8 +936,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -953,32 +946,23 @@
       }
     },
     "@jest/fake-timers": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.3.1.tgz",
-      "integrity": "sha512-M3ZFgwwlqJtWZ+QkBG5NmC23A9w+A6ZxNsO5nJxJsKYt4yguBd3i8TpjQz5NfCX91nEve1KqD9RA2Q+Q1uWqoA==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/fake-timers/-/fake-timers-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ffake-timers%2F-%2Ffake-timers-27.4.2.tgz",
+      "integrity": "sha1-0hf4bDuiAnvyngtzH9DLdhpy0JM=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.3.1",
-        "jest-mock": "^27.3.0",
-        "jest-util": "^27.3.1"
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -990,69 +974,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
-            "@types/stack-utils": "^2.0.0",
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.4",
-            "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3"
-          }
-        }
-      }
-    },
-    "@jest/globals": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.3.1.tgz",
-      "integrity": "sha512-Q651FWiWQAIFiN+zS51xqhdZ8g9b88nGCobC87argAxA7nMfNQq0Q0i9zTfQYgLa6qFXk2cGANEqfK051CZ8Pg==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.3.1",
-        "@jest/types": "^27.2.5",
-        "expect": "^27.3.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
-        "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1060,96 +983,178 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
           "dev": true
-        },
-        "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
-          "dev": true
-        },
-        "expect": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-27.3.1.tgz",
-          "integrity": "sha512-MrNXV2sL9iDRebWPGOGFdPQRl2eDQNu/uhxIMShjjx74T6kC6jFIkmQ6OqXDtevjGUkyB2IT56RzDBqXf/QPCg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.2.5",
-            "ansi-styles": "^5.0.0",
-            "jest-get-type": "^27.3.1",
-            "jest-matcher-utils": "^27.3.1",
-            "jest-message-util": "^27.3.1",
-            "jest-regex-util": "^27.0.6"
-          }
-        },
-        "jest-diff": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
-          "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
-          }
-        },
-        "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.3.1.tgz",
-          "integrity": "sha512-hX8N7zXS4k+8bC1Aj0OWpGb7D3gIXxYvPNK1inP5xvE4ztbz3rc4AkI6jGVaerepBnfWB17FL5lWFJT3s7qo8w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "jest-diff": "^27.3.1",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
-          }
         },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
+      }
+    },
+    "@jest/globals": {
+      "version": "27.4.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/globals/-/globals-27.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Fglobals%2F-%2Fglobals-27.4.4.tgz",
+      "integrity": "sha1-/lAagMI+otq1hcQr4qUZu144Uw0=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.4.4",
+        "@jest/types": "^27.4.2",
+        "expect": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/diff-sequences/-/diff-sequences-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff-sequences%2F-%2Fdiff-sequences-27.4.0.tgz",
+          "integrity": "sha1-14OSCtjQbscYoGDQAZbf7yWxMqU=",
+          "dev": true
+        },
+        "expect": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expect/-/expect-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpect%2F-%2Fexpect-27.4.2.tgz",
+          "integrity": "sha1-RCmw9+MHdx0Xbem98jIpsQHbbvY=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-styles": "^5.0.0",
+            "jest-get-type": "^27.4.0",
+            "jest-matcher-utils": "^27.4.2",
+            "jest-message-util": "^27.4.2",
+            "jest-regex-util": "^27.4.0"
+          }
+        },
+        "jest-diff": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-diff/-/jest-diff-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-diff%2F-%2Fjest-diff-27.4.2.tgz",
+          "integrity": "sha1-eGsqUhHYVPhI4tzB4yREjpSB828=",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^27.4.0",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-matcher-utils%2F-%2Fjest-matcher-utils-27.4.2.tgz",
+          "integrity": "sha1-0XxQOGB5eKJV4Kmlwywk6YS2xgs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^27.4.2",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^27.4.2",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "@jest/reporters": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.3.1.tgz",
-      "integrity": "sha512-m2YxPmL9Qn1emFVgZGEiMwDntDxRRQ2D58tiDQlwYTg5GvbFOKseYCcHtn0WsI8CG4vzPglo3nqbOiT8ySBT/w==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/reporters/-/reporters-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Freporters%2F-%2Freporters-27.4.5.tgz",
+      "integrity": "sha1-4imsykjRjqOegFVAwcMisHWuY60=",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.3.1",
-        "@jest/test-result": "^27.3.1",
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/console": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -1161,10 +1166,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.3.1",
-        "jest-resolve": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-worker": "^27.3.1",
+        "jest-haste-map": "^27.4.5",
+        "jest-resolve": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1173,9 +1178,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1187,8 +1192,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1197,9 +1202,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
-      "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
+      "version": "27.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/source-map/-/source-map-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Fsource-map%2F-%2Fsource-map-27.4.0.tgz",
+      "integrity": "sha1-LwOF0NiE+z4lVOj3H4+pV6+adLY=",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -1208,21 +1213,21 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.3.1.tgz",
-      "integrity": "sha512-mLn6Thm+w2yl0opM8J/QnPTqrfS4FoXsXF2WIWJb2O/GBSyResL71BRuMYbYRsGt7ELwS5JGcEcGb52BNrumgg==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/test-result/-/test-result-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftest-result%2F-%2Ftest-result-27.4.2.tgz",
+      "integrity": "sha1-Bf1KVGbsUC8+rgs53/K5PqTV2ew=",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/console": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1234,8 +1239,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1244,33 +1249,33 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.3.1.tgz",
-      "integrity": "sha512-siySLo07IMEdSjA4fqEnxfIX8lB/lWYsBPwNFtkOvsFQvmBrL3yj3k3uFNZv/JDyApTakRpxbKLJ3CT8UGVCrA==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/test-sequencer/-/test-sequencer-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftest-sequencer%2F-%2Ftest-sequencer-27.4.5.tgz",
+      "integrity": "sha1-HX4CaETTQ7YNLKf9gsV5oXtEXX0=",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.3.1",
+        "@jest/test-result": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.3.1",
-        "jest-runtime": "^27.3.1"
+        "jest-haste-map": "^27.4.5",
+        "jest-runtime": "^27.4.5"
       }
     },
     "@jest/transform": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.3.1.tgz",
-      "integrity": "sha512-3fSvQ02kuvjOI1C1ssqMVBKJpZf6nwoCiSu00zAKh5nrp3SptNtZy/8s5deayHnqxhjD9CWDJ+yqQwuQ0ZafXQ==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/transform/-/transform-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftransform%2F-%2Ftransform-27.4.5.tgz",
+      "integrity": "sha1-Pf4uNoDNSqJzVhcr8lYXq1uU8ZU=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.3.1",
-        "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.3.1",
+        "jest-haste-map": "^27.4.5",
+        "jest-regex-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1279,9 +1284,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1293,25 +1298,25 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
         }
       }
     },
     "@jest/types": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-26.6.2.tgz",
+      "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -1320,79 +1325,112 @@
         "chalk": "^4.0.0"
       }
     },
-    "@microsoft/api-documenter": {
-      "version": "7.13.68",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.13.68.tgz",
-      "integrity": "sha512-cRjwK1TDyGxFGgCsRG8G0Yi3Z4akvfWgw1pWAxKFbm7ajlQQGZcHPnb+n4lKlSeQ5g/cxc7hcdw54Mvisne9Bg==",
+    "@masterodin/publisher": {
+      "version": "0.10.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@masterodin/publisher/-/publisher-0.10.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40masterodin%2Fpublisher%2F-%2Fpublisher-0.10.0.tgz",
+      "integrity": "sha1-Ay6I9OioX1+GuNcjO7BKg12yg3I=",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.13.16",
+        "ansi-colors": "^4.1.1",
+        "commander": "^6.0.0",
+        "ignore-walk": "^4.0.1",
+        "rimraf": "^3.0.2",
+        "strip-json-comments": "^3.0.1"
+      }
+    },
+    "@microsoft/api-documenter": {
+      "version": "7.13.76",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@microsoft/api-documenter/-/api-documenter-7.13.76.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40microsoft%2Fapi-documenter%2F-%2Fapi-documenter-7.13.76.tgz",
+      "integrity": "sha1-0zTspBcOKRgj2kh5ajFBK9kt7kA=",
+      "dev": true,
+      "requires": {
+        "@microsoft/api-extractor-model": "7.15.1",
         "@microsoft/tsdoc": "0.13.2",
-        "@rushstack/node-core-library": "3.43.2",
-        "@rushstack/ts-command-line": "4.10.4",
+        "@rushstack/node-core-library": "3.44.2",
+        "@rushstack/ts-command-line": "4.10.5",
         "colors": "~1.2.1",
         "js-yaml": "~3.13.1",
         "resolve": "~1.17.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.17.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.17.0.tgz",
+          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.18.19",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.18.19.tgz",
-      "integrity": "sha512-aY+/XR7PtQXtnqNPFRs3/+iVRlQJpo6uLTjO2g7PqmnMywl3GBU3bCgAlV/khZtAQbIs6Le57XxmSE6rOqbcfg==",
+      "version": "7.19.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@microsoft/api-extractor/-/api-extractor-7.19.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40microsoft%2Fapi-extractor%2F-%2Fapi-extractor-7.19.2.tgz",
+      "integrity": "sha1-jFRgA1IxY8FDL24ZUGBl95DWGCw=",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.13.16",
+        "@microsoft/api-extractor-model": "7.15.1",
         "@microsoft/tsdoc": "0.13.2",
         "@microsoft/tsdoc-config": "~0.15.2",
-        "@rushstack/node-core-library": "3.43.2",
-        "@rushstack/rig-package": "0.3.5",
-        "@rushstack/ts-command-line": "4.10.4",
+        "@rushstack/node-core-library": "3.44.2",
+        "@rushstack/rig-package": "0.3.6",
+        "@rushstack/ts-command-line": "4.10.5",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~4.4.2"
+        "typescript": "~4.5.2"
       },
       "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.17.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.17.0.tgz",
+          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "typescript": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-          "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+          "version": "4.5.3",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/typescript/-/typescript-4.5.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypescript%2F-%2Ftypescript-4.5.3.tgz",
+          "integrity": "sha1-r6qFjmjHEDMX2J65DF2JBiaNNTw=",
           "dev": true
         }
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.13.16.tgz",
-      "integrity": "sha512-ttdxVXsTWL5dd26W1YNLe3LgDsE0EE273aZlcLe58W0opymBybCYU1Mn+OHQM8BuErrdvdN8LdpWAAbkiOEN/Q==",
+      "version": "7.15.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@microsoft/api-extractor-model/-/api-extractor-model-7.15.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40microsoft%2Fapi-extractor-model%2F-%2Fapi-extractor-model-7.15.1.tgz",
+      "integrity": "sha1-5S1oZ26EbYuG47GOJlSvOfum5KE=",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.13.2",
         "@microsoft/tsdoc-config": "~0.15.2",
-        "@rushstack/node-core-library": "3.43.2"
+        "@rushstack/node-core-library": "3.44.2"
       }
     },
     "@microsoft/tsdoc": {
       "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
-      "integrity": "sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40microsoft%2Ftsdoc%2F-%2Ftsdoc-0.13.2.tgz",
+      "integrity": "sha1-Ow77bTkDvUntsHNpb2DpDfCO+yY=",
       "dev": true
     },
     "@microsoft/tsdoc-config": {
       "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz",
-      "integrity": "sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40microsoft%2Ftsdoc-config%2F-%2Ftsdoc-config-0.15.2.tgz",
+      "integrity": "sha1-6zU8k/O2KrdL3Jq29Kgrz4AUDxQ=",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.13.2",
@@ -1403,8 +1441,8 @@
       "dependencies": {
         "resolve": {
           "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.19.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.19.0.tgz",
+          "integrity": "sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=",
           "dev": true,
           "requires": {
             "is-core-module": "^2.1.0",
@@ -1415,8 +1453,8 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40nodelib%2Ffs.scandir%2F-%2Ffs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1425,14 +1463,14 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40nodelib%2Ffs.stat%2F-%2Ffs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40nodelib%2Ffs.walk%2F-%2Ffs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1441,8 +1479,8 @@
     },
     "@octokit/auth-token": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/auth-token/-/auth-token-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fauth-token%2F-%2Fauth-token-2.5.0.tgz",
+      "integrity": "sha1-J8N+omwgXyhENAJHf/0mExHyHjY=",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.0.3"
@@ -1450,8 +1488,8 @@
     },
     "@octokit/core": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/core/-/core-3.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fcore%2F-%2Fcore-3.5.1.tgz",
+      "integrity": "sha1-hgHO6x7A4bG4IXuWCkE+2OlHgJs=",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
@@ -1465,8 +1503,8 @@
     },
     "@octokit/endpoint": {
       "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/endpoint/-/endpoint-6.0.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fendpoint%2F-%2Fendpoint-6.0.12.tgz",
+      "integrity": "sha1-O01HpLDnmxAn+4111CIZKLLQVlg=",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.0.3",
@@ -1476,16 +1514,16 @@
       "dependencies": {
         "is-plain-object": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-plain-object/-/is-plain-object-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-object%2F-%2Fis-plain-object-5.0.0.tgz",
+          "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q=",
           "dev": true
         }
       }
     },
     "@octokit/graphql": {
       "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/graphql/-/graphql-4.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fgraphql%2F-%2Fgraphql-4.8.0.tgz",
+      "integrity": "sha1-Zk2bEcDhIRLL944Q9JoFlZqiLMM=",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.6.0",
@@ -1495,14 +1533,14 @@
     },
     "@octokit/openapi-types": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/openapi-types/-/openapi-types-11.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fopenapi-types%2F-%2Fopenapi-types-11.2.0.tgz",
+      "integrity": "sha1-s41/w3NtUqHpayMMHM1KWKL0AKY=",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fplugin-paginate-rest%2F-%2Fplugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha1-MunHyrKjdEIdPQ3iORAih9eRvOc=",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.34.0"
@@ -1510,14 +1548,14 @@
     },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fplugin-request-log%2F-%2Fplugin-request-log-1.0.4.tgz",
+      "integrity": "sha1-XlDtcIOmE4FrHkooruxft/FGLoU=",
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Fplugin-rest-endpoint-methods%2F-%2Fplugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha1-jEYQkCGjQSIz9vUNKHhvjlUkJ7o=",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.34.0",
@@ -1526,8 +1564,8 @@
     },
     "@octokit/request": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/request/-/request-5.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Frequest%2F-%2Frequest-5.6.2.tgz",
+      "integrity": "sha1-GqdNXae54ErGDvIy7dmnQ43PMtg=",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
@@ -1540,16 +1578,16 @@
       "dependencies": {
         "is-plain-object": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-plain-object/-/is-plain-object-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-object%2F-%2Fis-plain-object-5.0.0.tgz",
+          "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q=",
           "dev": true
         }
       }
     },
     "@octokit/request-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/request-error/-/request-error-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Frequest-error%2F-%2Frequest-error-2.1.0.tgz",
+      "integrity": "sha1-nhUDV4Mb/HiNE6T9SxkT1gx01nc=",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.0.3",
@@ -1559,8 +1597,8 @@
     },
     "@octokit/rest": {
       "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/rest/-/rest-18.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Frest%2F-%2Frest-18.12.0.tgz",
+      "integrity": "sha1-8GvElS/IcTAwjYEMqdAOefaYiIE=",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.5.1",
@@ -1571,17 +1609,17 @@
     },
     "@octokit/types": {
       "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@octokit/types/-/types-6.34.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40octokit%2Ftypes%2F-%2Ftypes-6.34.0.tgz",
+      "integrity": "sha1-xgITMzNNHs+103CoeYFi3fGughg=",
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^11.2.0"
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.43.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.43.2.tgz",
-      "integrity": "sha512-b7AEhSf6CvZgvuDcWMFDeKx2mQSn9AVnMQVyxNxFeHCtLz3gJicqCOlw2GOXM8HKh6PInLdil/NVCDcstwSrIw==",
+      "version": "3.44.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@rushstack/node-core-library/-/node-core-library-3.44.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40rushstack%2Fnode-core-library%2F-%2Fnode-core-library-3.44.2.tgz",
+      "integrity": "sha1-T82Pdoh65ZaPJ5b2M6fkj169InE=",
       "dev": true,
       "requires": {
         "@types/node": "12.20.24",
@@ -1592,19 +1630,19 @@
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "timsort": "~0.3.0",
-        "z-schema": "~3.18.3"
+        "z-schema": "~5.0.2"
       },
       "dependencies": {
         "@types/node": {
           "version": "12.20.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/node/-/node-12.20.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fnode%2F-%2Fnode-12.20.24.tgz",
+          "integrity": "sha1-w3rGnLKUivtM75X0JPoAN5camlw=",
           "dev": true
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-7.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-7.0.1.tgz",
+          "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -1614,44 +1652,58 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonfile/-/jsonfile-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonfile%2F-%2Fjsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.17.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.17.0.tgz",
+          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
         }
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.5.tgz",
-      "integrity": "sha512-CvqWw+E81U5lRBN/lUj7Ngr/XQa/PPb2jAS5QcLP7WL+IMUl+3+Cc2qYrsDoB4zke81kz+usWGmBQpBzGMLmAA==",
+      "version": "0.3.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@rushstack/rig-package/-/rig-package-0.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40rushstack%2Frig-package%2F-%2Frig-package-0.3.6.tgz",
+      "integrity": "sha1-pXtT21kQb7k7zaNsrU+GAvUI68Y=",
       "dev": true,
       "requires": {
         "resolve": "~1.17.0",
         "strip-json-comments": "~3.1.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.17.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.17.0.tgz",
+          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.10.4.tgz",
-      "integrity": "sha512-4T5ao4UgDb6LmiRj4GumvG3VT/p6RSMgl7TN7S58ifaAGN2GeTNBajFCDdJs9QQP0d/4tA5p0SFzT7Ps5Byirg==",
+      "version": "4.10.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@rushstack/ts-command-line/-/ts-command-line-4.10.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40rushstack%2Fts-command-line%2F-%2Fts-command-line-4.10.5.tgz",
+      "integrity": "sha1-oxpE3dJP46WU5K2Rwi8+p2aLQ6k=",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.38",
@@ -1662,8 +1714,8 @@
     },
     "@semantic-release/changelog": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.0.tgz",
-      "integrity": "sha512-X01Me+QVMykvILockNGlXXl3dgr1QqpbRQsknQoOJQCXQGXoqY3DNQ3rBQuI8/SUK7RZwYLctg0NbPNArlo6eQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/changelog/-/changelog-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Fchangelog%2F-%2Fchangelog-6.0.0.tgz",
+      "integrity": "sha1-sWY2AJv73pwJxsG4lGOvJX1KcUI=",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.1.0",
@@ -1673,14 +1725,14 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.1.tgz",
-      "integrity": "sha512-ncNsnrLmiykhgNZUXNvhhAjNN0me7VGIb0X5hu3ogyi5DDPapjGAHdEffO5vi+HX1BFWLRD/Ximx5PjGAKjAqQ==",
+      "version": "9.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Fcommit-analyzer%2F-%2Fcommit-analyzer-9.0.2.tgz",
+      "integrity": "sha1-p45U+YNBk7VfEHP6YljuzJpUXgM=",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.7",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
         "lodash": "^4.17.4",
@@ -1689,14 +1741,14 @@
     },
     "@semantic-release/error": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/error/-/error-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Ferror%2F-%2Ferror-2.2.0.tgz",
+      "integrity": "sha1-7p1aCcmWnq3h7IZHdq7aXFzdu/A=",
       "dev": true
     },
     "@semantic-release/git": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.0.tgz",
-      "integrity": "sha512-/BljvngXJzwbFFJouxHHvSzAhi5iaucF7l0kQPszD4m7Y79+FHyvQl5Q/HK7T/e8MIwU9hz321KjOZn9yfSpPg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/git/-/git-10.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Fgit%2F-%2Fgit-10.0.0.tgz",
+      "integrity": "sha1-Qd2kNOnC/iItAw8SBg5vWoaW57o=",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.1.0",
@@ -1711,8 +1763,8 @@
     },
     "@semantic-release/github": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.2.tgz",
-      "integrity": "sha512-wIbfhOeuxlYzMTjtSAa2xgr54n7ZuPAS2gadyTWBpUt2PNAPgla7A6XxCXJnaKPgfVF0iFfSk3B+KlVKk6ByVg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/github/-/github-8.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Fgithub%2F-%2Fgithub-8.0.2.tgz",
+      "integrity": "sha1-gBFKQfbsirbA04pDa0j/PyIjqxY=",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.0.0",
@@ -1735,14 +1787,14 @@
       "dependencies": {
         "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@tootallnate/once/-/once-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tootallnate%2Fonce%2F-%2Fonce-2.0.0.tgz",
+          "integrity": "sha1-9UShSNOrNYAcH2M6dEH9h8LkhL8=",
           "dev": true
         },
         "fs-extra": {
           "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-10.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-10.0.0.tgz",
+          "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -1752,21 +1804,27 @@
         },
         "http-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-proxy-agent%2F-%2Fhttp-proxy-agent-5.0.0.tgz",
+          "integrity": "sha1-USmAAgNSDUNPFCvHj/PBcIAPK0M=",
           "dev": true,
           "requires": {
             "@tootallnate/once": "2",
             "agent-base": "6",
             "debug": "4"
           }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universalify/-/universalify-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-2.0.0.tgz",
+          "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+          "dev": true
         }
       }
     },
     "@semantic-release/npm": {
       "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/npm/-/npm-8.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Fnpm%2F-%2Fnpm-8.0.3.tgz",
+      "integrity": "sha1-aTeM5Sm70mOqj8iZstD4dBFOAwI=",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
@@ -1786,14 +1844,14 @@
       "dependencies": {
         "@semantic-release/error": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/error/-/error-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Ferror%2F-%2Ferror-3.0.0.tgz",
+          "integrity": "sha1-MKO5e7tYRNaV6yL506pA9qkncMI=",
           "dev": true
         },
         "fs-extra": {
           "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-10.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-10.0.0.tgz",
+          "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -1801,71 +1859,33 @@
             "universalify": "^2.0.0"
           }
         },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
-        "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universalify/-/universalify-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-2.0.0.tgz",
+          "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
           "dev": true
         }
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.2.tgz",
-      "integrity": "sha512-I4eavIcDan8fNQHskZ2cbWkFMimvgxNkqR2UfuYNwYBgswEl3SJsN8XMf9gZWObt6nXDc2QfDwhjy8DjTZqS3w==",
+      "version": "10.0.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Frelease-notes-generator%2F-%2Frelease-notes-generator-10.0.3.tgz",
+      "integrity": "sha1-hffKeL+msB+1/aCsSBEoVdaRcdw=",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-changelog-writer": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.0",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
@@ -1876,8 +1896,8 @@
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@sinonjs/commons/-/commons-1.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Fcommons%2F-%2Fcommons-1.8.3.tgz",
+      "integrity": "sha1-OALd0hpQqUm2ch3dcto25n5/Gy0=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -1885,8 +1905,8 @@
     },
     "@sinonjs/fake-timers": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Ffake-timers%2F-%2Ffake-timers-8.1.0.tgz",
+      "integrity": "sha1-P9wrbLWJNbIb+40WJesTAEhDFuc=",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -1894,20 +1914,20 @@
     },
     "@tootallnate/once": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@tootallnate/once/-/once-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tootallnate%2Fonce%2F-%2Fonce-1.1.2.tgz",
+      "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
       "dev": true
     },
     "@types/argparse": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/argparse/-/argparse-1.0.38.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fargparse%2F-%2Fargparse-1.0.38.tgz",
+      "integrity": "sha1-qB/YYG1IH4c6OADG665PHXaKVqk=",
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.16",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
-      "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
+      "version": "7.1.17",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/babel__core/-/babel__core-7.1.17.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fbabel__core%2F-%2Fbabel__core-7.1.17.tgz",
+      "integrity": "sha1-9QrJ0g1kFTtRBXjYT5ZD+aOvvmQ=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1919,8 +1939,8 @@
     },
     "@types/babel__generator": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
-      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/babel__generator/-/babel__generator-7.6.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fbabel__generator%2F-%2Fbabel__generator-7.6.3.tgz",
+      "integrity": "sha1-9Fa0ss55E392iqEw0kI9LwzPq6U=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1928,8 +1948,8 @@
     },
     "@types/babel__template": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/babel__template/-/babel__template-7.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fbabel__template%2F-%2Fbabel__template-7.4.1.tgz",
+      "integrity": "sha1-PRpI/Z1sDt/Vby/1eNrtSPNsiWk=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1938,8 +1958,8 @@
     },
     "@types/babel__traverse": {
       "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/babel__traverse/-/babel__traverse-7.14.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fbabel__traverse%2F-%2Fbabel__traverse-7.14.2.tgz",
+      "integrity": "sha1-/81HC7s/i/MEgWePtVAieMqDOkM=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1947,49 +1967,31 @@
     },
     "@types/debug": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/debug/-/debug-4.1.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fdebug%2F-%2Fdebug-4.1.7.tgz",
+      "integrity": "sha1-fMDqdhUJEkcJuLLRCQ2PbBeq24I=",
       "dev": true,
       "requires": {
         "@types/ms": "*"
       }
     },
-    "@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "dev": true,
-      "requires": {
-        "dotenv": "*"
-      }
-    },
     "@types/extend": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/extend/-/extend-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fextend%2F-%2Fextend-3.0.1.tgz",
+      "integrity": "sha1-kj3C1wfZRDgkM+AdbMDGkDCrLHU=",
       "dev": true
     },
     "@types/file-type": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.2.tgz",
-      "integrity": "sha512-GWtM4fyqfb+bec4ocpo51/y4x0b83Je+iA6eV131LT9wL0//G+1UgwbkMg7w61ceOwR+KkZXK00z44jrrNljWg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/file-type/-/file-type-5.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ffile-type%2F-%2Ffile-type-5.2.2.tgz",
+      "integrity": "sha1-kBzaOV91eAxSu8elb9H1tbyW8o8=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
-      "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/ignore-walk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/ignore-walk/-/ignore-walk-3.0.2.tgz",
-      "integrity": "sha512-piannjEnKe/Ka68B2kz6lhs/Yv7T7aKgMGaqfZ4IZUK18KUk4VS1cpke+8s76JjNigFWcOydfG/KKnAuxmWTFA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/graceful-fs/-/graceful-fs-4.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fgraceful-fs%2F-%2Fgraceful-fs-4.1.5.tgz",
+      "integrity": "sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1997,52 +1999,52 @@
     },
     "@types/isstream": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/isstream/-/isstream-0.1.0.tgz",
-      "integrity": "sha512-jo6R5XtVMgu1ej3H4o9NXiUE/4ZxyxmDrGslGiBa4/ugJr+Olw2viio/F2Vlc+zrwC9HJzuApOCCVC2g5jqV0w=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/isstream/-/isstream-0.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fisstream%2F-%2Fisstream-0.1.0.tgz",
+      "integrity": "sha1-9lIvUsCQOtXcFTlQpyAyGSgwn6E="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fistanbul-lib-coverage%2F-%2Fistanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha1-S6jdtyAiH0MuRDvV+RF/0iz9R2I="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fistanbul-lib-report%2F-%2Fistanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-wUwk8Y6oGQwRjudWK3/5mjZVJoY=",
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "@types/istanbul-reports": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fistanbul-reports%2F-%2Fistanbul-reports-3.0.1.tgz",
+      "integrity": "sha1-kVP+mLuivVZaY63ZQ21vDX+EaP8=",
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
     },
     "@types/json-schema": {
       "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/json-schema/-/json-schema-7.0.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fjson-schema%2F-%2Fjson-schema-7.0.9.tgz",
+      "integrity": "sha1-l+3JA36gw4WFMgsolk3eOznkZg0=",
       "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/json5/-/json5-0.0.29.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fjson5%2F-%2Fjson5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.177",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
-      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
+      "version": "4.14.178",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/lodash/-/lodash-4.14.178.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Flodash%2F-%2Flodash-4.14.178.tgz",
+      "integrity": "sha1-NB9tIkfbUo1KE927N0vNyAQG9Pg=",
       "dev": true
     },
     "@types/lodash.isempty": {
       "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isempty/-/lodash.isempty-4.4.6.tgz",
-      "integrity": "sha512-AauKrFlA4z3Usog5HLGDupKzkCP7h5KXGlfAcRGUfvTmL7guVuEzDSNI6lYJ7syO7J2RE2F47179pSLr26UHIw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/lodash.isempty/-/lodash.isempty-4.4.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Flodash.isempty%2F-%2Flodash.isempty-4.4.6.tgz",
+      "integrity": "sha1-SKVXaYVyfZuF1ZpgGZ1rEax1aj4=",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -2050,78 +2052,78 @@
     },
     "@types/mime-types": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
-      "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/mime-types/-/mime-types-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fmime-types%2F-%2Fmime-types-2.1.1.tgz",
+      "integrity": "sha1-2bpDSQ+jo9+Vh1mt9pOWw1Ms8sE=",
       "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/minimist/-/minimist-1.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fminimist%2F-%2Fminimist-1.2.2.tgz",
+      "integrity": "sha1-7nceK6Sz3Fs3KTXVSf2WF780W4w=",
       "dev": true
     },
     "@types/ms": {
       "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/ms/-/ms-0.7.31.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fms%2F-%2Fms-0.7.31.tgz",
+      "integrity": "sha1-MbfKZAcSij0rvCf+LSGzRTl/YZc=",
       "dev": true
     },
     "@types/node": {
       "version": "10.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-      "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/node/-/node-10.14.22.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fnode%2F-%2Fnode-10.14.22.tgz",
+      "integrity": "sha1-NLzfa2y1/A2zPSSBatnT7OIv7qQ="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fnormalize-package-data%2F-%2Fnormalize-package-data-2.4.1.tgz",
+      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE=",
       "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/parse-json/-/parse-json-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fparse-json%2F-%2Fparse-json-4.0.0.tgz",
+      "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA=",
       "dev": true
     },
     "@types/prettier": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/prettier/-/prettier-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fprettier%2F-%2Fprettier-2.4.2.tgz",
+      "integrity": "sha1-TGL66T60eWYMO9k/nSTVYVl6goE=",
       "dev": true
     },
     "@types/retry": {
       "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/retry/-/retry-0.12.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fretry%2F-%2Fretry-0.12.1.tgz",
+      "integrity": "sha1-2PHA0Nwjr61twWqemToIZXdLQGU=",
       "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/stack-utils/-/stack-utils-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fstack-utils%2F-%2Fstack-utils-2.0.1.tgz",
+      "integrity": "sha1-IPGClPeX8iCbX2XI47XI6CYdEnw="
     },
     "@types/tough-cookie": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/tough-cookie/-/tough-cookie-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftough-cookie%2F-%2Ftough-cookie-4.0.1.tgz",
+      "integrity": "sha1-j4DdllrYHz4bwm1vXHJ+Eych/0A="
     },
     "@types/yargs": {
       "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-15.0.14.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-15.0.14.tgz",
+      "integrity": "sha1-Jtgh3biecEkhYLZtEKDrbfj2+wY=",
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
       "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs-parser/-/yargs-parser-20.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs-parser%2F-%2Fyargs-parser-20.2.1.tgz",
+      "integrity": "sha1-O5ziSJkZ2eT+pDm3aRarw0st8Sk="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Feslint-plugin%2F-%2Feslint-plugin-4.33.0.tgz",
+      "integrity": "sha1-wk3HyAacdwa8QNmfb6h+3LIAUnY=",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "4.33.0",
@@ -2136,8 +2138,8 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -2147,8 +2149,8 @@
     },
     "@typescript-eslint/experimental-utils": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Fexperimental-utils%2F-%2Fexperimental-utils-4.33.0.tgz",
+      "integrity": "sha1-byp4akIJ+iIimJ6TgLUzGygQ9/0=",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
@@ -2161,8 +2163,8 @@
     },
     "@typescript-eslint/parser": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/parser/-/parser-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Fparser%2F-%2Fparser-4.33.0.tgz",
+      "integrity": "sha1-3+eXVw2WlOVgUo0Y7srYbIx0SJk=",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -2173,8 +2175,8 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Fscope-manager%2F-%2Fscope-manager-4.33.0.tgz",
+      "integrity": "sha1-045JKA2YPody4pEhz4xukiHygKM=",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
@@ -2183,14 +2185,14 @@
     },
     "@typescript-eslint/types": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/types/-/types-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Ftypes%2F-%2Ftypes-4.33.0.tgz",
+      "integrity": "sha1-oeWQNqO1OuhDDO6/KpGdx/mvbXI=",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Ftypescript-estree%2F-%2Ftypescript-estree-4.33.0.tgz",
+      "integrity": "sha1-DftRwpCPaMXAjYKu/q8WahfCRgk=",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
@@ -2204,8 +2206,8 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -2215,8 +2217,8 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40typescript-eslint%2Fvisitor-keys%2F-%2Fvisitor-keys-4.33.0.tgz",
+      "integrity": "sha1-KiL3ekFgQom3oYZYbp7EjKku8d0=",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
@@ -2225,8 +2227,8 @@
     },
     "JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/JSONStream/-/JSONStream-1.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2FJSONStream%2F-%2FJSONStream-1.3.5.tgz",
+      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
       "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
@@ -2235,20 +2237,20 @@
     },
     "abab": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/abab/-/abab-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fabab%2F-%2Fabab-2.0.5.tgz",
+      "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o=",
       "dev": true
     },
     "acorn": {
       "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn/-/acorn-5.7.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn%2F-%2Facorn-5.7.4.tgz",
+      "integrity": "sha1-Po2KmUfQWZoXltECJddDL0pKz14=",
       "dev": true
     },
     "acorn-globals": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn-globals/-/acorn-globals-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-globals%2F-%2Facorn-globals-6.0.0.tgz",
+      "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
       "dev": true,
       "requires": {
         "acorn": "^7.1.1",
@@ -2257,22 +2259,28 @@
       "dependencies": {
         "acorn": {
           "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn/-/acorn-7.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn%2F-%2Facorn-7.4.1.tgz",
+          "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
           "dev": true
         }
       }
     },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn-jsx/-/acorn-jsx-5.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-jsx%2F-%2Facorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
+      "dev": true
+    },
     "acorn-walk": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn-walk/-/acorn-walk-7.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-walk%2F-%2Facorn-walk-7.2.0.tgz",
+      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
       "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/agent-base/-/agent-base-6.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fagent-base%2F-%2Fagent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
       "dev": true,
       "requires": {
         "debug": "4"
@@ -2280,8 +2288,8 @@
     },
     "aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/aggregate-error/-/aggregate-error-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faggregate-error%2F-%2Faggregate-error-3.1.0.tgz",
+      "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -2290,8 +2298,8 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ajv/-/ajv-6.12.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fajv%2F-%2Fajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2302,14 +2310,14 @@
     },
     "ansi-colors": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-colors/-/ansi-colors-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-colors%2F-%2Fansi-colors-4.1.1.tgz",
+      "integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
       "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-escapes/-/ansi-escapes-4.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-escapes%2F-%2Fansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
@@ -2317,35 +2325,35 @@
       "dependencies": {
         "type-fest": {
           "version": "0.21.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.21.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.21.3.tgz",
+          "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
           "dev": true
         }
       }
     },
     "ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-regex/-/ansi-regex-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "requires": {
         "color-convert": "^2.0.1"
       }
     },
     "ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansicolors/-/ansicolors-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansicolors%2F-%2Fansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/anymatch/-/anymatch-1.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fanymatch%2F-%2Fanymatch-1.3.2.tgz",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "^2.1.5",
@@ -2354,7 +2362,7 @@
       "dependencies": {
         "braces": {
           "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/braces/-/braces-1.8.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbraces%2F-%2Fbraces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
@@ -2365,19 +2373,19 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-glob/-/is-glob-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -2386,7 +2394,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2395,7 +2403,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/micromatch/-/micromatch-2.3.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmicromatch%2F-%2Fmicromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
@@ -2416,7 +2424,7 @@
         },
         "object.omit": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.omit/-/object.omit-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.omit%2F-%2Fobject.omit-2.0.1.tgz",
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
@@ -2428,8 +2436,8 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/argparse/-/argparse-1.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fargparse%2F-%2Fargparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -2437,13 +2445,13 @@
     },
     "argv-formatter": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/argv-formatter/-/argv-formatter-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fargv-formatter%2F-%2Fargv-formatter-1.0.0.tgz",
       "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
       "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arr-diff/-/arr-diff-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-diff%2F-%2Farr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -2452,26 +2460,26 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arr-flatten/-/arr-flatten-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-flatten%2F-%2Farr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arr-union/-/arr-union-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-union%2F-%2Farr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-ify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-ify/-/array-ify-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-ify%2F-%2Farray-ify-1.0.0.tgz",
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
     "array-includes": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-includes/-/array-includes-3.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-includes%2F-%2Farray-includes-3.1.4.tgz",
+      "integrity": "sha1-9bSTFix2DzU5Yx8AW6K7Rqy0W6k=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -2483,20 +2491,20 @@
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-union/-/array-union-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-union%2F-%2Farray-union-2.1.0.tgz",
+      "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-unique/-/array-unique-0.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-unique%2F-%2Farray-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "array.prototype.flat": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray.prototype.flat%2F-%2Farray.prototype.flat-1.2.5.tgz",
+      "integrity": "sha1-B+CXXYS7x8SM0YedYJ5oJZjTPhM=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -2506,82 +2514,82 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arrify/-/arrify-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farrify%2F-%2Farrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/assign-symbols/-/assign-symbols-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fassign-symbols%2F-%2Fassign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/astral-regex/-/astral-regex-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fastral-regex%2F-%2Fastral-regex-2.0.0.tgz",
+      "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
       "dev": true
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/async-each/-/async-each-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasync-each%2F-%2Fasync-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/asynckit/-/asynckit-0.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasynckit%2F-%2Fasynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/at-least-node/-/at-least-node-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fat-least-node%2F-%2Fat-least-node-1.0.0.tgz",
+      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/atob/-/atob-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fatob%2F-%2Fatob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "axios": {
       "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/axios/-/axios-0.21.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faxios%2F-%2Faxios-0.21.4.tgz",
+      "integrity": "sha1-xnuQ3AVo5cHPKwuFjEO6KOLtpXU=",
       "requires": {
         "follow-redirects": "^1.14.0"
       }
     },
     "axios-cookiejar-support": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faxios-cookiejar-support%2F-%2Faxios-cookiejar-support-1.0.1.tgz",
+      "integrity": "sha1-ezKvfZMlCFRsaLH8W6j1YohBYuE=",
       "requires": {
         "is-redirect": "^1.0.0",
         "pify": "^5.0.0"
       }
     },
     "babel-jest": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
-      "integrity": "sha512-SjIF8hh/ir0peae2D6S6ZKRhUy7q/DnpH7k/V6fT4Bgs/LXXUztOpX4G2tCgq8mLo5HA9mN6NmlFMeYtKmIsTQ==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-jest/-/babel-jest-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-jest%2F-%2Fbabel-jest-27.4.5.tgz",
+      "integrity": "sha1-04vQvo6nHYuXhTpfyfdt7rCVxwk=",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.2.0",
+        "babel-preset-jest": "^27.4.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2593,8 +2601,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -2604,8 +2612,8 @@
     },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-plugin-istanbul%2F-%2Fbabel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2617,8 +2625,8 @@
       "dependencies": {
         "istanbul-lib-instrument": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-          "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-instrument%2F-%2Fistanbul-lib-instrument-5.1.0.tgz",
+          "integrity": "sha1-e0kZi2V7J6cwuOnLYB8eG/8kxZo=",
           "dev": true,
           "requires": {
             "@babel/core": "^7.12.3",
@@ -2631,9 +2639,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz",
-      "integrity": "sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==",
+      "version": "27.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-plugin-jest-hoist%2F-%2Fbabel-plugin-jest-hoist-27.4.0.tgz",
+      "integrity": "sha1-14MfwPk1c3iNgN7n5oJILaTHMNY=",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -2644,8 +2652,8 @@
     },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-preset-current-node-syntax%2F-%2Fbabel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -2663,18 +2671,18 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz",
-      "integrity": "sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==",
+      "version": "27.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-preset-jest/-/babel-preset-jest-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-preset-jest%2F-%2Fbabel-preset-jest-27.4.0.tgz",
+      "integrity": "sha1-cNDmdqKCzLIA+6vX9BXbX985O8o=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.2.0",
+        "babel-plugin-jest-hoist": "^27.4.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/babel-runtime/-/babel-runtime-6.26.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-runtime%2F-%2Fbabel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -2684,14 +2692,14 @@
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbalanced-match%2F-%2Fbalanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/base/-/base-0.11.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbase%2F-%2Fbase-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -2705,31 +2713,60 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
     },
     "before-after-hook": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/before-after-hook/-/before-after-hook-2.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbefore-after-hook%2F-%2Fbefore-after-hook-2.2.2.tgz",
+      "integrity": "sha1-pujKQQKNkO4sJCIvIByQlWCRYT4=",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/binary-extensions/-/binary-extensions-1.13.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbinary-extensions%2F-%2Fbinary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/bindings/-/bindings-1.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbindings%2F-%2Fbindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2738,20 +2775,20 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/bluebird/-/bluebird-3.7.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbluebird%2F-%2Fbluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bottleneck": {
       "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/bottleneck/-/bottleneck-2.19.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbottleneck%2F-%2Fbottleneck-2.19.5.tgz",
+      "integrity": "sha1-XfC5D1n9R2VuvmPHiphBkgXK3ZE=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2760,22 +2797,22 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/braces/-/braces-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbraces%2F-%2Fbraces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "requires": {
         "fill-range": "^7.0.1"
       }
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrowser-process-hrtime%2F-%2Fbrowser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
       "dev": true
     },
     "browserslist": {
       "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
-      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/browserslist/-/browserslist-4.18.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrowserslist%2F-%2Fbrowserslist-4.18.1.tgz",
+      "integrity": "sha1-YNOSDyW2hg65F8bHsYVXb02LAX8=",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001280",
@@ -2787,8 +2824,8 @@
     },
     "bser": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/bser/-/bser-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbser%2F-%2Fbser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -2796,25 +2833,25 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbuffer-equal-constant-time%2F-%2Fbuffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/buffer-from/-/buffer-from-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbuffer-from%2F-%2Fbuffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/builtin-modules/-/builtin-modules-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbuiltin-modules%2F-%2Fbuiltin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cache-base/-/cache-base-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcache-base%2F-%2Fcache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -2830,8 +2867,8 @@
     },
     "call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/call-bind/-/call-bind-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcall-bind%2F-%2Fcall-bind-1.0.2.tgz",
+      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -2840,13 +2877,13 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/callsites/-/callsites-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcallsites%2F-%2Fcallsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/camel-case/-/camel-case-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcamel-case%2F-%2Fcamel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -2856,13 +2893,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/camelcase/-/camelcase-5.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcamelcase%2F-%2Fcamelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "camelcase-keys": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/camelcase-keys/-/camelcase-keys-6.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcamelcase-keys%2F-%2Fcamelcase-keys-6.2.2.tgz",
+      "integrity": "sha1-XnVda6UaoiPsfT1S8ld4IQ+dw8A=",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -2871,14 +2908,14 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001286",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcaniuse-lite%2F-%2Fcaniuse-lite-1.0.30001286.tgz",
+      "integrity": "sha1-Pp3rrUIEGWGM/fUtybZXKyio//Y=",
       "dev": true
     },
     "cardinal": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cardinal/-/cardinal-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcardinal%2F-%2Fcardinal-2.1.1.tgz",
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "requires": {
@@ -2888,8 +2925,8 @@
     },
     "chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/chalk/-/chalk-4.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2897,13 +2934,13 @@
     },
     "char-regex": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/char-regex/-/char-regex-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchar-regex%2F-%2Fchar-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
       "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/chokidar/-/chokidar-1.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchokidar%2F-%2Fchokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
@@ -2918,15 +2955,24 @@
         "readdirp": "^2.0.0"
       },
       "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob-parent/-/glob-parent-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob-parent%2F-%2Fglob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-glob/-/is-glob-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -2936,21 +2982,21 @@
       }
     },
     "ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "version": "3.3.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ci-info/-/ci-info-3.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fci-info%2F-%2Fci-info-3.3.0.tgz",
+      "integrity": "sha1-tO0ftoGN6kgDpVxiMEH5Fl0gZrI=",
       "dev": true
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcjs-module-lexer%2F-%2Fcjs-module-lexer-1.2.2.tgz",
+      "integrity": "sha1-n4S6MkSlEvOlTlJ36O70xImGTkA=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/class-utils/-/class-utils-0.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fclass-utils%2F-%2Fclass-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -2961,82 +3007,25 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-0.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/clean-stack/-/clean-stack-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fclean-stack%2F-%2Fclean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "dev": true
     },
     "cli-table3": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cli-table3/-/cli-table3-0.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcli-table3%2F-%2Fcli-table3-0.6.0.tgz",
+      "integrity": "sha1-t7G8ZcqOe1zvkSThPcKyHizk+u4=",
       "dev": true,
       "requires": {
         "colors": "^1.1.2",
@@ -3046,8 +3035,8 @@
     },
     "cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cliui/-/cliui-7.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcliui%2F-%2Fcliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
@@ -3057,19 +3046,19 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/co/-/co-4.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fco%2F-%2Fco-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcollect-v8-coverage%2F-%2Fcollect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha1-zCyOlPwYu9/+ZNZTRXDIpnOyf1k=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/collection-visit/-/collection-visit-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcollection-visit%2F-%2Fcollection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -3079,47 +3068,47 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-convert/-/color-convert-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-convert%2F-%2Fcolor-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-name/-/color-name-1.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-name%2F-%2Fcolor-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
     },
     "colors": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/colors/-/colors-1.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolors%2F-%2Fcolors-1.2.5.tgz",
+      "integrity": "sha1-icetmjdLwDDfgBMkH2gTbtiDWvw=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/combined-stream/-/combined-stream-1.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcombined-stream%2F-%2Fcombined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+      "version": "6.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/commander/-/commander-6.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcommander%2F-%2Fcommander-6.2.1.tgz",
+      "integrity": "sha1-B5LraC37wyWZm7K4T93duhEKxzw=",
       "dev": true
     },
     "comment-parser": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.5.tgz",
-      "integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/comment-parser/-/comment-parser-1.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcomment-parser%2F-%2Fcomment-parser-1.1.5.tgz",
+      "integrity": "sha1-RTYn749n287ETnmpvVuqN/C86bI=",
       "dev": true
     },
     "compare-func": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/compare-func/-/compare-func-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcompare-func%2F-%2Fcompare-func-2.0.0.tgz",
+      "integrity": "sha1-+2XnXtvd/S5WhVTotbBf/3pR/LM=",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
@@ -3128,26 +3117,26 @@
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/component-emitter/-/component-emitter-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcomponent-emitter%2F-%2Fcomponent-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/concat-map/-/concat-map-0.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconcat-map%2F-%2Fconcat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "confusing-browser-globals": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconfusing-browser-globals%2F-%2Fconfusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha1-MNHn89G4grJexJM9HRraw1PSClk=",
       "dev": true
     },
     "conventional-changelog-angular": {
       "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-changelog-angular%2F-%2Fconventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha1-iWiF1juRSnDUk0tZ0v573hgysow=",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -3156,8 +3145,8 @@
     },
     "conventional-changelog-writer": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
-      "integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-changelog-writer%2F-%2Fconventional-changelog-writer-5.0.0.tgz",
+      "integrity": "sha1-xAQvPxVC8vQdfS4NbK0jq6jfjuw=",
       "dev": true,
       "requires": {
         "conventional-commits-filter": "^2.0.7",
@@ -3173,8 +3162,8 @@
     },
     "conventional-commits-filter": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-commits-filter%2F-%2Fconventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha1-+Nm08YL84Aya9xOdpJNlsTbIoLM=",
       "dev": true,
       "requires": {
         "lodash.ismatch": "^4.4.0",
@@ -3183,8 +3172,8 @@
     },
     "conventional-commits-parser": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.3.tgz",
-      "integrity": "sha512-YyRDR7On9H07ICFpRm/igcdjIqebXbvf4Cff+Pf0BrBys1i1EOzx9iFXNlAbdrLAR8jf7bkUYkDAr8pEy0q4Pw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/conventional-commits-parser/-/conventional-commits-parser-3.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-commits-parser%2F-%2Fconventional-commits-parser-3.2.3.tgz",
+      "integrity": "sha1-/ENwRpgjlFHj7zX9HY7WRPRr2G4=",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -3197,8 +3186,8 @@
     },
     "convert-source-map": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/convert-source-map/-/convert-source-map-1.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconvert-source-map%2F-%2Fconvert-source-map-1.8.0.tgz",
+      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3206,34 +3195,34 @@
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
           "dev": true
         }
       }
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/copy-descriptor/-/copy-descriptor-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcopy-descriptor%2F-%2Fcopy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-js": {
       "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/core-js/-/core-js-2.6.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcore-js%2F-%2Fcore-js-2.6.12.tgz",
+      "integrity": "sha1-2TM9+nsGXjR8xWgiGdb2kIWcwuw=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/core-util-is/-/core-util-is-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcore-util-is%2F-%2Fcore-util-is-1.0.3.tgz",
+      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cosmiconfig/-/cosmiconfig-7.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcosmiconfig%2F-%2Fcosmiconfig-7.0.1.tgz",
+      "integrity": "sha1-cU11ZSLKzoZ4Z8y0R0xdAbuuXW0=",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -3245,7 +3234,7 @@
     },
     "cpx": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cpx/-/cpx-1.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcpx%2F-%2Fcpx-1.5.0.tgz",
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
       "dev": true,
       "requires": {
@@ -3264,8 +3253,8 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cross-spawn/-/cross-spawn-7.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-spawn%2F-%2Fcross-spawn-7.0.3.tgz",
+      "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -3275,20 +3264,20 @@
     },
     "crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/crypto-random-string/-/crypto-random-string-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcrypto-random-string%2F-%2Fcrypto-random-string-2.0.0.tgz",
+      "integrity": "sha1-7yp6lm7BEIM4g2m6oC6+rSKbMNU=",
       "dev": true
     },
     "cssom": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cssom/-/cssom-0.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcssom%2F-%2Fcssom-0.4.4.tgz",
+      "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA=",
       "dev": true
     },
     "cssstyle": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cssstyle/-/cssstyle-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcssstyle%2F-%2Fcssstyle-2.3.0.tgz",
+      "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
       "dev": true,
       "requires": {
         "cssom": "~0.3.6"
@@ -3296,22 +3285,22 @@
       "dependencies": {
         "cssom": {
           "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cssom/-/cssom-0.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcssom%2F-%2Fcssom-0.3.8.tgz",
+          "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
           "dev": true
         }
       }
     },
     "dargs": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dargs/-/dargs-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdargs%2F-%2Fdargs-7.0.0.tgz",
+      "integrity": "sha1-BAFcQd4Ly2nshAUPPZvgyvjW1cw=",
       "dev": true
     },
     "data-urls": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/data-urls/-/data-urls-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdata-urls%2F-%2Fdata-urls-2.0.0.tgz",
+      "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
       "dev": true,
       "requires": {
         "abab": "^2.0.3",
@@ -3321,27 +3310,27 @@
     },
     "dateformat": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dateformat/-/dateformat-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdateformat%2F-%2Fdateformat-3.0.3.tgz",
+      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-4.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.3.3.tgz",
+      "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
       "requires": {
         "ms": "2.1.2"
       }
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/decamelize/-/decamelize-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecamelize%2F-%2Fdecamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/decamelize-keys/-/decamelize-keys-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecamelize-keys%2F-%2Fdecamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -3351,7 +3340,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/map-obj/-/map-obj-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmap-obj%2F-%2Fmap-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -3359,44 +3348,44 @@
     },
     "decimal.js": {
       "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/decimal.js/-/decimal.js-10.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecimal.js%2F-%2Fdecimal.js-10.3.1.tgz",
+      "integrity": "sha1-2MOkRKnGd0umDKatcmHDqU/V54M=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/decode-uri-component/-/decode-uri-component-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecode-uri-component%2F-%2Fdecode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dedent/-/dedent-0.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdedent%2F-%2Fdedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/deep-extend/-/deep-extend-0.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeep-extend%2F-%2Fdeep-extend-0.6.0.tgz",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/deep-is/-/deep-is-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeep-is%2F-%2Fdeep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/deepmerge/-/deepmerge-4.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeepmerge%2F-%2Fdeepmerge-4.2.2.tgz",
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-properties/-/define-properties-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-properties%2F-%2Fdefine-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
@@ -3404,24 +3393,55 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/defined/-/defined-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefined%2F-%2Fdefined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "del": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/del/-/del-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdel%2F-%2Fdel-6.0.0.tgz",
+      "integrity": "sha1-C0DQMyzqdD8WFPgYvk/rcXcUyVI=",
       "dev": true,
       "requires": {
         "globby": "^11.0.1",
@@ -3436,8 +3456,8 @@
       "dependencies": {
         "p-map": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-map/-/p-map-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-map%2F-%2Fp-map-4.0.0.tgz",
+          "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
           "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
@@ -3447,12 +3467,12 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdelayed-stream%2F-%2Fdelayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "dependency-lint": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dependency-lint/-/dependency-lint-5.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dependency-lint/-/dependency-lint-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdependency-lint%2F-%2Fdependency-lint-5.0.1.tgz",
       "integrity": "sha1-LvdZqHvVYItr3Sr3csnWoVseias=",
       "dev": true,
       "requires": {
@@ -3473,7 +3493,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
@@ -3484,7 +3504,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonfile/-/jsonfile-2.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonfile%2F-%2Fjsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -3493,28 +3513,28 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
     },
     "deprecation": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/deprecation/-/deprecation-2.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeprecation%2F-%2Fdeprecation-2.3.1.tgz",
+      "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk=",
       "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/detect-newline/-/detect-newline-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdetect-newline%2F-%2Fdetect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
       "dev": true
     },
     "detective": {
       "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/detective/-/detective-4.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdetective%2F-%2Fdetective-4.7.1.tgz",
+      "integrity": "sha1-DspzFDOEQv67bWXaVMELscgrJG4=",
       "dev": true,
       "requires": {
         "acorn": "^5.2.1",
@@ -3523,13 +3543,13 @@
     },
     "diff-sequences": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/diff-sequences/-/diff-sequences-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff-sequences%2F-%2Fdiff-sequences-26.6.2.tgz",
+      "integrity": "sha1-SLqZFX3hkjQS7tQdtrbUqpynwLE="
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dir-glob/-/dir-glob-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdir-glob%2F-%2Fdir-glob-3.0.1.tgz",
+      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
@@ -3537,14 +3557,14 @@
     },
     "docopt": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/docopt/-/docopt-0.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdocopt%2F-%2Fdocopt-0.6.2.tgz",
       "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
       "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/doctrine/-/doctrine-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdoctrine%2F-%2Fdoctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -3552,8 +3572,8 @@
     },
     "domexception": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/domexception/-/domexception-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdomexception%2F-%2Fdomexception-2.0.1.tgz",
+      "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
       "dev": true,
       "requires": {
         "webidl-conversions": "^5.0.0"
@@ -3561,16 +3581,16 @@
       "dependencies": {
         "webidl-conversions": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/webidl-conversions/-/webidl-conversions-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwebidl-conversions%2F-%2Fwebidl-conversions-5.0.0.tgz",
+          "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
           "dev": true
         }
       }
     },
     "dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dot-prop/-/dot-prop-5.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdot-prop%2F-%2Fdot-prop-5.3.0.tgz",
+      "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
@@ -3578,57 +3598,95 @@
     },
     "dotenv": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/dotenv/-/dotenv-6.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-6.2.0.tgz",
+      "integrity": "sha1-lBwEEFNdlCyL7PKNPzV9vZ1HYGQ="
     },
     "duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/duplexer/-/duplexer-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fduplexer%2F-%2Fduplexer-0.1.2.tgz",
+      "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY=",
       "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/duplexer2/-/duplexer2-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fduplexer2%2F-%2Fduplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fecdsa-sig-formatter%2F-%2Fecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.901",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.901.tgz",
-      "integrity": "sha512-ToJdV2vzwT2jeAsw8zIggTFllJ4Kxvwghk39AhJEHHlIxor10wsFI3wo69p8nFc0s/ATWBqugPv/k3nW4Y9Mww==",
+      "version": "1.4.17",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/electron-to-chromium/-/electron-to-chromium-1.4.17.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Felectron-to-chromium%2F-%2Felectron-to-chromium-1.4.17.tgz",
+      "integrity": "sha1-FuxA9hAFWC1dQfrAhACiVNzPuF8=",
       "dev": true
     },
     "emittery": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
-      "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/emittery/-/emittery-0.8.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Femittery%2F-%2Femittery-0.8.1.tgz",
+      "integrity": "sha1-uyPMhtA7MKp1p/c0gZ3uLhunCGA=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/emoji-regex/-/emoji-regex-8.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Femoji-regex%2F-%2Femoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
     },
     "enquirer": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/enquirer/-/enquirer-2.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fenquirer%2F-%2Fenquirer-2.3.6.tgz",
+      "integrity": "sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=",
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
     },
     "env-ci": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.4.1.tgz",
-      "integrity": "sha512-xyuCtyFZLpnW5aH0JstETKTSMwHHQX4m42juzEZzvbUCJX7RiPVlhASKM0f/cJ4vvI/+txMkZ7F5To6dCdPYhg==",
+      "version": "5.5.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/env-ci/-/env-ci-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fenv-ci%2F-%2Fenv-ci-5.5.0.tgz",
+      "integrity": "sha1-QzZONVTSYaWG3scHvDK+gRErVF8=",
       "dev": true,
       "requires": {
         "execa": "^5.0.0",
@@ -3638,8 +3696,8 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/error-ex/-/error-ex-1.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ferror-ex%2F-%2Ferror-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -3647,8 +3705,8 @@
     },
     "es-abstract": {
       "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/es-abstract/-/es-abstract-1.19.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fes-abstract%2F-%2Fes-abstract-1.19.1.tgz",
+      "integrity": "sha1-1IhXlodpFpWd547aoN9FZicRXsM=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -3675,8 +3733,8 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/es-to-primitive/-/es-to-primitive-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fes-to-primitive%2F-%2Fes-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -3686,20 +3744,19 @@
     },
     "escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/escalade/-/escalade-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescalade%2F-%2Fescalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescape-string-regexp%2F-%2Fescape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/escodegen/-/escodegen-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescodegen%2F-%2Fescodegen-2.0.0.tgz",
+      "integrity": "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -3709,9 +3766,15 @@
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/estraverse/-/estraverse-5.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Festraverse%2F-%2Festraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        },
         "levn": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/levn/-/levn-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flevn%2F-%2Flevn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
@@ -3721,8 +3784,8 @@
         },
         "optionator": {
           "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/optionator/-/optionator-0.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foptionator%2F-%2Foptionator-0.8.3.tgz",
+          "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
           "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
@@ -3735,13 +3798,13 @@
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprelude-ls%2F-%2Fprelude-ls-1.1.2.tgz",
           "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
           "dev": true
         },
         "type-check": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-check/-/type-check-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-check%2F-%2Ftype-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "dev": true,
           "requires": {
@@ -3752,8 +3815,8 @@
     },
     "eslint": {
       "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint/-/eslint-7.32.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint%2F-%2Feslint-7.32.0.tgz",
+      "integrity": "sha1-xtMooUvj+wjI0dIeEsAv23oqgS0=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -3798,10 +3861,25 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@babel/code-frame/-/code-frame-7.12.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcode-frame%2F-%2Fcode-frame-7.12.11.tgz",
+          "integrity": "sha1-9K1DWqJj25NbjxDyxVLSP7cWpj8=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescape-string-regexp%2F-%2Fescape-string-regexp-4.0.0.tgz",
+          "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+          "dev": true
+        },
         "eslint-utils": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-utils/-/eslint-utils-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-utils%2F-%2Feslint-utils-2.1.0.tgz",
+          "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -3809,31 +3887,22 @@
           "dependencies": {
             "eslint-visitor-keys": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-1.3.0.tgz",
+              "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
               "dev": true
             }
           }
         },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ignore/-/ignore-4.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fignore%2F-%2Fignore-4.0.6.tgz",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -3843,8 +3912,8 @@
     },
     "eslint-config-airbnb": {
       "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-config-airbnb%2F-%2Feslint-config-airbnb-18.2.1.tgz",
+      "integrity": "sha1-t/4rQvn4Fz6CW3PIAUtZLkScmNk=",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.2.1",
@@ -3854,8 +3923,8 @@
     },
     "eslint-config-airbnb-base": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-config-airbnb-base%2F-%2Feslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha1-ii6zhFXcWjElUBk7MZza7vBCzR4=",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.10",
@@ -3865,8 +3934,8 @@
     },
     "eslint-config-airbnb-typescript": {
       "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.3.1.tgz",
-      "integrity": "sha512-ql/Pe6/hppYuRp4m3iPaHJqkBB7dgeEmGPQ6X0UNmrQOfTF+dXw29/ZjU2kQ6RDoLxaxOA+Xqv07Vbef6oVTWw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-config-airbnb-typescript%2F-%2Feslint-config-airbnb-typescript-12.3.1.tgz",
+      "integrity": "sha1-g6tA12QCwgjrCFFiYNHW+sj4rLw=",
       "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^4.4.1",
@@ -3876,14 +3945,14 @@
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
-      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-config-prettier%2F-%2Feslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha1-90cbILb+ipqSVMxoRFQgKIai3Xo=",
       "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-import-resolver-node%2F-%2Feslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha1-QEi5WDldqJZoJSAB29nsprg7rL0=",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -3892,29 +3961,19 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-3.2.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-3.2.7.tgz",
+          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
           }
         }
       }
     },
     "eslint-module-utils": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
-      "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-module-utils%2F-%2Feslint-module-utils-2.7.1.tgz",
+      "integrity": "sha1-tDUAHJ+N1Kt/bQ78rkuWltTCS3w=",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -3924,8 +3983,8 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-3.2.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-3.2.7.tgz",
+          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3933,7 +3992,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-up/-/find-up-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -3942,7 +4001,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/locate-path/-/locate-path-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -3952,8 +4011,8 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-limit/-/p-limit-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-1.3.0.tgz",
+          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -3961,7 +4020,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-locate/-/p-locate-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -3970,13 +4029,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-try/-/p-try-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-try%2F-%2Fp-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-exists/-/path-exists-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-exists%2F-%2Fpath-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -3984,8 +4043,8 @@
     },
     "eslint-plugin-es": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
-      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-es%2F-%2Feslint-plugin-es-1.4.1.tgz",
+      "integrity": "sha1-EqyuD0lT52ukRL/RsicQgaxiCZg=",
       "dev": true,
       "requires": {
         "eslint-utils": "^1.4.2",
@@ -3994,8 +4053,8 @@
       "dependencies": {
         "eslint-utils": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-utils/-/eslint-utils-1.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-utils%2F-%2Feslint-utils-1.4.3.tgz",
+          "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -4003,22 +4062,22 @@
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
           "dev": true
         },
         "regexpp": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regexpp/-/regexpp-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregexpp%2F-%2Fregexpp-2.0.1.tgz",
+          "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
           "dev": true
         }
       }
     },
     "eslint-plugin-import": {
       "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
-      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-import%2F-%2Feslint-plugin-import-2.25.3.tgz",
+      "integrity": "sha1-pVS19m4I+09tyZIhhm5Xz/+CR2Y=",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -4038,8 +4097,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4047,8 +4106,8 @@
         },
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/doctrine/-/doctrine-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdoctrine%2F-%2Fdoctrine-2.1.0.tgz",
+          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
@@ -4056,26 +4115,16 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
     "eslint-plugin-jest": {
       "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
-      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-jest%2F-%2Feslint-plugin-jest-24.7.0.tgz",
+      "integrity": "sha1-IGrAgzhB5Z43UXCxX40JVSGcSIk=",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
@@ -4083,8 +4132,8 @@
     },
     "eslint-plugin-jsdoc": {
       "version": "34.8.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz",
-      "integrity": "sha512-UOU9A40Cl806JMtla2vF+RM6sNqfLPbhLv9FZqhcC7+LmChD3DVaWqM7ADxpF0kMyZNWe1QKUnqGnXaA3NTn+w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-jsdoc%2F-%2Feslint-plugin-jsdoc-34.8.2.tgz",
+      "integrity": "sha1-lHCEKWZ+Fl9yKqULmOhjkg+boU4=",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "^0.6.0",
@@ -4100,8 +4149,8 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4111,8 +4160,8 @@
     },
     "eslint-plugin-node": {
       "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.2.0.tgz",
-      "integrity": "sha512-2abNmzAH/JpxI4gEOwd6K8wZIodK3BmHbTxz4s79OIYwwIt2gkpEXlAouJXu4H1c9ySTnRso0tsuthSOZbUMlA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-node/-/eslint-plugin-node-9.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-node%2F-%2Feslint-plugin-node-9.2.0.tgz",
+      "integrity": "sha1-sZEfERAC02bFlUptltPNW/KjA2o=",
       "dev": true,
       "requires": {
         "eslint-plugin-es": "^1.4.1",
@@ -4125,8 +4174,8 @@
       "dependencies": {
         "eslint-utils": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-utils/-/eslint-utils-1.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-utils%2F-%2Feslint-utils-1.4.3.tgz",
+          "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -4134,16 +4183,16 @@
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
           "dev": true
         }
       }
     },
     "eslint-plugin-prettier": {
       "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-plugin-prettier%2F-%2Feslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha1-6d2yAO+289Bf/oOxZlpxavSjh+U=",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -4151,26 +4200,18 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-scope/-/eslint-scope-5.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-scope%2F-%2Feslint-scope-5.1.1.tgz",
+      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
       }
     },
     "eslint-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-utils/-/eslint-utils-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-utils%2F-%2Feslint-utils-3.0.0.tgz",
+      "integrity": "sha1-iuuvrOc0W7M1WdsKHxOh0tSMNnI=",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
@@ -4178,14 +4219,14 @@
     },
     "eslint-visitor-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha1-9lMoJZMFknOSyTjtROsKXJsr0wM=",
       "dev": true
     },
     "espree": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/espree/-/espree-7.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fespree%2F-%2Fespree-7.3.1.tgz",
+      "integrity": "sha1-8t8zC3Usb1UBn4vYm3ZgA5wbu7Y=",
       "dev": true,
       "requires": {
         "acorn": "^7.4.0",
@@ -4195,64 +4236,74 @@
       "dependencies": {
         "acorn": {
           "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-          "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn/-/acorn-7.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn%2F-%2Facorn-7.4.1.tgz",
+          "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
           "dev": true
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
           "dev": true
         }
       }
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/esprima/-/esprima-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesprima%2F-%2Fesprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esquery": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/esquery/-/esquery-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesquery%2F-%2Fesquery-1.4.0.tgz",
+      "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/estraverse/-/estraverse-5.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Festraverse%2F-%2Festraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesrecurse%2F-%2Fesrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/estraverse/-/estraverse-5.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Festraverse%2F-%2Festraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        }
       }
     },
     "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "version": "4.3.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/estraverse/-/estraverse-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Festraverse%2F-%2Festraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/esutils/-/esutils-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesutils%2F-%2Fesutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "execa": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/execa/-/execa-5.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexeca%2F-%2Fexeca-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
@@ -4268,13 +4319,13 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/exit/-/exit-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexit%2F-%2Fexit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expand-brackets/-/expand-brackets-0.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpand-brackets%2F-%2Fexpand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -4283,7 +4334,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expand-range/-/expand-range-1.8.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpand-range%2F-%2Fexpand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -4292,8 +4343,8 @@
       "dependencies": {
         "fill-range": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fill-range/-/fill-range-2.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffill-range%2F-%2Ffill-range-2.2.4.tgz",
+          "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
             "is-number": "^2.1.0",
@@ -4305,7 +4356,7 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number/-/is-number-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
@@ -4314,7 +4365,7 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isobject/-/isobject-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisobject%2F-%2Fisobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
@@ -4323,7 +4374,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4334,8 +4385,8 @@
     },
     "expect": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
-      "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expect/-/expect-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpect%2F-%2Fexpect-26.6.2.tgz",
+      "integrity": "sha1-xrmWvya/P+GLZ7LQ9R/JgbqTRBc=",
       "requires": {
         "@jest/types": "^26.6.2",
         "ansi-styles": "^4.0.0",
@@ -4347,12 +4398,12 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend/-/extend-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend%2F-%2Fextend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -4362,7 +4413,7 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extglob/-/extglob-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextglob%2F-%2Fextglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -4371,7 +4422,7 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         }
@@ -4379,20 +4430,20 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-deep-equal%2F-%2Ffast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fast-diff/-/fast-diff-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-diff%2F-%2Ffast-diff-1.2.0.tgz",
+      "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
       "dev": true
     },
     "fast-glob": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fast-glob/-/fast-glob-3.2.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-glob%2F-%2Ffast-glob-3.2.7.tgz",
+      "integrity": "sha1-/Wy3otfpqnp4RhEehaGW1rL3ZqE=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4400,35 +4451,24 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-json-stable-stringify%2F-%2Ffast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-levenshtein%2F-%2Ffast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fastq/-/fastq-1.13.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffastq%2F-%2Ffastq-1.13.0.tgz",
+      "integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -4436,8 +4476,8 @@
     },
     "fb-watchman": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
-      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fb-watchman/-/fb-watchman-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffb-watchman%2F-%2Ffb-watchman-2.0.1.tgz",
+      "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
       "dev": true,
       "requires": {
         "bser": "2.1.1"
@@ -4445,25 +4485,17 @@
     },
     "figures": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/figures/-/figures-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffigures%2F-%2Ffigures-3.2.0.tgz",
+      "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        }
       }
     },
     "file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/file-entry-cache/-/file-entry-cache-6.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffile-entry-cache%2F-%2Ffile-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
@@ -4471,50 +4503,50 @@
     },
     "file-type": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/file-type/-/file-type-7.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffile-type%2F-%2Ffile-type-7.7.1.tgz",
+      "integrity": "sha1-kcL17bjOcGiLm2ipDZMbu2yyH2U="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffile-uri-to-path%2F-%2Ffile-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "dev": true,
       "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/filename-regex/-/filename-regex-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffilename-regex%2F-%2Ffilename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fill-range/-/fill-range-7.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffill-range%2F-%2Ffill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
     },
     "find-index": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-index/-/find-index-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-index%2F-%2Ffind-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
     },
     "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "version": "4.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-up/-/find-up-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "requires": {
-        "locate-path": "^6.0.0",
+        "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
     },
     "find-versions": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-versions/-/find-versions-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-versions%2F-%2Ffind-versions-4.0.0.tgz",
+      "integrity": "sha1-PFflc7+XdpuMuN8Wk0tieRXaSWU=",
       "dev": true,
       "requires": {
         "semver-regex": "^3.1.2"
@@ -4522,8 +4554,8 @@
     },
     "flat-cache": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/flat-cache/-/flat-cache-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflat-cache%2F-%2Fflat-cache-3.0.4.tgz",
+      "integrity": "sha1-YbAzgwKy/p+Vfcwy/CqH8cMEixE=",
       "dev": true,
       "requires": {
         "flatted": "^3.1.0",
@@ -4532,24 +4564,24 @@
     },
     "flatted": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/flatted/-/flatted-3.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflatted%2F-%2Fflatted-3.2.4.tgz",
+      "integrity": "sha1-KNmWnqkGYbUTQlnzEqtqp5KaxeI=",
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/follow-redirects/-/follow-redirects-1.14.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffollow-redirects%2F-%2Ffollow-redirects-1.14.6.tgz",
+      "integrity": "sha1-jPsoG7wDWzwGfWzZdbD2reboVc0="
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/for-in/-/for-in-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffor-in%2F-%2Ffor-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/for-own/-/for-own-0.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffor-own%2F-%2Ffor-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -4558,8 +4590,8 @@
     },
     "form-data": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/form-data/-/form-data-2.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fform-data%2F-%2Fform-data-2.5.1.tgz",
+      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -4568,7 +4600,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fragment-cache/-/fragment-cache-0.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffragment-cache%2F-%2Ffragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -4577,42 +4609,82 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/from2/-/from2-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffrom2%2F-%2Ffrom2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fromentries": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fromentries/-/fromentries-1.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffromentries%2F-%2Ffromentries-1.3.2.tgz",
+      "integrity": "sha1-5LymgIgWv4+TtSdQ8RJ/Wm/Ybjo=",
       "dev": true
     },
     "fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-9.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-9.1.0.tgz",
+      "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universalify/-/universalify-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-2.0.0.tgz",
+          "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+          "dev": true
+        }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs.realpath%2F-%2Ffs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fsevents/-/fsevents-1.2.13.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffsevents%2F-%2Ffsevents-1.2.13.tgz",
+      "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4622,32 +4694,32 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/function-bind/-/function-bind-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffunction-bind%2F-%2Ffunction-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffunctional-red-black-tree%2F-%2Ffunctional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/gensync/-/gensync-1.0.0-beta.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgensync%2F-%2Fgensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-caller-file/-/get-caller-file-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-caller-file%2F-%2Fget-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-intrinsic/-/get-intrinsic-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-intrinsic%2F-%2Fget-intrinsic-1.1.1.tgz",
+      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -4657,20 +4729,20 @@
     },
     "get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-package-type/-/get-package-type-0.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-package-type%2F-%2Fget-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true
     },
     "get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-stream/-/get-stream-6.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-stream%2F-%2Fget-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-symbol-description/-/get-symbol-description-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-symbol-description%2F-%2Fget-symbol-description-1.0.0.tgz",
+      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -4679,13 +4751,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/get-value/-/get-value-2.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-value%2F-%2Fget-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "git-log-parser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/git-log-parser/-/git-log-parser-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgit-log-parser%2F-%2Fgit-log-parser-1.2.0.tgz",
       "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
       "dev": true,
       "requires": {
@@ -4697,19 +4769,49 @@
         "traverse": "~0.6.6"
       },
       "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        },
         "split2": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/split2/-/split2-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsplit2%2F-%2Fsplit2-1.0.0.tgz",
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
             "through2": "~2.0.0"
           }
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "through2": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/through2/-/through2-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthrough2%2F-%2Fthrough2-2.0.5.tgz",
+          "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
           "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
@@ -4720,8 +4822,8 @@
     },
     "git-raw-commits": {
       "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
-      "integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/git-raw-commits/-/git-raw-commits-2.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgit-raw-commits%2F-%2Fgit-raw-commits-2.0.10.tgz",
+      "integrity": "sha1-4iVe2VY7HJw+pr0FgGQQKQKXu8E=",
       "dev": true,
       "requires": {
         "dargs": "^7.0.0",
@@ -4733,8 +4835,8 @@
     },
     "glob": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob/-/glob-7.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob%2F-%2Fglob-7.2.0.tgz",
+      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4747,7 +4849,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob-base/-/glob-base-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob-base%2F-%2Fglob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -4755,15 +4857,24 @@
         "is-glob": "^2.0.0"
       },
       "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob-parent/-/glob-parent-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob-parent%2F-%2Fglob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-glob/-/is-glob-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -4773,34 +4884,17 @@
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "5.1.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob-parent/-/glob-parent-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob-parent%2F-%2Fglob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "glob2base": {
       "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/glob2base/-/glob2base-0.0.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob2base%2F-%2Fglob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
@@ -4809,7 +4903,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/global-dirs/-/global-dirs-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglobal-dirs%2F-%2Fglobal-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -4818,17 +4912,25 @@
     },
     "globals": {
       "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/globals/-/globals-13.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglobals%2F-%2Fglobals-13.12.0.tgz",
+      "integrity": "sha1-TXM3YDBCMKAILtluIeXFZfiYCJ4=",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.20.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.20.2.tgz",
+          "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+          "dev": true
+        }
       }
     },
     "globby": {
       "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/globby/-/globby-11.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglobby%2F-%2Fglobby-11.0.4.tgz",
+      "integrity": "sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -4841,13 +4943,13 @@
     },
     "graceful-fs": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/graceful-fs/-/graceful-fs-4.2.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgraceful-fs%2F-%2Fgraceful-fs-4.2.8.tgz",
+      "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
     },
     "handlebars": {
       "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/handlebars/-/handlebars-4.7.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhandlebars%2F-%2Fhandlebars-4.7.7.tgz",
+      "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -4859,14 +4961,14 @@
     },
     "hard-rejection": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/hard-rejection/-/hard-rejection-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhard-rejection%2F-%2Fhard-rejection-2.1.0.tgz",
+      "integrity": "sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM=",
       "dev": true
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has/-/has-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas%2F-%2Fhas-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -4874,25 +4976,25 @@
     },
     "has-bigints": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-bigints/-/has-bigints-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-bigints%2F-%2Fhas-bigints-1.0.1.tgz",
+      "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
       "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-flag/-/has-flag-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
     },
     "has-symbols": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-symbols/-/has-symbols-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-symbols%2F-%2Fhas-symbols-1.0.2.tgz",
+      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
       "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-tostringtag/-/has-tostringtag-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-tostringtag%2F-%2Fhas-tostringtag-1.0.0.tgz",
+      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
@@ -4900,7 +5002,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-value/-/has-value-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-value%2F-%2Fhas-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -4911,7 +5013,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-values/-/has-values-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-values%2F-%2Fhas-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -4921,7 +5023,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number/-/is-number-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -4930,7 +5032,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -4941,7 +5043,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -4952,20 +5054,20 @@
     },
     "highlight.js": {
       "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/highlight.js/-/highlight.js-10.7.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhighlight.js%2F-%2Fhighlight.js-10.7.3.tgz",
+      "integrity": "sha1-aXJy45kTVuQMPKxWanTu9oF1ZTE=",
       "dev": true
     },
     "hook-std": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
-      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/hook-std/-/hook-std-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhook-std%2F-%2Fhook-std-2.0.0.tgz",
+      "integrity": "sha1-/5qv3rtqmJo1T3KbtkRc9KOnB3w=",
       "dev": true
     },
     "hosted-git-info": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/hosted-git-info/-/hosted-git-info-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhosted-git-info%2F-%2Fhosted-git-info-4.0.2.tgz",
+      "integrity": "sha1-XkJVB+7eT+qEa3Ji8IOEVsQgmWE=",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -4973,8 +5075,8 @@
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhtml-encoding-sniffer%2F-%2Fhtml-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
       "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.5"
@@ -4982,14 +5084,14 @@
     },
     "html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/html-escaper/-/html-escaper-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhtml-escaper%2F-%2Fhtml-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true
     },
     "http-proxy-agent": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-proxy-agent%2F-%2Fhttp-proxy-agent-4.0.1.tgz",
+      "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
       "dev": true,
       "requires": {
         "@tootallnate/once": "1",
@@ -4999,8 +5101,8 @@
     },
     "https-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttps-proxy-agent%2F-%2Fhttps-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -5009,14 +5111,14 @@
     },
     "human-signals": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/human-signals/-/human-signals-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhuman-signals%2F-%2Fhuman-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/iconv-lite/-/iconv-lite-0.4.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -5024,14 +5126,14 @@
     },
     "ignore": {
       "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ignore/-/ignore-5.1.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fignore%2F-%2Fignore-5.1.9.tgz",
+      "integrity": "sha1-nsGly+jhRG7GDUQgBg1Dqm5zgvs=",
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "version": "4.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ignore-walk/-/ignore-walk-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fignore-walk%2F-%2Fignore-walk-4.0.1.tgz",
+      "integrity": "sha1-/IQOg0bPiKOpOAxbF5M82PTTn6M=",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -5039,8 +5141,8 @@
     },
     "import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/import-fresh/-/import-fresh-3.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-fresh%2F-%2Fimport-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -5049,75 +5151,38 @@
       "dependencies": {
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve-from/-/resolve-from-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-from%2F-%2Fresolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
           "dev": true
         }
       }
     },
     "import-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/import-from/-/import-from-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-from%2F-%2Fimport-from-4.0.0.tgz",
+      "integrity": "sha1-JxC41mgX0jLhb0Fm4xkkjT1UkuI=",
       "dev": true
     },
     "import-lazy": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/import-lazy/-/import-lazy-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-lazy%2F-%2Fimport-lazy-4.0.0.tgz",
+      "integrity": "sha1-6OtidIOgpD2jwD8+NVSL5csMwVM=",
       "dev": true
     },
     "import-local": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/import-local/-/import-local-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-local%2F-%2Fimport-local-3.0.3.tgz",
+      "integrity": "sha1-TVHCxJXKk5PaJZ7Ga2LgIpICEeA=",
       "dev": true,
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "pkg-dir": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pkg-dir/-/pkg-dir-4.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpkg-dir%2F-%2Fpkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
@@ -5127,19 +5192,19 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/imurmurhash/-/imurmurhash-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimurmurhash%2F-%2Fimurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/indent-string/-/indent-string-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Findent-string%2F-%2Findent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/inflight/-/inflight-1.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finflight%2F-%2Finflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -5149,20 +5214,20 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/inherits/-/inherits-2.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finherits%2F-%2Finherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ini/-/ini-1.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fini%2F-%2Fini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true
     },
     "internal-slot": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/internal-slot/-/internal-slot-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finternal-slot%2F-%2Finternal-slot-1.0.3.tgz",
+      "integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
       "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
@@ -5172,14 +5237,14 @@
     },
     "interpret": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/interpret/-/interpret-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finterpret%2F-%2Finterpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true
     },
     "into-stream": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/into-stream/-/into-stream-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finto-stream%2F-%2Finto-stream-6.0.0.tgz",
+      "integrity": "sha1-S/wSRMASgiThi4hw6Fst6OZsZwI=",
       "dev": true,
       "requires": {
         "from2": "^2.3.0",
@@ -5187,24 +5252,35 @@
       }
     },
     "is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "version": "0.1.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-arrayish%2F-%2Fis-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-bigint/-/is-bigint-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-bigint%2F-%2Fis-bigint-1.0.4.tgz",
+      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
       "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
@@ -5212,7 +5288,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-binary-path/-/is-binary-path-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-binary-path%2F-%2Fis-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -5221,8 +5297,8 @@
     },
     "is-boolean-object": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-boolean-object/-/is-boolean-object-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-boolean-object%2F-%2Fis-boolean-object-1.1.2.tgz",
+      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -5231,63 +5307,82 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-buffer/-/is-buffer-1.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-buffer%2F-%2Fis-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-callable/-/is-callable-1.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-callable%2F-%2Fis-callable-1.2.4.tgz",
+      "integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=",
       "dev": true
     },
     "is-core-module": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-core-module/-/is-core-module-2.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-core-module%2F-%2Fis-core-module-2.8.0.tgz",
+      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "version": "0.1.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-date-object/-/is-date-object-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-date-object%2F-%2Fis-date-object-1.0.5.tgz",
+      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "version": "0.1.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-5.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "dev": true
+        }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-dotfile/-/is-dotfile-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-dotfile%2F-%2Fis-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-equal-shallow%2F-%2Fis-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -5296,54 +5391,54 @@
     },
     "is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-1.0.1.tgz",
+      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "requires": {
         "is-plain-object": "^2.0.4"
       }
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-generator-fn/-/is-generator-fn-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-generator-fn%2F-%2Fis-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-glob/-/is-glob-4.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "version": "2.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-negative-zero/-/is-negative-zero-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-negative-zero%2F-%2Fis-negative-zero-2.0.2.tgz",
+      "integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
       "dev": true
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number/-/is-number-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
     },
     "is-number-object": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number-object/-/is-number-object-1.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number-object%2F-%2Fis-number-object-1.0.6.tgz",
+      "integrity": "sha1-anqvg4x/BoalC0VT9+VKlklOifA=",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -5351,63 +5446,63 @@
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-obj/-/is-obj-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-obj%2F-%2Fis-obj-2.0.0.tgz",
+      "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
       "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-path-cwd/-/is-path-cwd-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-path-cwd%2F-%2Fis-path-cwd-2.2.0.tgz",
+      "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-path-inside/-/is-path-inside-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-path-inside%2F-%2Fis-path-inside-3.0.3.tgz",
+      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
       "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-plain-obj/-/is-plain-obj-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-obj%2F-%2Fis-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-plain-object/-/is-plain-object-2.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-object%2F-%2Fis-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-posix-bracket%2F-%2Fis-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-potential-custom-element-name%2F-%2Fis-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-primitive/-/is-primitive-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-primitive%2F-%2Fis-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-redirect/-/is-redirect-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-redirect%2F-%2Fis-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-regex/-/is-regex-1.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-regex%2F-%2Fis-regex-1.1.4.tgz",
+      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -5416,20 +5511,20 @@
     },
     "is-shared-array-buffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-shared-array-buffer%2F-%2Fis-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha1-l7DIX72stZycRG/mU7gs8rW3z+Y=",
       "dev": true
     },
     "is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-stream/-/is-stream-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-stream%2F-%2Fis-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "dev": true
     },
     "is-string": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-string/-/is-string-1.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-string%2F-%2Fis-string-1.0.7.tgz",
+      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -5437,8 +5532,8 @@
     },
     "is-symbol": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-symbol/-/is-symbol-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-symbol%2F-%2Fis-symbol-1.0.4.tgz",
+      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
@@ -5446,7 +5541,7 @@
     },
     "is-text-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-text-path/-/is-text-path-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-text-path%2F-%2Fis-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
@@ -5455,51 +5550,51 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-typedarray%2F-%2Fis-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "version": "1.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-weakref/-/is-weakref-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-weakref%2F-%2Fis-weakref-1.0.2.tgz",
+      "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-windows/-/is-windows-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-windows%2F-%2Fis-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isarray/-/isarray-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisarray%2F-%2Fisarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isexe/-/isexe-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisexe%2F-%2Fisexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isobject/-/isobject-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisobject%2F-%2Fisobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isstream/-/isstream-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisstream%2F-%2Fisstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "issue-parser": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
-      "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/issue-parser/-/issue-parser-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fissue-parser%2F-%2Fissue-parser-6.0.0.tgz",
+      "integrity": "sha1-se3QYxXU8gRKl1Xa+F/a/em0AUo=",
       "dev": true,
       "requires": {
         "lodash.capitalize": "^4.2.1",
@@ -5511,14 +5606,14 @@
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-coverage%2F-%2Fistanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha1-GJ55CdCjn6Wj361bA/cZR3cBkdM=",
       "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-instrument%2F-%2Fistanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
@@ -5529,8 +5624,8 @@
     },
     "istanbul-lib-report": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-report%2F-%2Fistanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -5540,8 +5635,8 @@
     },
     "istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-source-maps%2F-%2Fistanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -5550,9 +5645,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-      "integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+      "version": "3.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/istanbul-reports/-/istanbul-reports-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-reports%2F-%2Fistanbul-reports-3.1.1.tgz",
+      "integrity": "sha1-cIWFfxfSRBBTxs5cO4/faIIok5c=",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -5561,36 +5656,25 @@
     },
     "java-properties": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
-      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/java-properties/-/java-properties-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjava-properties%2F-%2Fjava-properties-1.0.2.tgz",
+      "integrity": "sha1-zNH6c5B0OKW1w4mCJp0Odx/nghE=",
       "dev": true
     },
     "jest": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.3.1.tgz",
-      "integrity": "sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest/-/jest-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.4.5.tgz",
+      "integrity": "sha1-ZuRay6RBN/rCa+nTzFuwMeE23A8=",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.3.1",
+        "@jest/core": "^27.4.5",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.3.1"
-      }
-    },
-    "jest-changed-files": {
-      "version": "27.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.3.0.tgz",
-      "integrity": "sha512-9DJs9garMHv4RhylUMZgbdCJ3+jHSkpL9aaVKp13xtXAD80qLTLrqcDZL1PHA9dYA0bCI86Nv2BhkLpLhrBcPg==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.2.5",
-        "execa": "^5.0.0",
-        "throat": "^6.0.1"
+        "jest-cli": "^27.4.5"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5602,8 +5686,63 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "jest-cli": {
+          "version": "27.4.5",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-cli/-/jest-cli-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-cli%2F-%2Fjest-cli-27.4.5.tgz",
+          "integrity": "sha1-hwj1TCjRNoHzJV7JAmorFbA9Qeg=",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^27.4.5",
+            "@jest/test-result": "^27.4.2",
+            "@jest/types": "^27.4.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "jest-config": "^27.4.5",
+            "jest-util": "^27.4.2",
+            "jest-validate": "^27.4.2",
+            "prompts": "^2.0.1",
+            "yargs": "^16.2.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-changed-files/-/jest-changed-files-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-changed-files%2F-%2Fjest-changed-files-27.4.2.tgz",
+      "integrity": "sha1-2iVH6kfG5qX27TNhUb0gdXNutKU=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.4.2",
+        "execa": "^5.0.0",
+        "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5612,45 +5751,36 @@
       }
     },
     "jest-circus": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.3.1.tgz",
-      "integrity": "sha512-v1dsM9II6gvXokgqq6Yh2jHCpfg7ZqV4jWY66u7npz24JnhP3NHxI0sKT7+ZMQ7IrOWHYAaeEllOySbDbWsiXw==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-circus/-/jest-circus-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-circus%2F-%2Fjest-circus-27.4.5.tgz",
+      "integrity": "sha1-cL+3jgIAyrm4R0e/J03rrKpThGc=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.3.1",
-        "@jest/test-result": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/environment": "^27.4.4",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.3.1",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.3.1",
-        "jest-matcher-utils": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-runtime": "^27.3.1",
-        "jest-snapshot": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "pretty-format": "^27.3.1",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5662,8 +5792,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5671,244 +5801,218 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
           "dev": true
         },
         "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/diff-sequences/-/diff-sequences-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff-sequences%2F-%2Fdiff-sequences-27.4.0.tgz",
+          "integrity": "sha1-14OSCtjQbscYoGDQAZbf7yWxMqU=",
           "dev": true
         },
         "expect": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-27.3.1.tgz",
-          "integrity": "sha512-MrNXV2sL9iDRebWPGOGFdPQRl2eDQNu/uhxIMShjjx74T6kC6jFIkmQ6OqXDtevjGUkyB2IT56RzDBqXf/QPCg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expect/-/expect-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpect%2F-%2Fexpect-27.4.2.tgz",
+          "integrity": "sha1-RCmw9+MHdx0Xbem98jIpsQHbbvY=",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "ansi-styles": "^5.0.0",
-            "jest-get-type": "^27.3.1",
-            "jest-matcher-utils": "^27.3.1",
-            "jest-message-util": "^27.3.1",
-            "jest-regex-util": "^27.0.6"
+            "jest-get-type": "^27.4.0",
+            "jest-matcher-utils": "^27.4.2",
+            "jest-message-util": "^27.4.2",
+            "jest-regex-util": "^27.4.0"
           }
         },
         "jest-diff": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
-          "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-diff/-/jest-diff-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-diff%2F-%2Fjest-diff-27.4.2.tgz",
+          "integrity": "sha1-eGsqUhHYVPhI4tzB4yREjpSB828=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "diff-sequences": "^27.4.0",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
           "dev": true
         },
         "jest-matcher-utils": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.3.1.tgz",
-          "integrity": "sha512-hX8N7zXS4k+8bC1Aj0OWpGb7D3gIXxYvPNK1inP5xvE4ztbz3rc4AkI6jGVaerepBnfWB17FL5lWFJT3s7qo8w==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-matcher-utils%2F-%2Fjest-matcher-utils-27.4.2.tgz",
+          "integrity": "sha1-0XxQOGB5eKJV4Kmlwywk6YS2xgs=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^27.3.1",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "jest-diff": "^27.4.2",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
-          "dev": true
-        }
-      }
-    },
-    "jest-cli": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.3.1.tgz",
-      "integrity": "sha512-WHnCqpfK+6EvT62me6WVs8NhtbjAS4/6vZJnk7/2+oOr50cwAzG4Wxt6RXX0hu6m1169ZGMlhYYUNeKBXCph/Q==",
-      "dev": true,
-      "requires": {
-        "@jest/core": "^27.3.1",
-        "@jest/test-result": "^27.3.1",
-        "@jest/types": "^27.2.5",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "import-local": "^3.0.2",
-        "jest-config": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-validate": "^27.3.1",
-        "prompts": "^2.0.1",
-        "yargs": "^16.2.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        }
-      }
-    },
-    "jest-config": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.3.1.tgz",
-      "integrity": "sha512-KY8xOIbIACZ/vdYCKSopL44I0xboxC751IX+DXL2+Wx6DKNycyEfV3rryC3BPm5Uq/BBqDoMrKuqLEUNJmMKKg==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.3.1",
-        "@jest/types": "^27.2.5",
-        "babel-jest": "^27.3.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.2.4",
-        "jest-circus": "^27.3.1",
-        "jest-environment-jsdom": "^27.3.1",
-        "jest-environment-node": "^27.3.1",
-        "jest-get-type": "^27.3.1",
-        "jest-jasmine2": "^27.3.1",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.3.1",
-        "jest-runner": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-validate": "^27.3.1",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^27.3.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
         },
-        "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
-          "dev": true
-        }
-      }
-    },
-    "jest-diff": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
-      },
-      "dependencies": {
         "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
           "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           }
         }
       }
     },
+    "jest-config": {
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-config/-/jest-config-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-config%2F-%2Fjest-config-27.4.5.tgz",
+      "integrity": "sha1-d+1/K6e8/X10Ct5xHQ0TUS4IpZ4=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^27.4.5",
+        "@jest/types": "^27.4.2",
+        "babel-jest": "^27.4.5",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-circus": "^27.4.5",
+        "jest-environment-jsdom": "^27.4.4",
+        "jest-environment-node": "^27.4.4",
+        "jest-get-type": "^27.4.0",
+        "jest-jasmine2": "^27.4.5",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-runner": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.4.2",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
+          "dev": true
+        },
+        "jest-regex-util": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-diff/-/jest-diff-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-diff%2F-%2Fjest-diff-26.6.2.tgz",
+      "integrity": "sha1-GqdGi1LDpo19XF/c381eSb0WQ5Q=",
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
     "jest-docblock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
-      "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
+      "version": "27.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-docblock/-/jest-docblock-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-docblock%2F-%2Fjest-docblock-27.4.0.tgz",
+      "integrity": "sha1-BseANcqTy7uE+vj85k3q55pZ9p8=",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.3.1.tgz",
-      "integrity": "sha512-E4SwfzKJWYcvOYCjOxhZcxwL+AY0uFMvdCOwvzgutJiaiodFjkxQQDxHm8FQBeTqDnSmKsQWn7ldMRzTn2zJaQ==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-each/-/jest-each-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-each%2F-%2Fjest-each-27.4.2.tgz",
+      "integrity": "sha1-GTZMgqaS0NJlV2QgmNH0YZye59M=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "pretty-format": "^27.3.1"
+        "jest-get-type": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5920,40 +6024,58 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
-        "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
           "dev": true
+        },
+        "jest-get-type": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.3.1.tgz",
-      "integrity": "sha512-3MOy8qMzIkQlfb3W1TfrD7uZHj+xx8Olix5vMENkj5djPmRqndMaXtpnaZkxmxM+Qc3lo+yVzJjzuXbCcZjAlg==",
+      "version": "27.4.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-environment-jsdom/-/jest-environment-jsdom-27.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.4.4.tgz",
+      "integrity": "sha1-lPc46ZUU16iA6O2OA+OjIdQ7Sds=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.3.1",
-        "@jest/fake-timers": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/environment": "^27.4.4",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.3.0",
-        "jest-util": "^27.3.1",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2",
         "jsdom": "^16.6.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5965,8 +6087,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5975,23 +6097,23 @@
       }
     },
     "jest-environment-node": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.3.1.tgz",
-      "integrity": "sha512-T89F/FgkE8waqrTSA7/ydMkcc52uYPgZZ6q8OaZgyiZkJb5QNNCF6oPZjH9IfPFfcc9uBWh1574N0kY0pSvTXw==",
+      "version": "27.4.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-environment-node/-/jest-environment-node-27.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-node%2F-%2Fjest-environment-node-27.4.4.tgz",
+      "integrity": "sha1-Qv5eOyJMtpuZgR6/b16qWllhhRQ=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.3.1",
-        "@jest/fake-timers": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/environment": "^27.4.4",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.3.0",
-        "jest-util": "^27.3.1"
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6003,8 +6125,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6014,34 +6136,34 @@
     },
     "jest-get-type": {
       "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-26.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-26.3.0.tgz",
+      "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA="
     },
     "jest-haste-map": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.3.1.tgz",
-      "integrity": "sha512-lYfNZIzwPccDJZIyk9Iz5iQMM/MH56NIIcGj7AFU1YyA4ewWFBl8z+YPJuSCRML/ee2cCt2y3W4K3VXPT6Nhzg==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-haste-map/-/jest-haste-map-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-haste-map%2F-%2Fjest-haste-map-27.4.5.tgz",
+      "integrity": "sha1-wpISJKWSI/keA+wVcDkFl47wzBo=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.6",
-        "jest-serializer": "^27.0.6",
-        "jest-util": "^27.3.1",
-        "jest-worker": "^27.3.1",
+        "jest-regex-util": "^27.4.0",
+        "jest-serializer": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6053,8 +6175,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6062,8 +6184,8 @@
         },
         "anymatch": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/anymatch/-/anymatch-3.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fanymatch%2F-%2Fanymatch-3.1.2.tgz",
+          "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
           "dev": true,
           "requires": {
             "normalize-path": "^3.0.0",
@@ -6072,64 +6194,55 @@
         },
         "fsevents": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fsevents/-/fsevents-2.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffsevents%2F-%2Ffsevents-2.3.2.tgz",
+          "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
           "dev": true,
           "optional": true
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
         },
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-path%2F-%2Fnormalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
           "dev": true
         }
       }
     },
     "jest-jasmine2": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.3.1.tgz",
-      "integrity": "sha512-WK11ZUetDQaC09w4/j7o4FZDUIp+4iYWH/Lik34Pv7ukL+DuXFGdnmmi7dT58J2ZYKFB5r13GyE0z3NPeyJmsg==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-jasmine2/-/jest-jasmine2-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-jasmine2%2F-%2Fjest-jasmine2-27.4.5.tgz",
+      "integrity": "sha1-/3nRFWFnn/bIlxWwzWsejA37xtw=",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.3.1",
-        "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/environment": "^27.4.4",
+        "@jest/source-map": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.3.1",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.3.1",
-        "jest-matcher-utils": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-runtime": "^27.3.1",
-        "jest-snapshot": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "pretty-format": "^27.3.1",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6141,8 +6254,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6150,131 +6263,170 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
           "dev": true
         },
         "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/diff-sequences/-/diff-sequences-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff-sequences%2F-%2Fdiff-sequences-27.4.0.tgz",
+          "integrity": "sha1-14OSCtjQbscYoGDQAZbf7yWxMqU=",
           "dev": true
         },
         "expect": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-27.3.1.tgz",
-          "integrity": "sha512-MrNXV2sL9iDRebWPGOGFdPQRl2eDQNu/uhxIMShjjx74T6kC6jFIkmQ6OqXDtevjGUkyB2IT56RzDBqXf/QPCg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expect/-/expect-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpect%2F-%2Fexpect-27.4.2.tgz",
+          "integrity": "sha1-RCmw9+MHdx0Xbem98jIpsQHbbvY=",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "ansi-styles": "^5.0.0",
-            "jest-get-type": "^27.3.1",
-            "jest-matcher-utils": "^27.3.1",
-            "jest-message-util": "^27.3.1",
-            "jest-regex-util": "^27.0.6"
+            "jest-get-type": "^27.4.0",
+            "jest-matcher-utils": "^27.4.2",
+            "jest-message-util": "^27.4.2",
+            "jest-regex-util": "^27.4.0"
           }
         },
         "jest-diff": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
-          "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-diff/-/jest-diff-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-diff%2F-%2Fjest-diff-27.4.2.tgz",
+          "integrity": "sha1-eGsqUhHYVPhI4tzB4yREjpSB828=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "diff-sequences": "^27.4.0",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
           "dev": true
         },
         "jest-matcher-utils": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.3.1.tgz",
-          "integrity": "sha512-hX8N7zXS4k+8bC1Aj0OWpGb7D3gIXxYvPNK1inP5xvE4ztbz3rc4AkI6jGVaerepBnfWB17FL5lWFJT3s7qo8w==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-matcher-utils%2F-%2Fjest-matcher-utils-27.4.2.tgz",
+          "integrity": "sha1-0XxQOGB5eKJV4Kmlwywk6YS2xgs=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^27.3.1",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "jest-diff": "^27.4.2",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
-        }
-      }
-    },
-    "jest-leak-detector": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.3.1.tgz",
-      "integrity": "sha512-78QstU9tXbaHzwlRlKmTpjP9k4Pvre5l0r8Spo4SbFFVy/4Abg9I6ZjHwjg2QyKEAMg020XcjP+UgLZIY50yEg==",
-      "dev": true,
-      "requires": {
-        "jest-get-type": "^27.3.1",
-        "pretty-format": "^27.3.1"
-      },
-      "dependencies": {
-        "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
-          "dev": true
-        }
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
-      "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
-      },
-      "dependencies": {
+        },
         "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
           "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           }
         }
       }
     },
+    "jest-leak-detector": {
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-leak-detector%2F-%2Fjest-leak-detector-27.4.2.tgz",
+      "integrity": "sha1-f8MSCJOnqRHFU/Pyvf+fqkRUq7s=",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "26.6.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-matcher-utils%2F-%2Fjest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha1-jm/W6GPIstMaxkcu6yN7xZXlPno=",
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
     "jest-message-util": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
-      "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-26.6.2.tgz",
+      "integrity": "sha1-WBc3RK1vwFBrXSEVC5vlbvABygc=",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@jest/types": "^26.6.2",
@@ -6285,35 +6437,22 @@
         "pretty-format": "^26.6.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.2"
-      },
-      "dependencies": {
-        "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
       }
     },
     "jest-mock": {
-      "version": "27.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.3.0.tgz",
-      "integrity": "sha512-ziZiLk0elZOQjD08bLkegBzv5hCABu/c8Ytx45nJKkysQwGaonvmTxwjLqEA4qGdasq9o2I8/HtdGMNnVsMTGw==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-mock/-/jest-mock-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-mock%2F-%2Fjest-mock-27.4.2.tgz",
+      "integrity": "sha1-GE/xl6JUkb/kVwwobapdYut2C4g=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6325,8 +6464,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6336,37 +6475,37 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-pnp-resolver%2F-%2Fjest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw=",
       "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
-      "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-26.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-26.0.0.tgz",
+      "integrity": "sha1-0l5xhLNuOf1GbDvEG+CXHoIf7ig="
     },
     "jest-resolve": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.3.1.tgz",
-      "integrity": "sha512-Dfzt25CFSPo3Y3GCbxynRBZzxq9AdyNN+x/v2IqYx6KVT5Z6me2Z/PsSGFSv3cOSUZqJ9pHxilao/I/m9FouLw==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-resolve/-/jest-resolve-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-resolve%2F-%2Fjest-resolve-27.4.5.tgz",
+      "integrity": "sha1-jcRPUGX7jViUTCD5Mst7n+l2DMo=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.3.1",
+        "jest-haste-map": "^27.4.5",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.3.1",
-        "jest-validate": "^27.3.1",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6378,40 +6517,30 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
           }
         }
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.3.1.tgz",
-      "integrity": "sha512-X7iLzY8pCiYOnvYo2YrK3P9oSE8/3N2f4pUZMJ8IUcZnT81vlSonya1KTO9ZfKGuC+svE6FHK/XOb8SsoRUV1A==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-resolve-dependencies%2F-%2Fjest-resolve-dependencies-27.4.5.tgz",
+      "integrity": "sha1-k5ivhUvbEtap5ailNu5AH4iaPs8=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
-        "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.3.1"
+        "@jest/types": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-snapshot": "^27.4.5"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6423,64 +6552,55 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
         }
       }
     },
     "jest-runner": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.3.1.tgz",
-      "integrity": "sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-runner/-/jest-runner-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-runner%2F-%2Fjest-runner-27.4.5.tgz",
+      "integrity": "sha1-2rorpxyPNBN9x6xFYWrdNTcKaB4=",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.3.1",
-        "@jest/environment": "^27.3.1",
-        "@jest/test-result": "^27.3.1",
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.4",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.3.1",
-        "jest-environment-node": "^27.3.1",
-        "jest-haste-map": "^27.3.1",
-        "jest-leak-detector": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-resolve": "^27.3.1",
-        "jest-runtime": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-worker": "^27.3.1",
+        "jest-docblock": "^27.4.0",
+        "jest-environment-jsdom": "^27.4.4",
+        "jest-environment-node": "^27.4.4",
+        "jest-haste-map": "^27.4.5",
+        "jest-leak-detector": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.5",
+        "jest-runtime": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6492,45 +6612,63 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
+          }
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
           }
         }
       }
     },
     "jest-runtime": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.3.1.tgz",
-      "integrity": "sha512-qtO6VxPbS8umqhEDpjA4pqTkKQ1Hy4ZSi9mDVeE9Za7LKBo2LdW2jmT+Iod3XFaJqINikZQsn2wEi0j9wPRbLg==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-runtime/-/jest-runtime-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-runtime%2F-%2Fjest-runtime-27.4.5.tgz",
+      "integrity": "sha1-l3A60qF5nU9Qq1kEm9IanOrtKBM=",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.3.1",
-        "@jest/environment": "^27.3.1",
-        "@jest/globals": "^27.3.1",
-        "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.3.1",
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.4",
+        "@jest/globals": "^27.4.4",
+        "@jest/source-map": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -6539,32 +6677,23 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-mock": "^27.3.0",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.3.1",
-        "jest-snapshot": "^27.3.1",
-        "jest-util": "^27.3.1",
-        "jest-validate": "^27.3.1",
+        "jest-haste-map": "^27.4.5",
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.2.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6576,42 +6705,66 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-bom/-/strip-bom-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-bom%2F-%2Fstrip-bom-4.0.0.tgz",
+          "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
           "dev": true
         }
       }
     },
     "jest-serializer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
-      "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
+      "version": "27.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-serializer/-/jest-serializer-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-serializer%2F-%2Fjest-serializer-27.4.0.tgz",
+      "integrity": "sha1-NIZlhuHK4jiLfRL/oseBnt71lYo=",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -6619,9 +6772,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.3.1.tgz",
-      "integrity": "sha512-APZyBvSgQgOT0XumwfFu7X3G5elj6TGhCBLbBdn3R1IzYustPGPE38F51dBWMQ8hRXa9je0vAdeVDtqHLvB6lg==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-snapshot/-/jest-snapshot-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-snapshot%2F-%2Fjest-snapshot-27.4.5.tgz",
+      "integrity": "sha1-LqkJsgqsD+YlBLwWEzH3MLin7Mc=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -6630,39 +6783,30 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.3.1",
+        "expect": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.3.1",
-        "jest-get-type": "^27.3.1",
-        "jest-haste-map": "^27.3.1",
-        "jest-matcher-utils": "^27.3.1",
-        "jest-message-util": "^27.3.1",
-        "jest-resolve": "^27.3.1",
-        "jest-util": "^27.3.1",
+        "jest-diff": "^27.4.2",
+        "jest-get-type": "^27.4.0",
+        "jest-haste-map": "^27.4.5",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.5",
+        "jest-util": "^27.4.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.3.1",
+        "pretty-format": "^27.4.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6674,8 +6818,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6683,87 +6827,99 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
           "dev": true
         },
         "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/diff-sequences/-/diff-sequences-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff-sequences%2F-%2Fdiff-sequences-27.4.0.tgz",
+          "integrity": "sha1-14OSCtjQbscYoGDQAZbf7yWxMqU=",
           "dev": true
         },
         "expect": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-27.3.1.tgz",
-          "integrity": "sha512-MrNXV2sL9iDRebWPGOGFdPQRl2eDQNu/uhxIMShjjx74T6kC6jFIkmQ6OqXDtevjGUkyB2IT56RzDBqXf/QPCg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expect/-/expect-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpect%2F-%2Fexpect-27.4.2.tgz",
+          "integrity": "sha1-RCmw9+MHdx0Xbem98jIpsQHbbvY=",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "ansi-styles": "^5.0.0",
-            "jest-get-type": "^27.3.1",
-            "jest-matcher-utils": "^27.3.1",
-            "jest-message-util": "^27.3.1",
-            "jest-regex-util": "^27.0.6"
+            "jest-get-type": "^27.4.0",
+            "jest-matcher-utils": "^27.4.2",
+            "jest-message-util": "^27.4.2",
+            "jest-regex-util": "^27.4.0"
           }
         },
         "jest-diff": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
-          "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-diff/-/jest-diff-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-diff%2F-%2Fjest-diff-27.4.2.tgz",
+          "integrity": "sha1-eGsqUhHYVPhI4tzB4yREjpSB828=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "diff-sequences": "^27.4.0",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
           "dev": true
         },
         "jest-matcher-utils": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.3.1.tgz",
-          "integrity": "sha512-hX8N7zXS4k+8bC1Aj0OWpGb7D3gIXxYvPNK1inP5xvE4ztbz3rc4AkI6jGVaerepBnfWB17FL5lWFJT3s7qo8w==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-matcher-utils%2F-%2Fjest-matcher-utils-27.4.2.tgz",
+          "integrity": "sha1-0XxQOGB5eKJV4Kmlwywk6YS2xgs=",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^27.3.1",
-            "jest-get-type": "^27.3.1",
-            "pretty-format": "^27.3.1"
+            "jest-diff": "^27.4.2",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.2"
           }
         },
         "jest-message-util": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.3.1.tgz",
-          "integrity": "sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-message-util/-/jest-message-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-message-util%2F-%2Fjest-message-util-27.4.2.tgz",
+          "integrity": "sha1-B/PxvyB9ac95jOgwzFfxqEn5k4g=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.2.5",
+            "@jest/types": "^27.4.2",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.4",
-            "pretty-format": "^27.3.1",
+            "pretty-format": "^27.4.2",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-          "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-regex-util/-/jest-regex-util-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-regex-util%2F-%2Fjest-regex-util-27.4.0.tgz",
+          "integrity": "sha1-5MRbUmUxKIQ9B62UrsNDk+oU+8o=",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -6772,12 +6928,12 @@
       }
     },
     "jest-util": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.3.1.tgz",
-      "integrity": "sha512-8fg+ifEH3GDryLQf/eKZck1DEs2YuVPBCMOaHQxVVLmQwl/CDhWzrvChTX4efLZxGrw+AA0mSXv78cyytBt/uw==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-util/-/jest-util-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-util%2F-%2Fjest-util-27.4.2.tgz",
+      "integrity": "sha1-7ZWwWxrf12HizaR+AUTGpY4FpiE=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -6786,9 +6942,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6800,8 +6956,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6810,23 +6966,23 @@
       }
     },
     "jest-validate": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.3.1.tgz",
-      "integrity": "sha512-3H0XCHDFLA9uDII67Bwi1Vy7AqwA5HqEEjyy934lgVhtJ3eisw6ShOF1MDmRPspyikef5MyExvIm0/TuLzZ86Q==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-validate/-/jest-validate-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-validate%2F-%2Fjest-validate-27.4.2.tgz",
+      "integrity": "sha1-7s/MGxyUKaoAfaCKK65OMqgbu8M=",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.3.1",
+        "jest-get-type": "^27.4.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.3.1"
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6838,46 +6994,64 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        },
         "camelcase": {
           "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/camelcase/-/camelcase-6.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcamelcase%2F-%2Fcamelcase-6.2.1.tgz",
+          "integrity": "sha1-JQ/TUM/VVdDSFgsdUVEOr4Mm6G4=",
           "dev": true
         },
         "jest-get-type": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-          "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+          "version": "27.4.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-get-type/-/jest-get-type-27.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-get-type%2F-%2Fjest-get-type-27.4.0.tgz",
+          "integrity": "sha1-dQPSZj//pDFjgzezmY05xeko6bU=",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-27.4.2.tgz",
+          "integrity": "sha1-5M6SrWbDiIQj0zK0BHfIfR2sH7g=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "jest-watcher": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.3.1.tgz",
-      "integrity": "sha512-9/xbV6chABsGHWh9yPaAGYVVKurWoP3ZMCv6h+O1v9/+pkOroigs6WzZ0e9gLP/njokUwM7yQhr01LKJVMkaZA==",
+      "version": "27.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-watcher/-/jest-watcher-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-watcher%2F-%2Fjest-watcher-27.4.2.tgz",
+      "integrity": "sha1-yQN+39gDVMn+kN5Lb4tuK45zZ0Q=",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.3.1",
-        "@jest/types": "^27.2.5",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.3.1",
+        "jest-util": "^27.4.2",
         "string-length": "^4.0.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@jest/types/-/types-27.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jest%2Ftypes%2F-%2Ftypes-27.4.2.tgz",
+          "integrity": "sha1-llNuvTTaY5LCt8dzfWk4hbXdRKU=",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6889,8 +7063,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@types/yargs/-/yargs-16.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fyargs%2F-%2Fyargs-16.0.4.tgz",
+          "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6899,9 +7073,9 @@
       }
     },
     "jest-worker": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-      "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+      "version": "27.4.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jest-worker/-/jest-worker-27.4.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-worker%2F-%2Fjest-worker-27.4.5.tgz",
+      "integrity": "sha1-1pbj5Grg8kz/P6cZX/uiKIkmIkI=",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -6911,8 +7085,8 @@
       "dependencies": {
         "supports-color": {
           "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-color/-/supports-color-8.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-8.1.1.tgz",
+          "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -6922,19 +7096,19 @@
     },
     "jju": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jju/-/jju-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjju%2F-%2Fjju-1.4.0.tgz",
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjs-tokens%2F-%2Fjs-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/js-yaml/-/js-yaml-3.13.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjs-yaml%2F-%2Fjs-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -6943,14 +7117,14 @@
     },
     "jsdoctypeparser": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsdoctypeparser%2F-%2Fjsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha1-jJfi+2kxXrJ0sPATd+qlyUC9eyY=",
       "dev": true
     },
     "jsdom": {
       "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsdom/-/jsdom-16.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsdom%2F-%2Fjsdom-16.7.0.tgz",
+      "integrity": "sha1-kYrnGWVCSxl8gZ+Bg6dU4Yl3txA=",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -6984,14 +7158,14 @@
       "dependencies": {
         "acorn": {
           "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/acorn/-/acorn-8.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn%2F-%2Facorn-8.6.0.tgz",
+          "integrity": "sha1-42kroOsaDIPqpPN/X6c2jdcUKJU=",
           "dev": true
         },
         "form-data": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/form-data/-/form-data-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fform-data%2F-%2Fform-data-3.0.1.tgz",
+          "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -7003,69 +7177,77 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsesc/-/jsesc-2.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsesc%2F-%2Fjsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-parse-better-errors%2F-%2Fjson-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-parse-even-better-errors%2F-%2Fjson-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-schema-traverse%2F-%2Fjson-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-stable-stringify-without-jsonify%2F-%2Fjson-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-stringify-safe%2F-%2Fjson-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "1.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json5/-/json5-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson5%2F-%2Fjson5-1.0.1.tgz",
+      "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonfile/-/jsonfile-6.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonfile%2F-%2Fjsonfile-6.1.0.tgz",
+      "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universalify/-/universalify-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-2.0.0.tgz",
+          "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+          "dev": true
+        }
       }
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonparse/-/jsonparse-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonparse%2F-%2Fjsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonwebtoken": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonwebtoken%2F-%2Fjsonwebtoken-8.5.1.tgz",
+      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -7081,15 +7263,15 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jwa/-/jwa-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjwa%2F-%2Fjwa-1.4.1.tgz",
+      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7098,8 +7280,8 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jws/-/jws-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjws%2F-%2Fjws-3.2.2.tgz",
+      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -7107,13 +7289,13 @@
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-6.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/klaw/-/klaw-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fklaw%2F-%2Fklaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
@@ -7122,20 +7304,20 @@
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kleur/-/kleur-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkleur%2F-%2Fkleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true
     },
     "leven": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/leven/-/leven-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fleven%2F-%2Fleven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/levn/-/levn-0.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flevn%2F-%2Flevn-0.4.1.tgz",
+      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
@@ -7143,14 +7325,14 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "version": "1.2.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flines-and-columns%2F-%2Flines-and-columns-1.2.4.tgz",
+      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/load-json-file/-/load-json-file-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fload-json-file%2F-%2Fload-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -7162,7 +7344,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/parse-json/-/parse-json-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-json%2F-%2Fparse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -7172,137 +7354,131 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pify/-/pify-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }
     },
     "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "version": "5.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/locate-path/-/locate-path-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "requires": {
-        "p-locate": "^5.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash/-/lodash-4.17.21.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash%2F-%2Flodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
       "dev": true
     },
     "lodash.capitalize": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.capitalize%2F-%2Flodash.capitalize-4.2.1.tgz",
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.escaperegexp%2F-%2Flodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.get/-/lodash.get-4.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.get%2F-%2Flodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.includes/-/lodash.includes-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.includes%2F-%2Flodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isboolean%2F-%2Flodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isempty/-/lodash.isempty-4.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isempty%2F-%2Flodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isequal/-/lodash.isequal-4.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isequal%2F-%2Flodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isinteger%2F-%2Flodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.ismatch%2F-%2Flodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isnumber%2F-%2Flodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isplainobject%2F-%2Flodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.isstring/-/lodash.isstring-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isstring%2F-%2Flodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.merge/-/lodash.merge-4.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.merge%2F-%2Flodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
       "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.once/-/lodash.once-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.once%2F-%2Flodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.set": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.set/-/lodash.set-4.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.set%2F-%2Flodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.truncate": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.truncate/-/lodash.truncate-4.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.truncate%2F-%2Flodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.uniqby%2F-%2Flodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lower-case/-/lower-case-1.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flower-case%2F-%2Flower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flru-cache%2F-%2Flru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -7310,14 +7486,14 @@
     },
     "lunr": {
       "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/lunr/-/lunr-2.3.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flunr%2F-%2Flunr-2.3.9.tgz",
+      "integrity": "sha1-GLEjFCgyM33W6WTfGlp3B7JdNeE=",
       "dev": true
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/make-dir/-/make-dir-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmake-dir%2F-%2Fmake-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -7325,8 +7501,8 @@
     },
     "makeerror": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/makeerror/-/makeerror-1.0.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmakeerror%2F-%2Fmakeerror-1.0.12.tgz",
+      "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
@@ -7334,19 +7510,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/map-cache/-/map-cache-0.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmap-cache%2F-%2Fmap-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/map-obj/-/map-obj-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmap-obj%2F-%2Fmap-obj-4.3.0.tgz",
+      "integrity": "sha1-kwT5Buk/qucIgNoQKp8d8OqLsFo=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/map-visit/-/map-visit-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmap-visit%2F-%2Fmap-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -7355,14 +7531,14 @@
     },
     "marked": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/marked/-/marked-2.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-2.1.3.tgz",
+      "integrity": "sha1-vQF872Qxck/Usn4GV/XOsUv/N1M=",
       "dev": true
     },
     "marked-terminal": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
-      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/marked-terminal/-/marked-terminal-4.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked-terminal%2F-%2Fmarked-terminal-4.2.0.tgz",
+      "integrity": "sha1-WTc0pTz5pLsB6pYapXm9IYic5QI=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.3.1",
@@ -7375,20 +7551,20 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/math-random/-/math-random-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmath-random%2F-%2Fmath-random-1.0.4.tgz",
+      "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
       "dev": true
     },
     "memorystream": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/memorystream/-/memorystream-0.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmemorystream%2F-%2Fmemorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
     "meow": {
       "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/meow/-/meow-8.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmeow%2F-%2Fmeow-8.1.2.tgz",
+      "integrity": "sha1-vL5FvaDuFynTUMA8/8g5WjbE6Jc=",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -7402,32 +7578,24 @@
         "trim-newlines": "^3.0.0",
         "type-fest": "^0.18.0",
         "yargs-parser": "^20.2.3"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-          "dev": true
-        }
       }
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/merge-stream/-/merge-stream-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-stream%2F-%2Fmerge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/merge2/-/merge2-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge2%2F-%2Fmerge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "dev": true
     },
     "micromatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/micromatch/-/micromatch-4.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmicromatch%2F-%2Fmicromatch-4.0.4.tgz",
+      "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -7435,39 +7603,39 @@
     },
     "mime": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mime/-/mime-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime%2F-%2Fmime-3.0.0.tgz",
+      "integrity": "sha1-s3RVDco6DBhEOwyVCmpY8ZMc96c=",
       "dev": true
     },
     "mime-db": {
       "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mime-db/-/mime-db-1.51.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.51.0.tgz",
+      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww="
     },
     "mime-types": {
       "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mime-types/-/mime-types-2.1.34.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-2.1.34.tgz",
+      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
       "requires": {
         "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mimic-fn/-/mimic-fn-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmimic-fn%2F-%2Fmimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
     "min-indent": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/min-indent/-/min-indent-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmin-indent%2F-%2Fmin-indent-1.0.1.tgz",
+      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/minimatch/-/minimatch-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -7475,14 +7643,14 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/minimist/-/minimist-1.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimist%2F-%2Fminimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/minimist-options/-/minimist-options-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimist-options%2F-%2Fminimist-options-4.1.0.tgz",
+      "integrity": "sha1-wGVXE8U6ii69d/+iR9NCxA8BBhk=",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
@@ -7492,8 +7660,8 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mixin-deep/-/mixin-deep-1.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmixin-deep%2F-%2Fmixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -7502,8 +7670,8 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmkdirp%2F-%2Fmkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -7511,26 +7679,26 @@
     },
     "modify-values": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/modify-values/-/modify-values-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmodify-values%2F-%2Fmodify-values-1.0.1.tgz",
+      "integrity": "sha1-s5OfpgVUZHTj4+PGPWS9Q7TuYCI=",
       "dev": true
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ms/-/ms-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
     },
     "nan": {
       "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nan/-/nan-2.15.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnan%2F-%2Fnan-2.15.0.tgz",
+      "integrity": "sha1-PzSkc/8Y4VwbVia2KQO1rW5mX+4=",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nanomatch/-/nanomatch-1.2.13.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnanomatch%2F-%2Fnanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -7548,13 +7716,13 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arr-diff/-/arr-diff-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-diff%2F-%2Farr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-unique/-/array-unique-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-unique%2F-%2Farray-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         }
@@ -7562,32 +7730,32 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/natural-compare/-/natural-compare-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnatural-compare%2F-%2Fnatural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/neo-async/-/neo-async-2.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fneo-async%2F-%2Fneo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "nerf-dart": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nerf-dart/-/nerf-dart-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnerf-dart%2F-%2Fnerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nice-try/-/nice-try-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnice-try%2F-%2Fnice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/no-case/-/no-case-2.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fno-case%2F-%2Fno-case-2.3.2.tgz",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
@@ -7595,8 +7763,8 @@
     },
     "nock": {
       "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.1.tgz",
-      "integrity": "sha512-CoHAabbqq/xZEknubuyQMjq6Lfi5b7RtK6SoNK6m40lebGp3yiMagWtIoYaw2s9sISD7wPuCfwFpivVHX/35RA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nock/-/nock-13.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnock%2F-%2Fnock-13.2.1.tgz",
+      "integrity": "sha1-/PW9ubufBVSoTCXTMzFmwP/YCFg=",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -7607,8 +7775,8 @@
     },
     "node-emoji": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/node-emoji/-/node-emoji-1.11.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-emoji%2F-%2Fnode-emoji-1.11.0.tgz",
+      "integrity": "sha1-aaAVDmlG4vEV6dfqTfeXHiYoMBw=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21"
@@ -7616,8 +7784,8 @@
     },
     "node-fetch": {
       "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/node-fetch/-/node-fetch-2.6.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-fetch%2F-%2Fnode-fetch-2.6.6.tgz",
+      "integrity": "sha1-F1GnwBg06OFpd1hzLp77burfr4k=",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -7625,19 +7793,19 @@
       "dependencies": {
         "tr46": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tr46/-/tr46-0.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftr46%2F-%2Ftr46-0.0.3.tgz",
           "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
           "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/webidl-conversions/-/webidl-conversions-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwebidl-conversions%2F-%2Fwebidl-conversions-3.0.1.tgz",
           "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
           "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/whatwg-url/-/whatwg-url-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhatwg-url%2F-%2Fwhatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
           "dev": true,
           "requires": {
@@ -7649,26 +7817,20 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/node-int64/-/node-int64-0.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-int64%2F-%2Fnode-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
-    },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
     "node-releases": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/node-releases/-/node-releases-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-releases%2F-%2Fnode-releases-2.0.1.tgz",
+      "integrity": "sha1-PR05XyBPHy8ppUNYuftnh2WtL8U=",
       "dev": true
     },
     "normalize-package-data": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-package-data/-/normalize-package-data-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-package-data%2F-%2Fnormalize-package-data-3.0.3.tgz",
+      "integrity": "sha1-28w+LaWVCaCYNCKITNFy7v36Ul4=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
@@ -7679,8 +7841,8 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7690,7 +7852,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-path/-/normalize-path-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-path%2F-%2Fnormalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -7699,14 +7861,14 @@
     },
     "normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-url/-/normalize-url-6.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-url%2F-%2Fnormalize-url-6.1.0.tgz",
+      "integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
       "dev": true
     },
     "npm": {
       "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/npm/-/npm-7.24.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnpm%2F-%2Fnpm-7.24.2.tgz",
+      "integrity": "sha1-hhEXr4JBvqWSKJ8iQHIw5TAOWco=",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
@@ -9793,8 +9955,8 @@
     },
     "npm-run-all": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/npm-run-all/-/npm-run-all-4.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnpm-run-all%2F-%2Fnpm-run-all-4.1.5.tgz",
+      "integrity": "sha1-BEdiAqFe4OLiFAgIYb/xKlHZj7o=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -9810,8 +9972,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -9819,8 +9981,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/chalk/-/chalk-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -9830,8 +9992,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-convert/-/color-convert-1.9.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-convert%2F-%2Fcolor-convert-1.9.3.tgz",
+          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -9839,14 +10001,14 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-name/-/color-name-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-name%2F-%2Fcolor-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/cross-spawn/-/cross-spawn-6.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-spawn%2F-%2Fcross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -9856,33 +10018,71 @@
             "which": "^1.2.9"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/hosted-git-info/-/hosted-git-info-2.8.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhosted-git-info%2F-%2Fhosted-git-info-2.8.9.tgz",
+          "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-package-data/-/normalize-package-data-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-package-data%2F-%2Fnormalize-package-data-2.5.0.tgz",
+          "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-key/-/path-key-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-key%2F-%2Fpath-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-type/-/path-type-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-type%2F-%2Fpath-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pify/-/pify-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/read-pkg/-/read-pkg-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fread-pkg%2F-%2Fread-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shebang-command/-/shebang-command-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-command%2F-%2Fshebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -9891,14 +10091,14 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shebang-regex/-/shebang-regex-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-regex%2F-%2Fshebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-color/-/supports-color-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -9906,8 +10106,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/which/-/which-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhich%2F-%2Fwhich-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -9917,8 +10117,8 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/npm-run-path/-/npm-run-path-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnpm-run-path%2F-%2Fnpm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
@@ -9926,19 +10126,19 @@
     },
     "nwsapi": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/nwsapi/-/nwsapi-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnwsapi%2F-%2Fnwsapi-2.2.0.tgz",
+      "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object-assign/-/object-assign-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-assign%2F-%2Fobject-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object-copy/-/object-copy-0.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-copy%2F-%2Fobject-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -9949,53 +10149,16 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-0.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -10005,20 +10168,20 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.11.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object-inspect/-/object-inspect-1.11.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-inspect%2F-%2Fobject-inspect-1.11.1.tgz",
+      "integrity": "sha1-1L19feVLmnVZn1mgC9aYwfHGVJs=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object-keys/-/object-keys-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-keys%2F-%2Fobject-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object-visit/-/object-visit-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-visit%2F-%2Fobject-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -10027,8 +10190,8 @@
     },
     "object.assign": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.assign/-/object.assign-4.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.assign%2F-%2Fobject.assign-4.1.2.tgz",
+      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
@@ -10039,8 +10202,8 @@
     },
     "object.entries": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.entries/-/object.entries-1.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.entries%2F-%2Fobject.entries-1.1.5.tgz",
+      "integrity": "sha1-4azdF8TeLNltWghIfPuduE2IGGE=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10050,15 +10213,15 @@
     },
     "object.omit": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
-      "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.omit/-/object.omit-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.omit%2F-%2Fobject.omit-3.0.0.tgz",
+      "integrity": "sha1-Dj7cL84rpU31V3/1KfbZe9ilIq8=",
       "requires": {
         "is-extendable": "^1.0.0"
       }
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.pick/-/object.pick-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.pick%2F-%2Fobject.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -10066,8 +10229,8 @@
     },
     "object.values": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/object.values/-/object.values-1.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject.values%2F-%2Fobject.values-1.1.5.tgz",
+      "integrity": "sha1-lZ9j486e8QhyAzMIITHkpFm3Fqw=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10077,7 +10240,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/once/-/once-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonce%2F-%2Fonce-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -10086,8 +10249,8 @@
     },
     "onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/onetime/-/onetime-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonetime%2F-%2Fonetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
@@ -10095,8 +10258,8 @@
     },
     "optionator": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/optionator/-/optionator-0.9.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foptionator%2F-%2Foptionator-0.9.1.tgz",
+      "integrity": "sha1-TyNqY3Pa4FZqbUPhMmZ09QwpFJk=",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
@@ -10109,14 +10272,14 @@
     },
     "p-each-series": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-each-series/-/p-each-series-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-each-series%2F-%2Fp-each-series-2.2.0.tgz",
+      "integrity": "sha1-EFqwNXznKyAqiouUkzZyZXteKpo=",
       "dev": true
     },
     "p-filter": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-filter/-/p-filter-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-filter%2F-%2Fp-filter-2.1.0.tgz",
+      "integrity": "sha1-GxRyVirnoPdC8PPT03GOpm/5wJw=",
       "dev": true,
       "requires": {
         "p-map": "^2.0.0"
@@ -10124,44 +10287,44 @@
     },
     "p-is-promise": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-is-promise/-/p-is-promise-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-is-promise%2F-%2Fp-is-promise-3.0.0.tgz",
+      "integrity": "sha1-WOeMff4uFjzyoE/4aefB26ZKWXE=",
       "dev": true
     },
     "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "version": "2.3.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-limit/-/p-limit-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
-        "yocto-queue": "^0.1.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "version": "4.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-locate/-/p-locate-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "requires": {
-        "p-limit": "^3.0.2"
+        "p-limit": "^2.2.0"
       }
     },
     "p-map": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-map/-/p-map-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-map%2F-%2Fp-map-2.1.0.tgz",
+      "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
       "dev": true
     },
     "p-reduce": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-reduce/-/p-reduce-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-reduce%2F-%2Fp-reduce-2.1.0.tgz",
+      "integrity": "sha1-CUCNpJUHxsJ0+qMfKN8zS8cStko=",
       "dev": true
     },
     "p-retry": {
       "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-retry/-/p-retry-4.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-retry%2F-%2Fp-retry-4.6.1.tgz",
+      "integrity": "sha1-j83dXN96Z6CRGpzy7w5d9/YCMWw=",
       "dev": true,
       "requires": {
         "@types/retry": "^0.12.0",
@@ -10170,20 +10333,20 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-try/-/p-try-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-try%2F-%2Fp-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "package-json-reducer": {
       "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/package-json-reducer/-/package-json-reducer-1.0.18.tgz",
-      "integrity": "sha512-3T/Xh3ff1ak7Eh4szCg0rsILawOcxf73yrk4ddU/wDnK8bpmcRVPLK4+kT6raALdsEMArLWjpOOH8c5NJRkAlA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/package-json-reducer/-/package-json-reducer-1.0.18.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpackage-json-reducer%2F-%2Fpackage-json-reducer-1.0.18.tgz",
+      "integrity": "sha1-F5N45rAQ86ruEn2vnof9pkU0T/E=",
       "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/parent-module/-/parent-module-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparent-module%2F-%2Fparent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -10191,7 +10354,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/parse-glob/-/parse-glob-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-glob%2F-%2Fparse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -10203,13 +10366,13 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-glob/-/is-glob-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -10220,8 +10383,8 @@
     },
     "parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/parse-json/-/parse-json-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-json%2F-%2Fparse-json-5.2.0.tgz",
+      "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -10232,80 +10395,77 @@
     },
     "parse5": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/parse5/-/parse5-6.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparse5%2F-%2Fparse5-6.0.1.tgz",
+      "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pascalcase/-/pascalcase-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpascalcase%2F-%2Fpascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-exists/-/path-exists-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-exists%2F-%2Fpath-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-is-absolute%2F-%2Fpath-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-key/-/path-key-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-key%2F-%2Fpath-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-parse/-/path-parse-1.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-parse%2F-%2Fpath-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-type/-/path-type-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-type%2F-%2Fpath-type-4.0.0.tgz",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
       "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/picocolors/-/picocolors-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpicocolors%2F-%2Fpicocolors-1.0.0.tgz",
+      "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
       "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/picomatch/-/picomatch-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpicomatch%2F-%2Fpicomatch-2.3.0.tgz",
+      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI="
     },
     "pidtree": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
-      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pidtree/-/pidtree-0.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpidtree%2F-%2Fpidtree-0.3.1.tgz",
+      "integrity": "sha1-7wmsLMBTPfHzJQzPLE02aw0SEUo=",
       "dev": true
     },
     "pify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pify/-/pify-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-5.0.0.tgz",
+      "integrity": "sha1-H17KP16H6+wozG1UoOSq8ArMEn8="
     },
     "pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
+      "version": "4.0.4",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pirates/-/pirates-4.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpirates%2F-%2Fpirates-4.0.4.tgz",
+      "integrity": "sha1-B9+B5hAo5AJzXN1J23AeSIW05uY=",
+      "dev": true
     },
     "pkg-conf": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pkg-conf/-/pkg-conf-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpkg-conf%2F-%2Fpkg-conf-2.1.0.tgz",
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
@@ -10315,7 +10475,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-up/-/find-up-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -10324,7 +10484,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/locate-path/-/locate-path-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -10334,8 +10494,8 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-limit/-/p-limit-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-1.3.0.tgz",
+          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -10343,7 +10503,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-locate/-/p-locate-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -10352,13 +10512,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-try/-/p-try-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-try%2F-%2Fp-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-exists/-/path-exists-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-exists%2F-%2Fpath-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -10366,7 +10526,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pkg-dir/-/pkg-dir-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpkg-dir%2F-%2Fpkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -10375,7 +10535,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/find-up/-/find-up-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -10384,7 +10544,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/locate-path/-/locate-path-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -10394,8 +10554,8 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-limit/-/p-limit-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-1.3.0.tgz",
+          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -10403,7 +10563,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-locate/-/p-locate-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -10412,13 +10572,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/p-try/-/p-try-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-try%2F-%2Fp-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/path-exists/-/path-exists-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-exists%2F-%2Fpath-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -10426,95 +10586,64 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/posix-character-classes/-/posix-character-classes-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fposix-character-classes%2F-%2Fposix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/prelude-ls/-/prelude-ls-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprelude-ls%2F-%2Fprelude-ls-1.2.1.tgz",
+      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/preserve/-/preserve-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpreserve%2F-%2Fpreserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/prettier/-/prettier-2.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprettier%2F-%2Fprettier-2.5.1.tgz",
+      "integrity": "sha1-//dfqdUZxUzw/OMowQF9lFRrxWo=",
       "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprettier-linter-helpers%2F-%2Fprettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s=",
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
       }
     },
     "pretty-format": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
-      "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
-      "dev": true,
+      "version": "26.6.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/pretty-format/-/pretty-format-26.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpretty-format%2F-%2Fpretty-format-26.6.2.tgz",
+      "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
       "requires": {
-        "@jest/types": "^27.2.5",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
         "react-is": "^17.0.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        }
       }
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprocess-nextick-args%2F-%2Fprocess-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/progress/-/progress-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprogress%2F-%2Fprogress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
     "prompts": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/prompts/-/prompts-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprompts%2F-%2Fprompts-2.4.2.tgz",
+      "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
@@ -10523,42 +10652,42 @@
     },
     "propagate": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/propagate/-/propagate-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpropagate%2F-%2Fpropagate-2.0.1.tgz",
+      "integrity": "sha1-QM3tqxgIXHkjNOZPCsFyVtOPmkU=",
       "dev": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/psl/-/psl-1.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpsl%2F-%2Fpsl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/punycode/-/punycode-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpunycode%2F-%2Fpunycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/q/-/q-1.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fq%2F-%2Fq-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/queue-microtask/-/queue-microtask-1.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqueue-microtask%2F-%2Fqueue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/quick-lru/-/quick-lru-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fquick-lru%2F-%2Fquick-lru-4.0.1.tgz",
+      "integrity": "sha1-W4h48ROlgheEjGSCAmxz4bpXcn8=",
       "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/randomatic/-/randomatic-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frandomatic%2F-%2Frandomatic-3.1.1.tgz",
+      "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -10568,16 +10697,16 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number/-/is-number-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-4.0.0.tgz",
+          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
           "dev": true
         }
       }
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/rc/-/rc-1.2.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frc%2F-%2Frc-1.2.8.tgz",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -10588,7 +10717,7 @@
       "dependencies": {
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-json-comments/-/strip-json-comments-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-json-comments%2F-%2Fstrip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
@@ -10596,30 +10725,31 @@
     },
     "react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/react-is/-/react-is-17.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freact-is%2F-%2Freact-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA="
     },
     "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "version": "5.2.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/read-pkg/-/read-pkg-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fread-pkg%2F-%2Fread-pkg-5.2.0.tgz",
+      "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
         "hosted-git-info": {
           "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/hosted-git-info/-/hosted-git-info-2.8.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhosted-git-info%2F-%2Fhosted-git-info-2.8.9.tgz",
+          "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/normalize-package-data/-/normalize-package-data-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-package-data%2F-%2Fnormalize-package-data-2.5.0.tgz",
+          "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -10628,33 +10758,24 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.6.0.tgz",
+          "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
           "dev": true
         }
       }
     },
     "read-pkg-up": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/read-pkg-up/-/read-pkg-up-7.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fread-pkg-up%2F-%2Fread-pkg-up-7.0.1.tgz",
+      "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
       "dev": true,
       "requires": {
         "find-up": "^4.1.0",
@@ -10662,122 +10783,29 @@
         "type-fest": "^0.8.1"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-              "dev": true
-            }
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.8.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.8.1.tgz",
+          "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
           "dev": true
         }
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-3.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-3.6.0.tgz",
+      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readdirp/-/readdirp-2.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freaddirp%2F-%2Freaddirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -10787,20 +10815,20 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/arr-diff/-/arr-diff-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-diff%2F-%2Farr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/array-unique/-/array-unique-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-unique%2F-%2Farray-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/braces/-/braces-2.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbraces%2F-%2Fbraces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -10817,7 +10845,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -10828,8 +10856,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -10837,7 +10865,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/expand-brackets/-/expand-brackets-2.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpand-brackets%2F-%2Fexpand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -10852,7 +10880,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-0.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -10861,17 +10889,57 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -10881,16 +10949,16 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-5.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extglob/-/extglob-2.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextglob%2F-%2Fextglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -10905,7 +10973,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -10914,7 +10982,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -10925,7 +10993,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fill-range/-/fill-range-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffill-range%2F-%2Ffill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -10937,7 +11005,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -10947,54 +11015,43 @@
           }
         },
         "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-number/-/is-number-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -11003,7 +11060,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -11014,8 +11071,8 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/micromatch/-/micromatch-3.1.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmicromatch%2F-%2Fmicromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -11035,13 +11092,43 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/to-regex-range/-/to-regex-range-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-regex-range%2F-%2Fto-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
@@ -11053,7 +11140,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/rechoir/-/rechoir-0.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frechoir%2F-%2Frechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -11062,8 +11149,8 @@
     },
     "redent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/redent/-/redent-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fredent%2F-%2Fredent-3.0.0.tgz",
+      "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
@@ -11072,7 +11159,7 @@
     },
     "redeyed": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/redeyed/-/redeyed-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fredeyed%2F-%2Fredeyed-2.1.1.tgz",
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "requires": {
@@ -11081,14 +11168,14 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregenerator-runtime%2F-%2Fregenerator-runtime-0.11.1.tgz",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regex-cache/-/regex-cache-0.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregex-cache%2F-%2Fregex-cache-0.4.4.tgz",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -11096,8 +11183,8 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regex-not/-/regex-not-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregex-not%2F-%2Fregex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -11106,20 +11193,20 @@
     },
     "regexpp": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regexpp/-/regexpp-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregexpp%2F-%2Fregexpp-3.2.0.tgz",
+      "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
       "dev": true
     },
     "regextras": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/regextras/-/regextras-0.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregextras%2F-%2Fregextras-0.7.1.tgz",
+      "integrity": "sha1-vpVxnV9D+e8Ln6B62Jt8YGmVo7I=",
       "dev": true
     },
     "registry-auth-token": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/registry-auth-token/-/registry-auth-token-4.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregistry-auth-token%2F-%2Fregistry-auth-token-4.2.1.tgz",
+      "integrity": "sha1-bXtABkQZGJcszV/tzUHcMix5slA=",
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
@@ -11127,47 +11214,48 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fremove-trailing-separator%2F-%2Fremove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
-      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/repeat-element/-/repeat-element-1.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frepeat-element%2F-%2Frepeat-element-1.1.4.tgz",
+      "integrity": "sha1-vmgVIIR6tYx1aKx1+/rSjtQtOek=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/repeat-string/-/repeat-string-1.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frepeat-string%2F-%2Frepeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/require-directory/-/require-directory-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frequire-directory%2F-%2Frequire-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/require-from-string/-/require-from-string-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frequire-from-string%2F-%2Frequire-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.20.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve/-/resolve-1.20.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.20.0.tgz",
+      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve-cwd/-/resolve-cwd-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-cwd%2F-%2Fresolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
@@ -11175,14 +11263,14 @@
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve-from/-/resolve-from-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-from%2F-%2Fresolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true
     },
     "resolve-global": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve-global/-/resolve-global-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-global%2F-%2Fresolve-global-1.0.0.tgz",
+      "integrity": "sha1-oqed9K8so/Sb93753azTItrRklU=",
       "dev": true,
       "requires": {
         "global-dirs": "^0.1.1"
@@ -11190,43 +11278,43 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve-url/-/resolve-url-0.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-url%2F-%2Fresolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "resolve.exports": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/resolve.exports/-/resolve.exports-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve.exports%2F-%2Fresolve.exports-1.1.0.tgz",
+      "integrity": "sha1-XOhCuUsFFGwOAwdphdHQ5+SMkMk=",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ret/-/ret-0.1.15.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fret%2F-%2Fret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "retry": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/retry/-/retry-0.13.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fretry%2F-%2Fretry-0.13.1.tgz",
+      "integrity": "sha1-GFsVh6z2eRnWOzVzSeA1N7JIRlg=",
       "dev": true
     },
     "retry-axios": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
-      "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/retry-axios/-/retry-axios-2.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fretry-axios%2F-%2Fretry-axios-2.6.0.tgz",
+      "integrity": "sha1-1Nxcio5zmC4mpwXkajPfmaKHI+A="
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/reusify/-/reusify-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freusify%2F-%2Freusify-1.0.4.tgz",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
       "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/rimraf/-/rimraf-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frimraf%2F-%2Frimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -11234,8 +11322,8 @@
     },
     "run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/run-parallel/-/run-parallel-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frun-parallel%2F-%2Frun-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
@@ -11243,12 +11331,12 @@
     },
     "safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-regex/-/safe-regex-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-regex%2F-%2Fsafe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -11257,26 +11345,26 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafer-buffer%2F-%2Fsafer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "saxes": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/saxes/-/saxes-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsaxes%2F-%2Fsaxes-5.0.1.tgz",
+      "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
     },
     "semantic-release": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.0.tgz",
-      "integrity": "sha512-/Szyhq5DTZCYry/aZqpBbK/kqv10ydn6oiiaYOXtPgDbAIkqidZcQOm+mfYFJ0sBTUaOYCKMlcPMgJycP7jDYQ==",
+      "version": "18.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semantic-release/-/semantic-release-18.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemantic-release%2F-%2Fsemantic-release-18.0.1.tgz",
+      "integrity": "sha1-31rUS5wv1n/jzbxmCz0fVSmLnzQ=",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^9.0.0",
+        "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
         "@semantic-release/github": "^8.0.0",
         "@semantic-release/npm": "^8.0.0",
@@ -11308,14 +11396,14 @@
       "dependencies": {
         "@semantic-release/error": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/@semantic-release/error/-/error-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40semantic-release%2Ferror%2F-%2Ferror-3.0.0.tgz",
+          "integrity": "sha1-MKO5e7tYRNaV6yL506pA9qkncMI=",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-7.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -11325,13 +11413,13 @@
     },
     "semver": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver/-/semver-6.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
     },
     "semver-diff": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver-diff/-/semver-diff-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver-diff%2F-%2Fsemver-diff-3.1.1.tgz",
+      "integrity": "sha1-Bfd85Z8yXgDicGr9Z7tQbdscoys=",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -11339,14 +11427,14 @@
     },
     "semver-regex": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/semver-regex/-/semver-regex-3.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver-regex%2F-%2Fsemver-regex-3.1.3.tgz",
+      "integrity": "sha1-srzG+X9jJp8oaZTil+IptiRdDcM=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/set-value/-/set-value-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fset-value%2F-%2Fset-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -11357,7 +11445,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -11366,7 +11454,7 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         }
@@ -11374,8 +11462,8 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shebang-command/-/shebang-command-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-command%2F-%2Fshebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
@@ -11383,20 +11471,20 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shebang-regex/-/shebang-regex-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-regex%2F-%2Fshebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true
     },
     "shell-quote": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shell-quote/-/shell-quote-1.7.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshell-quote%2F-%2Fshell-quote-1.7.3.tgz",
+      "integrity": "sha1-qkDtrBcERbmkMeF7tiwLiBucQSM=",
       "dev": true
     },
     "shelljs": {
       "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/shelljs/-/shelljs-0.8.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshelljs%2F-%2Fshelljs-0.8.4.tgz",
+      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -11406,8 +11494,8 @@
     },
     "side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/side-channel/-/side-channel-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fside-channel%2F-%2Fside-channel-1.0.4.tgz",
+      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
@@ -11416,15 +11504,15 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/signal-exit/-/signal-exit-3.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsignal-exit%2F-%2Fsignal-exit-3.0.6.tgz",
+      "integrity": "sha1-JOYwxLDwP+pEaivSmeYrSmyo0K8=",
       "dev": true
     },
     "signale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
-      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/signale/-/signale-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsignale%2F-%2Fsignale-1.4.0.tgz",
+      "integrity": "sha1-xL5YMC+wJirAD8PYhqfBE3WQQvE=",
       "dev": true,
       "requires": {
         "chalk": "^2.3.2",
@@ -11434,8 +11522,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -11443,8 +11531,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/chalk/-/chalk-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11454,8 +11542,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-convert/-/color-convert-1.9.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-convert%2F-%2Fcolor-convert-1.9.3.tgz",
+          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -11463,19 +11551,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/color-name/-/color-name-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-name%2F-%2Fcolor-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/figures/-/figures-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffigures%2F-%2Ffigures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -11484,14 +11566,14 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-color/-/supports-color-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -11501,19 +11583,19 @@
     },
     "sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/sisteransi/-/sisteransi-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsisteransi%2F-%2Fsisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/slash/-/slash-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fslash%2F-%2Fslash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
     },
     "slice-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/slice-ansi/-/slice-ansi-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fslice-ansi%2F-%2Fslice-ansi-4.0.0.tgz",
+      "integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
@@ -11523,8 +11605,8 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/snapdragon/-/snapdragon-0.8.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsnapdragon%2F-%2Fsnapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
         "base": "^0.11.1",
@@ -11539,8 +11621,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -11548,7 +11630,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-0.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -11557,85 +11639,28 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend-shallow%2F-%2Fextend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map/-/source-map-0.5.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -11643,8 +11668,8 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/snapdragon-node/-/snapdragon-node-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsnapdragon-node%2F-%2Fsnapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -11654,19 +11679,48 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-accessor-descriptor%2F-%2Fis-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-data-descriptor%2F-%2Fis-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-descriptor/-/is-descriptor-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-descriptor%2F-%2Fis-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/snapdragon-util/-/snapdragon-util-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsnapdragon-util%2F-%2Fsnapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -11674,7 +11728,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -11685,20 +11739,20 @@
     },
     "sorted-object": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/sorted-object/-/sorted-object-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsorted-object%2F-%2Fsorted-object-2.0.1.tgz",
       "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map/-/source-map-0.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map-resolve/-/source-map-resolve-0.5.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map-resolve%2F-%2Fsource-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
         "atob": "^2.1.2",
@@ -11709,9 +11763,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map-support/-/source-map-support-0.5.21.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map-support%2F-%2Fsource-map-support-0.5.21.tgz",
+      "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -11720,20 +11774,20 @@
     },
     "source-map-url": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map-url/-/source-map-url-0.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map-url%2F-%2Fsource-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
       "dev": true
     },
     "spawn-error-forwarder": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspawn-error-forwarder%2F-%2Fspawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/spdx-correct/-/spdx-correct-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-correct%2F-%2Fspdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -11742,14 +11796,14 @@
     },
     "spdx-exceptions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-exceptions%2F-%2Fspdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-expression-parse%2F-%2Fspdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -11758,14 +11812,14 @@
     },
     "spdx-license-ids": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-license-ids%2F-%2Fspdx-license-ids-3.0.11.tgz",
+      "integrity": "sha1-UMDYxAoU7Bv0Sbrmmg6kaFqdn5U=",
       "dev": true
     },
     "split": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/split/-/split-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsplit%2F-%2Fsplit-1.0.1.tgz",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2"
@@ -11773,8 +11827,8 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/split-string/-/split-string-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsplit-string%2F-%2Fsplit-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -11782,50 +11836,37 @@
     },
     "split2": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/split2/-/split2-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsplit2%2F-%2Fsplit2-3.2.2.tgz",
+      "integrity": "sha1-vyzyo32DgxLCSciSBv16F90SNl8=",
       "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsprintf-js%2F-%2Fsprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stack-utils": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/stack-utils/-/stack-utils-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstack-utils%2F-%2Fstack-utils-2.0.5.tgz",
+      "integrity": "sha1-0lJl/KmVFUZZ27+6O0klR3jS/dU=",
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescape-string-regexp%2F-%2Fescape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q="
         }
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/static-extend/-/static-extend-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstatic-extend%2F-%2Fstatic-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -11835,92 +11876,67 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/define-property/-/define-property-0.2.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefine-property%2F-%2Fdefine-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/stream-combiner2/-/stream-combiner2-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstream-combiner2%2F-%2Fstream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "string-argv": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string-argv/-/string-argv-0.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-argv%2F-%2Fstring-argv-0.3.1.tgz",
+      "integrity": "sha1-leL77AQnrhkYSTX4FtdKqkxcGdo=",
       "dev": true
     },
     "string-length": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string-length/-/string-length-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-length%2F-%2Fstring-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
       "dev": true,
       "requires": {
         "char-regex": "^1.0.2",
@@ -11929,27 +11945,19 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string-width/-/string-width-4.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-width%2F-%2Fstring-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        }
       }
     },
     "string.prototype.padend": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
-      "integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring.prototype.padend%2F-%2Fstring.prototype.padend-3.1.3.tgz",
+      "integrity": "sha1-mXpt4SySx8s03IogGmxT2b2IpfE=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -11959,8 +11967,8 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring.prototype.trimend%2F-%2Fstring.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -11969,8 +11977,8 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring.prototype.trimstart%2F-%2Fstring.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -11978,47 +11986,39 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/string_decoder/-/string_decoder-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.3.0.tgz",
+      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-ansi/-/strip-ansi-6.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "version": "3.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-bom/-/strip-bom-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-bom%2F-%2Fstrip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-final-newline/-/strip-final-newline-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-final-newline%2F-%2Fstrip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true
     },
     "strip-indent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-indent/-/strip-indent-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-indent%2F-%2Fstrip-indent-3.0.0.tgz",
+      "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
       "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
@@ -12026,13 +12026,13 @@
     },
     "strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/strip-json-comments/-/strip-json-comments-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-json-comments%2F-%2Fstrip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true
     },
     "subarg": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/subarg/-/subarg-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsubarg%2F-%2Fsubarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
@@ -12041,16 +12041,16 @@
     },
     "supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-color/-/supports-color-7.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "requires": {
         "has-flag": "^4.0.0"
       }
     },
     "supports-hyperlinks": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-hyperlinks%2F-%2Fsupports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha1-T3e0JIh2WJF3S3DHm6vYf5vVlLs=",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
@@ -12059,14 +12059,14 @@
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/symbol-tree/-/symbol-tree-3.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsymbol-tree%2F-%2Fsymbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
     },
     "table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+      "version": "6.7.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/table/-/table-6.7.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftable%2F-%2Ftable-6.7.5.tgz",
+      "integrity": "sha1-8ER4w1HvPYx5BPDovpChtiQX0jg=",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -12077,9 +12077,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
-          "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
+          "version": "8.8.2",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ajv/-/ajv-8.8.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fajv%2F-%2Fajv-8.8.2.tgz",
+          "integrity": "sha1-AbT+8gB6KL918Lf8AJ9iZ53kq7s=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -12090,22 +12090,22 @@
         },
         "json-schema-traverse": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-schema-traverse%2F-%2Fjson-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
           "dev": true
         }
       }
     },
     "temp-dir": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/temp-dir/-/temp-dir-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftemp-dir%2F-%2Ftemp-dir-2.0.0.tgz",
+      "integrity": "sha1-vekrBb3+sVFugEycAK1FF38xMh4=",
       "dev": true
     },
     "tempy": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tempy/-/tempy-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftempy%2F-%2Ftempy-1.0.1.tgz",
+      "integrity": "sha1-MP6QH9hpz7Nu4r2ZmAWqcvuwNd4=",
       "dev": true,
       "requires": {
         "del": "^6.0.0",
@@ -12117,16 +12117,16 @@
       "dependencies": {
         "type-fest": {
           "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-          "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.16.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.16.0.tgz",
+          "integrity": "sha1-MkC4kaeLDerpENvrhlU+VSoUiGA=",
           "dev": true
         }
       }
     },
     "terminal-link": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/terminal-link/-/terminal-link-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fterminal-link%2F-%2Fterminal-link-2.1.1.tgz",
+      "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -12135,8 +12135,8 @@
     },
     "test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/test-exclude/-/test-exclude-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftest-exclude%2F-%2Ftest-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
       "dev": true,
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
@@ -12146,71 +12146,58 @@
     },
     "text-extensions": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/text-extensions/-/text-extensions-1.9.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftext-extensions%2F-%2Ftext-extensions-1.9.0.tgz",
+      "integrity": "sha1-GFPkX+45yUXOb2w2stZZtaq8KiY=",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/text-table/-/text-table-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftext-table%2F-%2Ftext-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throat": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
-      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/throat/-/throat-6.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthroat%2F-%2Fthroat-6.0.1.tgz",
+      "integrity": "sha1-1RT+2tlXQMEsLX/HDqhj61Gt43U=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/through/-/through-2.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthrough%2F-%2Fthrough-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/through2/-/through2-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthrough2%2F-%2Fthrough2-4.0.2.tgz",
+      "integrity": "sha1-p846wqeosLlmyA58SfBITDsjl2Q=",
       "dev": true,
       "requires": {
         "readable-stream": "3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/timsort/-/timsort-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftimsort%2F-%2Ftimsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tmpl": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tmpl/-/tmpl-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftmpl%2F-%2Ftmpl-1.0.5.tgz",
+      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/to-fast-properties/-/to-fast-properties-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-fast-properties%2F-%2Fto-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/to-object-path/-/to-object-path-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-object-path%2F-%2Fto-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -12219,7 +12206,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -12230,8 +12217,8 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/to-regex/-/to-regex-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-regex%2F-%2Fto-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
         "define-property": "^2.0.2",
@@ -12242,33 +12229,26 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/to-regex-range/-/to-regex-range-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-regex-range%2F-%2Fto-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "requires": {
         "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tough-cookie/-/tough-cookie-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftough-cookie%2F-%2Ftough-cookie-4.0.0.tgz",
+      "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
         "universalify": "^0.1.2"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        }
       }
     },
     "tr46": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tr46/-/tr46-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftr46%2F-%2Ftr46-2.1.0.tgz",
+      "integrity": "sha1-+oeqgcpdWUHajL8fm3SdyWmk4kA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
@@ -12276,77 +12256,38 @@
     },
     "traverse": {
       "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/traverse/-/traverse-0.6.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftraverse%2F-%2Ftraverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
     "trim-newlines": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/trim-newlines/-/trim-newlines-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftrim-newlines%2F-%2Ftrim-newlines-3.0.1.tgz",
+      "integrity": "sha1-Jgpdli2LdSQlsy86fbDcrNF2wUQ=",
       "dev": true
     },
-    "tsc-publish": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/tsc-publish/-/tsc-publish-0.5.2.tgz",
-      "integrity": "sha512-Z/2yZSVFoeEgziTVeYc+jc6+2AygX9dnbwB6f3XuI4sSgTjoq5ggRGoTtuKcI91FzUeJq88rVZkN/VZmjbSzPw==",
-      "dev": true,
-      "requires": {
-        "@types/ignore-walk": "^3.0.1",
-        "@types/node": "^12.12.5",
-        "ansi-colors": "^4.1.1",
-        "commander": "^3.0.0",
-        "ignore-walk": "^3.0.3",
-        "strip-json-comments": "^3.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.37",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-          "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig-paths": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+      "version": "3.12.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftsconfig-paths%2F-%2Ftsconfig-paths-3.12.0.tgz",
+      "integrity": "sha1-GXaaym7o9qGjQeOMj6Rd2fsYiZs=",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tslib/-/tslib-1.14.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-1.14.1.tgz",
+      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
       "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/tsutils/-/tsutils-3.21.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftsutils%2F-%2Ftsutils-3.21.0.tgz",
+      "integrity": "sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -12354,8 +12295,8 @@
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-check/-/type-check-0.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-check%2F-%2Ftype-check-0.4.0.tgz",
+      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
@@ -12363,20 +12304,20 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-detect/-/type-detect-4.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-detect%2F-%2Ftype-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "0.18.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/type-fest/-/type-fest-0.18.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-fest%2F-%2Ftype-fest-0.18.1.tgz",
+      "integrity": "sha1-20vBUaSiz07r+a3V23VQjbbMhB8=",
       "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedarray-to-buffer%2F-%2Ftypedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
@@ -12384,8 +12325,8 @@
     },
     "typedoc": {
       "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
-      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/typedoc/-/typedoc-0.17.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.17.8.tgz",
+      "integrity": "sha1-lrZ+lFSqeFO/xNyaVciget/VR44=",
       "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
@@ -12402,8 +12343,8 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/fs-extra/-/fs-extra-8.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-8.1.0.tgz",
+          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -12413,7 +12354,7 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/jsonfile/-/jsonfile-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonfile%2F-%2Fjsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
@@ -12422,22 +12363,16 @@
         },
         "marked": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-          "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
-          "dev": true
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/marked/-/marked-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-1.0.0.tgz",
+          "integrity": "sha1-01eEJFoEhx5ZiKSR4ohnNi6UFpM=",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
       "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
-      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc-default-themes%2F-%2Ftypedoc-default-themes-0.10.2.tgz",
+      "integrity": "sha1-dDOAqAr+YsXvksob1KvirFlr5NI=",
       "dev": true,
       "requires": {
         "lunr": "^2.3.8"
@@ -12445,21 +12380,21 @@
     },
     "typescript": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/typescript/-/typescript-3.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypescript%2F-%2Ftypescript-3.8.3.tgz",
+      "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE=",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
-      "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==",
+      "version": "3.14.5",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/uglify-js/-/uglify-js-3.14.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuglify-js%2F-%2Fuglify-js-3.14.5.tgz",
+      "integrity": "sha1-zau31JVCMdgMtKknZUxGVeUfSFk=",
       "dev": true,
       "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funbox-primitive%2F-%2Funbox-primitive-1.0.1.tgz",
+      "integrity": "sha1-CF4hViXsMWJXTciFmr7nilmxRHE=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -12470,8 +12405,8 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/union-value/-/union-value-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funion-value%2F-%2Funion-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -12482,7 +12417,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         }
@@ -12490,8 +12425,8 @@
     },
     "unique-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/unique-string/-/unique-string-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funique-string%2F-%2Funique-string-2.0.0.tgz",
+      "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
@@ -12499,19 +12434,18 @@
     },
     "universal-user-agent": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universal-user-agent/-/universal-user-agent-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversal-user-agent%2F-%2Funiversal-user-agent-6.0.0.tgz",
+      "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4=",
       "dev": true
     },
     "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
+      "version": "0.1.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/universalify/-/universalify-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/unset-value/-/unset-value-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funset-value%2F-%2Funset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -12521,7 +12455,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-value/-/has-value-0.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-value%2F-%2Fhas-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -12532,7 +12466,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/isobject/-/isobject-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisobject%2F-%2Fisobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -12543,7 +12477,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/has-values/-/has-values-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-values%2F-%2Fhas-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -12551,14 +12485,14 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/upper-case/-/upper-case-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fupper-case%2F-%2Fupper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/uri-js/-/uri-js-4.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furi-js%2F-%2Furi-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -12566,38 +12500,38 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/urix/-/urix-0.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furix%2F-%2Furix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url-join": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/url-join/-/url-join-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furl-join%2F-%2Furl-join-4.0.1.tgz",
+      "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
       "dev": true
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/use/-/use-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuse%2F-%2Fuse-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Futil-deprecate%2F-%2Futil-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-compile-cache%2F-%2Fv8-compile-cache-2.3.0.tgz",
+      "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
       "dev": true
     },
     "v8-to-istanbul": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
-      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-to-istanbul%2F-%2Fv8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha1-Cut2OJTxoKFnat+Ki3YSo4kCRGw=",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -12607,16 +12541,16 @@
       "dependencies": {
         "source-map": {
           "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/source-map/-/source-map-0.7.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
           "dev": true
         }
       }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fvalidate-npm-package-license%2F-%2Fvalidate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -12624,15 +12558,15 @@
       }
     },
     "validator": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+      "version": "13.7.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/validator/-/validator-13.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fvalidator%2F-%2Fvalidator-13.7.0.tgz",
+      "integrity": "sha1-T5ZYuhO6jz2C7ogdNRZInqhcCFc=",
       "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fw3c-hr-time%2F-%2Fw3c-hr-time-1.0.2.tgz",
+      "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
@@ -12640,8 +12574,8 @@
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fw3c-xmlserializer%2F-%2Fw3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
@@ -12649,8 +12583,8 @@
     },
     "walker": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/walker/-/walker-1.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwalker%2F-%2Fwalker-1.0.8.tgz",
+      "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
@@ -12658,14 +12592,14 @@
     },
     "webidl-conversions": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/webidl-conversions/-/webidl-conversions-6.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwebidl-conversions%2F-%2Fwebidl-conversions-6.1.0.tgz",
+      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhatwg-encoding%2F-%2Fwhatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
@@ -12673,14 +12607,14 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhatwg-mimetype%2F-%2Fwhatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/whatwg-url/-/whatwg-url-8.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhatwg-url%2F-%2Fwhatwg-url-8.7.0.tgz",
+      "integrity": "sha1-ZWp45RD/jzk3vAvL6fXArDWUG3c=",
       "dev": true,
       "requires": {
         "lodash": "^4.7.0",
@@ -12690,8 +12624,8 @@
     },
     "which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/which/-/which-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhich%2F-%2Fwhich-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -12699,8 +12633,8 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhich-boxed-primitive%2F-%2Fwhich-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
       "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
@@ -12712,20 +12646,20 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/word-wrap/-/word-wrap-1.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fword-wrap%2F-%2Fword-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwordwrap%2F-%2Fwordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/wrap-ansi/-/wrap-ansi-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrap-ansi%2F-%2Fwrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
@@ -12735,14 +12669,14 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/wrappy/-/wrappy-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrappy%2F-%2Fwrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/write-file-atomic/-/write-file-atomic-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrite-file-atomic%2F-%2Fwrite-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -12752,51 +12686,51 @@
       }
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "7.5.6",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/ws/-/ws-7.5.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fws%2F-%2Fws-7.5.6.tgz",
+      "integrity": "sha1-5Z/FCfsV3ftlSH7pdlxaUd7F/ns=",
       "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/xml-name-validator/-/xml-name-validator-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxml-name-validator%2F-%2Fxml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/xmlchars/-/xmlchars-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxmlchars%2F-%2Fxmlchars-2.2.0.tgz",
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/xtend/-/xtend-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxtend%2F-%2Fxtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/y18n/-/y18n-5.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fy18n%2F-%2Fy18n-5.0.8.tgz",
+      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/yallist/-/yallist-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyallist%2F-%2Fyallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
     "yaml": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/yaml/-/yaml-1.10.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyaml%2F-%2Fyaml-1.10.2.tgz",
+      "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks=",
       "dev": true
     },
     "yargs": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/yargs/-/yargs-16.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyargs%2F-%2Fyargs-16.2.0.tgz",
+      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
@@ -12810,32 +12744,32 @@
     },
     "yargs-parser": {
       "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/yargs-parser/-/yargs-parser-20.2.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyargs-parser%2F-%2Fyargs-parser-20.2.9.tgz",
+      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/yocto-queue/-/yocto-queue-0.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyocto-queue%2F-%2Fyocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true
     },
     "z-schema": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "version": "5.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/z-schema/-/z-schema-5.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fz-schema%2F-%2Fz-schema-5.0.2.tgz",
+      "integrity": "sha1-9BA5Syyfy57a9qdRFJHAu06JpQQ=",
       "dev": true,
       "requires": {
         "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
       },
       "dependencies": {
         "commander": {
           "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/commander/-/commander-2.20.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcommander%2F-%2Fcommander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,10 @@
     "url": "https://github.com/IBM/node-sdk-core/issues"
   },
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.13.68",
-    "@microsoft/api-extractor": "^7.18.19",
+    "@microsoft/api-documenter": "^7.13.76",
+    "@microsoft/api-extractor": "^7.19.2",
     "@types/debug": "^4.1.7",
     "@types/lodash.isempty": "^4.4.6",
-    "@types/dotenv": "^8.2.0",
     "@types/extend": "^3.0.1",
     "@types/mime-types": "^2.1.1",
     "@commitlint/cli": "^12.0.1",
@@ -64,8 +63,8 @@
     "nock": "^13.1.2",
     "object.assign": "~4.1.0",
     "prettier": "^2.3.0",
-    "semantic-release": "18.0.0",
-    "tsc-publish": "^0.5.2",
+    "semantic-release": "18.0.1",
+    "@masterodin/publisher": "^0.10.0",
     "typedoc": "^0.17.0",
     "typescript": "~3.8.3",
     "npm-run-all": "^4.1.5",
@@ -123,7 +122,7 @@
     "build:doc": "npm-run-all build:api build:md copy:doc",
     "copy:doc": "cpx \"temp/ibm-cloud-sdk-core.api.json\" dist/docs",
     "copy:pkg": "package-json-reducer -s \"config devDependencies directories scripts jestSonar jest\" -o ./dist/package.json package.json",
-    "postversion": "tsc-publish --no-checks --dry-run",
+    "postversion": "publisher --no-checks --dry-run",
     "all": "npm-run-all build test lint"
   },
   "jest": {


### PR DESCRIPTION
This PR contains a few changes to our dependency versions to avoid vulnerability alerts.
I also removed the contents of the .cveignore file since that is no longer needed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
