### PR TITLE
fix: avoid Buffer re-encode during compression

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -444,6 +444,8 @@ export class RequestWrapper {
       if (isStream(data)) {
         const streamData = await streamToPromise(data);
         reqBuffer = Buffer.isBuffer(streamData) ? streamData : Buffer.from(streamData);
+      } else if (Buffer.isBuffer(data)) {
+        reqBuffer = data;
       } else if (data.toString && data.toString() !== '[object Object]' && !Array.isArray(data)) {
         // this handles pretty much any primitive that isnt a JSON object or array
         reqBuffer = Buffer.from(data.toString());

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -908,6 +908,19 @@ describe('gzipRequestBody', () => {
     expect(headers['Content-Encoding']).toBe('gzip');
   });
 
+  it('should compress buffer data into a buffer', async () => {
+    // Use an invalid UTF-8 overlong encoding as example binary data
+    const originalData = Buffer.from('f08282ac', 'hex');
+    const headers = {};
+
+    const data = await requestWrapperInstance.gzipRequestBody(originalData, headers);
+    expect(data).toBeInstanceOf(Buffer);
+    expect(gzipSpy).toHaveBeenCalled();
+    expect(headers['Content-Encoding']).toBe('gzip');
+    // If UTF-8 has been assumed the data will not match
+    expect(zlib.gunzipSync(data)).toEqual(originalData);
+  });
+
   it('should log an error and return data unaltered if data cant be stringified', async () => {
     let data = { key: 'value' };
     data.circle = data;


### PR DESCRIPTION
This is similar to the problem fixed by #182 but in this case for `Buffer` request body data instead of a `ReadableStream`.

The fix in this case is if the `data` is already a `Buffer` then just compress it, don't convert it to a `string` and back to a `Buffer` again before compressing it.
 
I added a test with `Buffer` input. I chose the input carefully to ensure that if it was assumed to be `UTF-8` encoded it would not be the same when decompressed and added an additional assertion for the decompressed data to match the original.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
