### PR TITLE
fix: remove 'module' entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.17.6",
   "description": "Core functionality to support SDKs generated with IBM's OpenAPI SDK Generator.",
   "main": "./index.js",
-  "module": "./es/index.js",
   "typings": "./es/index.d.ts",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
A recent change to the library introduced
a separate es6 module for the library to support
tree shaking.  Unfortunately, if an SDK project
doesn't (at a minimum) define the 'main' entry point
in its package.json file, then a problem can occur
due to an es5 vs es6 incompatibility.
This commit provides a tactical fix for this issue
by removing the 'module' entry point from the library's
package.json.  This will prevent webpack from being
able to minimize the resulting application code, but
it will avoid the problem.

Once we have a strategy for rolling out "tree
shakability" in various SDK projects, we can
re-introduce the 'module' entry point.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
