### PR TITLE
fix: avoid errors during logging of requests/responses

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -132,22 +132,12 @@ export class RequestWrapper {
       this.axiosInstance.interceptors.request.use(
         (config) => {
           logger.debug('Request:');
-          try {
-            logger.debug(JSON.stringify(config, null, 2));
-          } catch {
-            logger.error(config);
-          }
-
+          logger.debug(config);
           return config;
         },
         (error) => {
           logger.error('Error: ');
-          try {
-            logger.error(JSON.stringify(error, null, 2));
-          } catch {
-            logger.error(error);
-          }
-
+          logger.error(error);
           return Promise.reject(error);
         }
       );
@@ -155,22 +145,12 @@ export class RequestWrapper {
       this.axiosInstance.interceptors.response.use(
         (response) => {
           logger.debug('Response:');
-          try {
-            logger.debug(JSON.stringify(response, null, 2));
-          } catch {
-            logger.error(response);
-          }
-
+          logger.debug(response);
           return response;
         },
         (error) => {
           logger.error('Error: ');
-          try {
-            logger.error(JSON.stringify(error, null, 2));
-          } catch {
-            logger.error(error);
-          }
-
+          logger.error(error);
           return Promise.reject(error);
         }
       );


### PR DESCRIPTION
Fixes https://github.com/IBM/node-sdk-core/issues/179

This commit slightly modifies how requests and responses
are logged when debug logging is enabled to avoid
any JSON marshalling type errors.
We no longer use JSON.stringify() to format
the request and response objects, as they
actually aren't needed because the
logger.debug() and logger.error() functions
can handle objects just fine and do a decent job
of pretty-printing them.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
