### PR TITLE
fix: do not retry on 501

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -365,6 +365,7 @@ export class RequestWrapper {
       retry: 4, // 4 retries by default
       retryDelay: 1000, // 1000 ms (1 sec) initial delay
       httpMethodsToRetry: ['GET', 'HEAD', 'OPTIONS', 'DELETE', 'PUT', 'POST'],
+      statusCodesToRetry: [[429], [500], [502, 599]], // do not retry on 501
       instance: axiosInstance,
       backoffType: 'exponential',
       checkRetryAfter: true, // use Retry-After header first

--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -365,7 +365,12 @@ export class RequestWrapper {
       retry: 4, // 4 retries by default
       retryDelay: 1000, // 1000 ms (1 sec) initial delay
       httpMethodsToRetry: ['GET', 'HEAD', 'OPTIONS', 'DELETE', 'PUT', 'POST'],
-      statusCodesToRetry: [[429], [500], [502, 599]], // do not retry on 501
+      // do not retry on 501
+      statusCodesToRetry: [
+        [429, 429],
+        [500, 500],
+        [502, 599],
+      ],
       instance: axiosInstance,
       backoffType: 'exponential',
       checkRetryAfter: true, // use Retry-After header first

--- a/test/unit/retry.test.js
+++ b/test/unit/retry.test.js
@@ -90,6 +90,15 @@ describe('Node Core retries', () => {
     await service.createRequest(parameters).catch((err) => expect(err).toBeDefined());
   });
 
+  it('should not retry on 501`', async () => {
+    const scopes = [
+      nock(url).get('/').reply(501, undefined),
+      nock(url).get('/').reply(200, 'retry success!'),
+    ];
+
+    await service.createRequest(parameters).catch((err) => expect(err).toBeDefined());
+  });
+
   it('should not retry after we call disableRetries', async () => {
     const scopes = [
       nock(url).get('/').reply(500, undefined),

--- a/test/unit/retry.test.js
+++ b/test/unit/retry.test.js
@@ -96,7 +96,11 @@ describe('Node Core retries', () => {
       nock(url).get('/').reply(200, 'retry success!'),
     ];
 
-    await service.createRequest(parameters).catch((err) => expect(err).toBeDefined());
+    let err;
+    await service.createRequest(parameters).catch((error) => {
+      err = error;
+    });
+    expect(err).toBeDefined();
   });
 
   it('should not retry after we call disableRetries', async () => {


### PR DESCRIPTION
The other SDK cores skip retry for `501`,
so the Node core should behave the same way.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
