### PR TITLE
fix: ensure dist/docs is a directory during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "build:api": "api-extractor run --local",
     "build:md": "api-documenter markdown -i temp --output-folder build/docs",
     "build:doc": "npm-run-all build:api build:md copy:doc",
-    "copy:doc": "cp \"temp/ibm-cloud-sdk-core.api.json\" dist/docs",
+    "copy:doc": "mkdir -p dist/docs && cp \"temp/ibm-cloud-sdk-core.api.json\" dist/docs",
     "copy:pkg": "package-json-reducer -s \"config devDependencies directories scripts jestSonar jest\" -o ./dist/package.json package.json",
     "postversion": "publisher --no-checks --dry-run",
     "all": "npm-run-all build test lint"


### PR DESCRIPTION
A recent change seems to have removed the creation of the `dist/docs/`
folder during the build and as such, the `cp` command we invoke was
renaming the JSON docs file as a new file with the name `docs`.

This change ensures a folder called `dist/docs/` is created if one
is not already present.

Resolves #201 