### PR TITLE
fix: update file-type to resolve vulnerability

### DIFF
--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -94,7 +94,7 @@ export class BearerTokenAuthenticator extends Authenticator {
 }
 
 // @public
-export function buildRequestFileObject(fileParam: FileWithMetadata): FileObject;
+export function buildRequestFileObject(fileParam: FileWithMetadata): Promise<FileObject>;
 
 // @public
 export function checkCredentials(obj: any, credsToCheck: string[]): Error | null;
@@ -155,7 +155,7 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
 
 // @public (undocumented)
 export const contentType: {
-    fromFilename: (file: String | File | Buffer | NodeJS.ReadableStream | FileObject) => string;
+    fromFilename: (file: String | File | FileObject | NodeJS.ReadableStream | Buffer) => string;
     fromHeader: (buffer: Buffer) => string;
 };
 
@@ -211,7 +211,7 @@ export interface FileWithMetadata {
 export function getAuthenticatorFromEnvironment(serviceName: string): Authenticator;
 
 // @public
-export function getContentType(inputData: NodeJS.ReadableStream | Buffer): string;
+export function getContentType(inputData: NodeJS.ReadableStream | Buffer): Promise<string>;
 
 // @public
 export function getCurrentTime(): number;

--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -178,7 +178,7 @@ export class RequestWrapper {
         // Skip keys with undefined/null values or empty object value
         values
           .filter((v) => v != null && !isEmptyObject(v))
-          .forEach((value) => {
+          .forEach(async (value) => {
             // Special case of empty file object
             if (
               Object.prototype.hasOwnProperty.call(value, 'contentType') &&
@@ -188,7 +188,7 @@ export class RequestWrapper {
             }
 
             if (isFileWithMetadata(value)) {
-              const fileObj = buildRequestFileObject(value);
+              const fileObj = await buildRequestFileObject(value);
               multipartForm.append(key, fileObj.value, fileObj.options);
             } else {
               if (typeof value === 'object' && !isFileData(value)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "dotenv": "^6.2.0",
         "expect": "^26.1.0",
         "extend": "^3.0.2",
-        "file-type": "^7.7.1",
+        "file-type": "16.5.4",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
         "jsonwebtoken": "^8.5.1",
@@ -61,7 +61,7 @@
         "npm-run-all": "^4.1.5",
         "object.assign": "~4.1.0",
         "package-json-reducer": "^1.0.18",
-        "prettier": "^2.3.0",
+        "prettier": "~2.3.0",
         "rimraf": "^3.0.2",
         "semantic-release": "19.0.3",
         "typescript": "~3.8.3"
@@ -2429,6 +2429,11 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -5307,11 +5312,19 @@
       }
     },
     "node_modules/file-type": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -5862,6 +5875,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -5979,8 +6011,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -11947,6 +11978,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -12150,18 +12193,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -12543,6 +12583,34 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/redent": {
@@ -13188,7 +13256,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -13350,6 +13417,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -13582,6 +13665,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
+      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -13820,8 +13919,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -16068,6 +16166,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -18268,9 +18371,14 @@
       }
     },
     "file-type": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -18656,6 +18764,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -18736,8 +18849,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -23210,6 +23322,11 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -23354,9 +23471,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -23654,6 +23771,26 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "redent": {
@@ -24152,7 +24289,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -24275,6 +24411,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -24459,6 +24604,15 @@
         "is-number": "^7.0.0"
       }
     },
+    "token-types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
+      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -24641,8 +24795,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "npm-run-all": "^4.1.5",
     "object.assign": "~4.1.0",
     "package-json-reducer": "^1.0.18",
-    "prettier": "^2.3.0",
+    "prettier": "~2.3.0",
     "rimraf": "^3.0.2",
     "semantic-release": "19.0.3",
     "typescript": "~3.8.3"
@@ -83,7 +83,7 @@
     "dotenv": "^6.2.0",
     "expect": "^26.1.0",
     "extend": "^3.0.2",
-    "file-type": "^7.7.1",
+    "file-type": "16.5.4",
     "form-data": "^2.3.3",
     "isstream": "~0.1.2",
     "jsonwebtoken": "^8.5.1",

--- a/test/unit/build-request-file-object.test.js
+++ b/test/unit/build-request-file-object.test.js
@@ -24,18 +24,18 @@ describe('buildRequestFileObject', () => {
   const customName = 'custom-name.env';
 
   describe('filename tests', () => {
-    it('should prioritze user given filename', () => {
+    it('should prioritze user given filename', async () => {
       const fileParams = {
         data: fs.createReadStream(filepath),
         filename: customName,
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe(customName);
     });
 
-    it('should handle file object with `value` property', () => {
+    it('should handle file object with `value` property', async () => {
       const fileParams = {
         data: {
           value: fs.readFileSync(filepath),
@@ -44,23 +44,23 @@ describe('buildRequestFileObject', () => {
           },
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe(customName);
     });
 
-    it('should get filename from readable stream', () => {
+    it('should get filename from readable stream', async () => {
       const fileParams = {
         data: fs.createReadStream(filepath),
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe('other-file.env');
     });
 
-    it('should handle file object with a readable stream as its `value`', () => {
+    it('should handle file object with a readable stream as its `value`', async () => {
       const fileStream = fs.createReadStream(filepath);
       fileStream.path = `/fake/path/${customName}`;
 
@@ -69,13 +69,13 @@ describe('buildRequestFileObject', () => {
           value: fileStream,
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe(customName);
     });
 
-    it('should handle path property being a buffer', () => {
+    it('should handle path property being a buffer', async () => {
       const fileStream = fs.createReadStream(filepath);
       fileStream.path = Buffer.from(`/fake/path/${customName}`);
 
@@ -84,18 +84,18 @@ describe('buildRequestFileObject', () => {
           value: fileStream,
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(Buffer.isBuffer(fileStream.path)).toBe(true);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe(customName);
     });
 
-    it('should use an underscore when filename is not found', () => {
+    it('should use an underscore when filename is not found', async () => {
       const fileParams = {
         data: fs.readFileSync(filepath),
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.filename).toBeDefined();
       expect(fileObj.options.filename).toBe('_');
@@ -104,7 +104,7 @@ describe('buildRequestFileObject', () => {
 
   //      CONTENT TYPE
   describe('content type tests', () => {
-    it('should read contentType from options in file object', () => {
+    it('should read contentType from options in file object', async () => {
       const fileParams = {
         data: {
           value: {},
@@ -113,50 +113,50 @@ describe('buildRequestFileObject', () => {
           },
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.contentType).toBeDefined();
       expect(fileObj.options.contentType).toBe('audio/wave');
     });
 
-    it('should read contentType from user parameter', () => {
+    it('should read contentType from user parameter', async () => {
       const fileParams = {
         contentType: 'audio/wave',
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.contentType).toBeDefined();
       expect(fileObj.options.contentType).toBe('audio/wave');
     });
 
-    it('should use `getContentType` to read mime type from file object', () => {
+    it('should use `getContentType` to read mime type from file object', async () => {
       const fileParams = {
         data: {
           value: fs.createReadStream(audioFile),
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.contentType).toBeDefined();
       expect(fileObj.options.contentType).toBe('audio/wave');
     });
 
-    it('should use `getContentType` to read mime type from data', () => {
+    it('should use `getContentType` to read mime type from data', async () => {
       const fileParams = {
         data: fs.createReadStream(audioFile),
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.contentType).toBeDefined();
       expect(fileObj.options.contentType).toBe('audio/wave');
     });
 
-    it('should default to `application/octet-stream` if no other content type is defined', () => {
+    it('should default to `application/octet-stream` if no other content type is defined', async () => {
       const fileParams = {
         // the `lookup` package doesn't have a value for a file with extension `.env`
         data: fs.createReadStream(filepath),
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.options).toBeDefined();
       expect(fileObj.options.contentType).toBeDefined();
       expect(fileObj.options.contentType).toBe('application/octet-stream');
@@ -165,34 +165,34 @@ describe('buildRequestFileObject', () => {
 
   //      VALUE
   describe('value tests', () => {
-    it('should read value from data.value for a file object', () => {
+    it('should read value from data.value for a file object', async () => {
       const data = fs.createReadStream(filepath);
       const fileParams = {
         data: {
           value: data,
         },
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.value).toBeDefined();
       expect(fileObj.value).toBe(data);
     });
 
-    it('should read value from data property', () => {
+    it('should read value from data property', async () => {
       const data = fs.readFileSync(filepath);
       const fileParams = {
         data,
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.value).toBeDefined();
       expect(fileObj.value).toBe(data);
     });
 
-    it('should convert string data to a buffer', () => {
+    it('should convert string data to a buffer', async () => {
       const data = 'just a string';
       const fileParams = {
         data,
       };
-      const fileObj = buildRequestFileObject(fileParams);
+      const fileObj = await buildRequestFileObject(fileParams);
       expect(fileObj.value).toBeDefined();
       expect(Buffer.isBuffer(fileObj.value)).toBe(true);
       expect(fileObj.value.toString()).toBe(data);

--- a/test/unit/get-content-type.test.js
+++ b/test/unit/get-content-type.test.js
@@ -20,29 +20,29 @@ const { getContentType } = require('../../dist/lib/helper');
 const filepath = `${__dirname}/../resources/blank.wav`;
 
 describe('getContentType', () => {
-  it('should read content type from read stream', () => {
+  it('should read content type from read stream', async () => {
     const streamFile = fs.createReadStream(filepath);
-    expect(getContentType(streamFile)).toBe('audio/wave');
+    expect(await getContentType(streamFile)).toBe('audio/wave');
   });
 
-  it('should not get content type from read stream with corrupted path property', () => {
+  it('should not get content type from read stream with corrupted path property', async () => {
     const streamFile = fs.createReadStream(filepath);
     streamFile.path = 'unrecognizeable-format';
-    expect(getContentType(streamFile)).toBeNull();
+    expect(await getContentType(streamFile)).toBeNull();
   });
 
-  it('should read content type from buffer', () => {
+  it('should read content type from buffer', async () => {
     const bufferFile = fs.readFileSync(filepath);
-    expect(getContentType(bufferFile)).toBe('audio/x-wav');
+    expect(await getContentType(bufferFile)).toBe('audio/vnd.wave');
   });
 
-  it('should not read content type from a string', () => {
+  it('should not read content type from a string', async () => {
     const str = 'a,b,c,d,e';
-    expect(getContentType(str)).toBeNull();
+    expect(await getContentType(str)).toBeNull();
   });
 
-  it('should not read content type from a number', () => {
+  it('should not read content type from a number', async () => {
     const number = 4;
-    expect(getContentType(number)).toBeNull();
+    expect(await getContentType(number)).toBeNull();
   });
 });


### PR DESCRIPTION
Resolves #204 

The CVE states that v16.5.4 is clean, so I upgraded to that and modified the code accordingly. It led to some function changes from sync to async but all functions that should really only be used internally. That said, I think these functions are technically exported as part of the public API, so we should evaluate if this should considered a breaking change or a necessary fix of broken (vulnerable) code.

I wanted to upgrade to v17 but that caused a number of TypeScript errors from the `file-type` internal code. I may open an issue there to see if I can find out why it's happening.