### PR TITLE
fix: correct AuthenticatorInterface type

### DIFF
--- a/auth/authenticators/authenticator-interface.ts
+++ b/auth/authenticators/authenticator-interface.ts
@@ -44,7 +44,7 @@ export interface AuthenticatorInterface {
    * @param {object.<string, string>} requestOptions.headers The headers the
    *   authentication information will be added to.
    */
-  authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+  authenticate(requestOptions: AuthenticateOptions): Promise<void>;
 
   /**
    * Returns a string that indicates the authentication type.

--- a/auth/authenticators/authenticator.ts
+++ b/auth/authenticators/authenticator.ts
@@ -63,7 +63,7 @@ export class Authenticator implements AuthenticatorInterface {
    * @throws {Error} - The authenticate method was not implemented by a
    *   subclass.
    */
-  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void> {
     const error = new Error('Should be implemented by subclass!');
     return Promise.reject(error);
   }

--- a/auth/authenticators/basic-authenticator.ts
+++ b/auth/authenticators/basic-authenticator.ts
@@ -69,7 +69,7 @@ export class BasicAuthenticator extends Authenticator {
    * @param {object.<string, string>} requestOptions.headers - The headers the
    *   authentication information will be added too.
    */
-  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void> {
     return new Promise((resolve) => {
       requestOptions.headers = extend(true, {}, requestOptions.headers, this.authHeader);
       resolve();

--- a/auth/authenticators/token-request-based-authenticator.ts
+++ b/auth/authenticators/token-request-based-authenticator.ts
@@ -119,7 +119,7 @@ export class TokenRequestBasedAuthenticator extends Authenticator {
    *   authentication information will be added too. Overrides default headers
    *   where there's conflict.
    */
-  public authenticate(requestOptions: AuthenticateOptions): Promise<void | Error> {
+  public authenticate(requestOptions: AuthenticateOptions): Promise<void> {
     return this.tokenManager.getToken().then((token) => {
       const authHeader = { Authorization: `Bearer ${token}` };
       requestOptions.headers = extend(true, {}, requestOptions.headers, authHeader);

--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -21,7 +21,7 @@ export function atMostOne(a: any, b: any): boolean;
 export class Authenticator implements AuthenticatorInterface {
     constructor();
     // Warning: (ae-forgotten-export) The symbol "AuthenticateOptions" needs to be exported by the entry point index.d.ts
-    authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+    authenticate(requestOptions: AuthenticateOptions): Promise<void>;
     authenticationType(): string;
     static AUTHTYPE_BASIC: string;
     // (undocumented)
@@ -42,7 +42,7 @@ export class Authenticator implements AuthenticatorInterface {
 
 // @public
 export interface AuthenticatorInterface {
-    authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+    authenticate(requestOptions: AuthenticateOptions): Promise<void>;
     authenticationType(): string;
 }
 
@@ -72,7 +72,7 @@ export class BaseService {
 export class BasicAuthenticator extends Authenticator {
     // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
     constructor(options: Options);
-    authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+    authenticate(requestOptions: AuthenticateOptions): Promise<void>;
     authenticationType(): string;
     // (undocumented)
     protected authHeader: {
@@ -390,7 +390,7 @@ export type TokenManagerOptions = {
 export class TokenRequestBasedAuthenticator extends Authenticator {
     // Warning: (ae-forgotten-export) The symbol "BaseOptions" needs to be exported by the entry point index.d.ts
     constructor(options: BaseOptions);
-    authenticate(requestOptions: AuthenticateOptions): Promise<void | Error>;
+    authenticate(requestOptions: AuthenticateOptions): Promise<void>;
     // (undocumented)
     protected disableSslVerification: boolean;
     // (undocumented)


### PR DESCRIPTION
The interface incorrectly defined the data channel as "void or Error" when it
should only be "void", as Errors are sent in a different channel. This updates
the type to be correct. It should not constitute a breaking update as we
already defined authenticators with the new type in this project.

Resolves #176

Signed-off-by: Dustin Popp <dpopp07@gmail.com>