### PR TITLE
feat: add `setDefaultHeaders` method on base service class

### DIFF
--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -64,6 +64,7 @@ export class BaseService {
     enableRetries(retryOptions?: RetryOptions): void;
     getAuthenticator(): any;
     getHttpClient(): AxiosInstance;
+    setDefaultHeaders(headers: OutgoingHttpHeaders): void;
     setEnableGzipCompression(setting: boolean): void;
     setServiceUrl(url: string): void;
 }

--- a/lib/base-service.ts
+++ b/lib/base-service.ts
@@ -155,6 +155,20 @@ export class BaseService {
   }
 
   /**
+   * Set the HTTP headers to be sent in every request.
+   *
+   * @param {OutgoingHttpHeaders} headers The map of headers to include in requests.
+   */
+  public setDefaultHeaders(headers: OutgoingHttpHeaders): void {
+    if (typeof headers !== 'object') {
+      // do nothing, for now
+      return;
+    }
+
+    this.baseOptions.headers = headers;
+  }
+
+  /**
    * Turn request body compression on or off.
    *
    * @param {boolean} setting Will turn it on if 'true', off if 'false'.

--- a/test/unit/base-service.test.js
+++ b/test/unit/base-service.test.js
@@ -480,6 +480,35 @@ describe('Base Service', () => {
 
     expect(disableRetriesMock).toHaveBeenCalled();
   });
+
+  it('setDefaultHeaders should override the headers object with new headers', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+      headers: {
+        'X-Some-Header': 'value',
+      },
+    });
+
+    testService.setDefaultHeaders({ 'X-New-Header': 'new value' });
+
+    expect(testService.baseOptions.headers['X-New-Header']).toEqual('new value');
+    expect(testService.baseOptions.headers['X-Some-Header']).toBeUndefined();
+    expect(Object.keys(testService.baseOptions.headers)).toEqual(['X-New-Header']);
+  });
+
+  it('setDefaultHeaders should do nothing when not given an object', () => {
+    const testService = new TestService({
+      authenticator: AUTHENTICATOR,
+      headers: {
+        'X-Some-Header': 'value',
+      },
+    });
+
+    testService.setDefaultHeaders('new header: another value');
+
+    expect(Object.keys(testService.baseOptions.headers)).toEqual(['X-Some-Header']);
+    expect(testService.baseOptions.headers['X-Some-Header']).toEqual('value');
+  });
 });
 
 function TestService(options) {


### PR DESCRIPTION
This change adds a setter for the default headers stored on the base service.
These headers are sent with every SDK request. All of the other language cores
supported setting these values post-construction so this brings Node to parity.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>