### PR TITLE
feat: add method `getNewLogger` to public API

### DIFF
--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -8,6 +8,7 @@
 
 import { AxiosInstance } from 'axios';
 import type { CookieJar } from 'tough-cookie';
+import { Debugger } from 'debug';
 import { OutgoingHttpHeaders } from 'http';
 import { Stream } from 'stream';
 
@@ -228,6 +229,9 @@ export function getMissingParams(params: {
 }, requires: string[]): null | Error;
 
 // @public
+export function getNewLogger(moduleName: string): SDKLogger;
+
+// @public
 function getOptions(createRequestMock: any): any;
 
 // @public
@@ -345,6 +349,20 @@ export function readExternalSources(serviceName: string): any;
 
 // @public
 export function removeSuffix(str: string, suffix: string): string;
+
+// @public (undocumented)
+export interface SDKLogger {
+    // (undocumented)
+    debug: Debugger;
+    // (undocumented)
+    error: Debugger;
+    // (undocumented)
+    info: Debugger;
+    // (undocumented)
+    verbose: Debugger;
+    // (undocumented)
+    warn: Debugger;
+}
 
 // @public
 export function streamToPromise(stream: Stream): Promise<any>;

--- a/index.ts
+++ b/index.ts
@@ -27,3 +27,4 @@ export { default as qs } from './lib/querystring';
 export { default as contentType } from './lib/content-type';
 export * from './lib/stream-to-promise';
 export { unitTestUtils };
+export { getNewLogger, SDKLogger } from './lib/get-new-logger';

--- a/lib/get-new-logger.ts
+++ b/lib/get-new-logger.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/get-new-logger.ts
+++ b/lib/get-new-logger.ts
@@ -1,0 +1,75 @@
+/**
+ * (C) Copyright IBM Corp. 2019, 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import logger, { Debugger } from 'debug';
+
+export interface SDKLogger {
+  error: Debugger;
+  warn: Debugger;
+  info: Debugger;
+  verbose: Debugger;
+  debug: Debugger;
+}
+
+/**
+ * Return a new logger, formatted with a particular name. The logging functions, in
+ * order of increasing verbosity, are: `error`, `warn`, `info`, `verbose`, and `debug`.
+ *
+ * The logger will be an instance of the `debug` package and utilizes its support for
+ * configuration with environment variables.
+ *
+ * Additionally, the logger will be turned on automatically if the "NODE_DEBUG"
+ * environment variable is set to "axios".
+ *
+ * @param {string} moduleName - the namespace for the logger. The name will appear in
+ * the logs and it will be the name used for configuring the log level.
+ *
+ * @returns {SDKLogger} the new logger
+ */
+export function getNewLogger(moduleName: string): SDKLogger {
+  const debug = logger(`${moduleName}:debug`);
+  const error = logger(`${moduleName}:error`);
+  const info = logger(`${moduleName}:info`);
+  const verbose = logger(`${moduleName}:verbose`);
+  const warn = logger(`${moduleName}:warning`);
+
+  // enable loggers if axios flag is set & mimic log levels severity
+  if (process.env.NODE_DEBUG === 'axios') {
+    debug.enabled = true;
+  }
+  if (debug.enabled) {
+    verbose.enabled = true;
+  }
+  if (verbose.enabled) {
+    info.enabled = true;
+  }
+  if (info.enabled) {
+    warn.enabled = true;
+  }
+  if (warn.enabled) {
+    error.enabled = true;
+  }
+
+  const newLogger: SDKLogger = {
+    debug,
+    error,
+    info,
+    verbose,
+    warn,
+  };
+
+  return newLogger;
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2019, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -14,35 +14,6 @@
  * limitations under the License.
  */
 
-import logger from 'debug';
+import { getNewLogger } from './get-new-logger';
 
-const debug = logger('ibm-cloud-sdk-core:debug');
-const error = logger('ibm-cloud-sdk-core:error');
-const info = logger('ibm-cloud-sdk-core:info');
-const verbose = logger('ibm-cloud-sdk-core:verbose');
-const warn = logger('ibm-cloud-sdk-core:warning');
-
-// enable loggers if axios flag is set & mimic log levels severity
-if (process.env.NODE_DEBUG === 'axios') {
-  debug.enabled = true;
-}
-if (debug.enabled) {
-  verbose.enabled = true;
-}
-if (verbose.enabled) {
-  info.enabled = true;
-}
-if (info.enabled) {
-  warn.enabled = true;
-}
-if (warn.enabled) {
-  error.enabled = true;
-}
-// export loggers;
-export default {
-  debug,
-  error,
-  info,
-  verbose,
-  warn,
-};
+export default getNewLogger('ibm-cloud-sdk-core');

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -1,0 +1,141 @@
+/**
+ * (C) Copyright IBM Corp. 2019, 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('get new logger', () => {
+  let env;
+
+  beforeEach(() => {
+    env = process.env;
+    process.env = {};
+    jest.resetModules();
+  });
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('should return a logger with all methods disabled by default', () => {
+    const getNewLogger = setEnvironmentAndResetModule();
+    const logger = getNewLogger('test-module');
+
+    expect(logger.warn.enabled).toBeFalsy();
+    expect(logger.verbose.enabled).toBeFalsy();
+    expect(logger.info.enabled).toBeFalsy();
+    expect(logger.error.enabled).toBeFalsy();
+    expect(logger.debug.enabled).toBeFalsy();
+  });
+
+  it('should return a logger with all methods enabled when axios debug flag is set', () => {
+    process.env.NODE_DEBUG = 'axios';
+    const getNewLogger = setEnvironmentAndResetModule();
+    const logger = getNewLogger('test-module');
+
+    expect(logger.debug.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.verbose.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+  });
+
+  it('should return a logger with all methods enabled when configued with "*"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module*');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.debug.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.verbose.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+  });
+
+  it('should return a debug-scoped logger when configued with "debug"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:debug');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.debug.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.verbose.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+  });
+
+  it('should return an error-scoped logger when configued with "error"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:error');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.debug.enabled).toBe(false);
+    expect(logger.info.enabled).toBe(false);
+    expect(logger.verbose.enabled).toBe(false);
+    expect(logger.warn.enabled).toBe(false);
+  });
+
+  it('should return an info-scoped logger when configued with "info"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:info');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.debug.enabled).toBe(false);
+    expect(logger.verbose.enabled).toBe(false);
+  });
+
+  it('should return a verbose-scoped logger when configued with "verbose"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:verbose');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.verbose.enabled).toBe(true);
+    expect(logger.debug.enabled).toBe(false);
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+  });
+
+  it('should return a warn-scoped logger when configued with "warning"', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:warning');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.warn.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.verbose.enabled).toBe(false);
+    expect(logger.info.enabled).toBe(false);
+    expect(logger.debug.enabled).toBe(false);
+  });
+
+  it('should prioritize stricter log levels', () => {
+    const getNewLogger = setEnvironmentAndResetModule('test-module:error,test-module:verbose');
+    const logger = getNewLogger('test-module');
+
+    expect(logger.debug.enabled).toBe(false);
+    expect(logger.error.enabled).toBe(true);
+    expect(logger.info.enabled).toBe(true);
+    expect(logger.verbose.enabled).toBe(true);
+    expect(logger.warn.enabled).toBe(true);
+  });
+});
+
+// the "debug" module that we rely on to provide logging functionality seems to read the
+// environment variables at module-load time. For this reason, simply programatically
+// re-writing the environment variables prior to calling 'getNewLogger' is not sufficient
+// for proper configuration. We need to re-load the module each time.
+//
+// This should be fine in standard practice, as environment variables are expected to be
+// set prior to executing any SDK code.
+function setEnvironmentAndResetModule(debugValue) {
+  process.env.DEBUG = debugValue;
+  const { getNewLogger } = require('../../dist/lib/get-new-logger');
+  return getNewLogger;
+}

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -82,7 +82,7 @@ describe('get new logger', () => {
     expect(logger.warn.enabled).toBe(false);
   });
 
-  it('should return an info-scoped logger when configued with "info"', () => {
+  it('should return an info-scoped logger when configured with "info"', () => {
     const getNewLogger = setEnvironmentAndResetModule('test-module:info');
     const logger = getNewLogger('test-module');
 

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -93,7 +93,7 @@ describe('get new logger', () => {
     expect(logger.verbose.enabled).toBe(false);
   });
 
-  it('should return a verbose-scoped logger when configued with "verbose"', () => {
+  it('should return a verbose-scoped logger when configured with "verbose"', () => {
     const getNewLogger = setEnvironmentAndResetModule('test-module:verbose');
     const logger = getNewLogger('test-module');
 

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -71,7 +71,7 @@ describe('get new logger', () => {
     expect(logger.warn.enabled).toBe(true);
   });
 
-  it('should return an error-scoped logger when configued with "error"', () => {
+  it('should return an error-scoped logger when configured with "error"', () => {
     const getNewLogger = setEnvironmentAndResetModule('test-module:error');
     const logger = getNewLogger('test-module');
 

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -49,7 +49,7 @@ describe('get new logger', () => {
     expect(logger.warn.enabled).toBe(true);
   });
 
-  it('should return a logger with all methods enabled when configued with "*"', () => {
+  it('should return a logger with all methods enabled when configured with "*"', () => {
     const getNewLogger = setEnvironmentAndResetModule('test-module*');
     const logger = getNewLogger('test-module');
 

--- a/test/unit/get-new-logger.test.js
+++ b/test/unit/get-new-logger.test.js
@@ -104,7 +104,7 @@ describe('get new logger', () => {
     expect(logger.warn.enabled).toBe(true);
   });
 
-  it('should return a warn-scoped logger when configued with "warning"', () => {
+  it('should return a warn-scoped logger when configured with "warning"', () => {
     const getNewLogger = setEnvironmentAndResetModule('test-module:warning');
     const logger = getNewLogger('test-module');
 

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -40,19 +40,10 @@ describe('Logger', () => {
     expect(logger.debug.enabled).toBeFalsy();
   });
 
-  it('should enable all loggers when axios debug flag is set', () => {
-    process.env.NODE_DEBUG = 'axios';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.debug.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.verbose.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-  });
-
-  it('should enable all loggers', () => {
+  it('should enable all loggers using the name "ibm-cloud-sdk-core"', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core*';
     const logger = require('../../dist/lib/logger').default;
+
     expect(logger.debug.enabled).toBe(true);
     expect(logger.error.enabled).toBe(true);
     expect(logger.info.enabled).toBe(true);
@@ -60,73 +51,14 @@ describe('Logger', () => {
     expect(logger.warn.enabled).toBe(true);
   });
 
-  it('should enable debug miniumum scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:debug';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.debug.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.verbose.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-  });
-
-  it('should prioritize debug scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:debug,ibm-cloud-sdk-core:verbose';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.debug.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.verbose.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-  });
-
-  it('should prioritize verbose scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:error,ibm-cloud-sdk-core:verbose';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.debug.enabled).toBe(false);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.verbose.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-  });
-
-  it('should enable error miniumum scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:error';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.debug.enabled).toBe(false);
-    expect(logger.info.enabled).toBe(false);
-    expect(logger.verbose.enabled).toBe(false);
-    expect(logger.warn.enabled).toBe(false);
-  });
-
-  it('should enable info miniumum scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:info';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.debug.enabled).toBe(false);
-    expect(logger.verbose.enabled).toBe(false);
-  });
-
-  it('should enable verbose miniumum scope', () => {
-    process.env.DEBUG = 'ibm-cloud-sdk-core:verbose';
-    const logger = require('../../dist/lib/logger').default;
-    expect(logger.verbose.enabled).toBe(true);
-    expect(logger.debug.enabled).toBe(false);
-    expect(logger.info.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
-    expect(logger.warn.enabled).toBe(true);
-  });
-
-  it('should enable warn miniumum scope', () => {
+  it('should enable scoped loggers using the name "ibm-cloud-sdk-core"', () => {
     process.env.DEBUG = 'ibm-cloud-sdk-core:warning';
     const logger = require('../../dist/lib/logger').default;
-    expect(logger.warn.enabled).toBe(true);
-    expect(logger.error.enabled).toBe(true);
+
+    expect(logger.debug.enabled).toBe(false);
     expect(logger.verbose.enabled).toBe(false);
     expect(logger.info.enabled).toBe(false);
-    expect(logger.debug.enabled).toBe(false);
+    expect(logger.warn.enabled).toBe(true);
+    expect(logger.error.enabled).toBe(true);
   });
 });

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2019, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This method will return a new logger configured with a provided name. This can be used by generated service classes to create a new logger specific to its module context.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
