### PR TITLE
fix: allow for synchronous building of file requests

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -173,22 +173,19 @@ export class RequestWrapper {
 
     // Form params
     if (formData) {
-      Object.keys(formData).forEach((key) => {
-        const values = Array.isArray(formData[key]) ? formData[key] : [formData[key]];
+      for (const key of Object.keys(formData)) { // eslint-disable-line
+        let values = Array.isArray(formData[key]) ? formData[key] : [formData[key]];
         // Skip keys with undefined/null values or empty object value
-        values
-          .filter((v) => v != null && !isEmptyObject(v))
-          .forEach(async (value) => {
-            // Special case of empty file object
-            if (
-              Object.prototype.hasOwnProperty.call(value, 'contentType') &&
-              !Object.prototype.hasOwnProperty.call(value, 'data')
-            ) {
-              return;
-            }
+        values = values.filter((v) => v != null && !isEmptyObject(v));
 
+        for (let value of values) { // eslint-disable-line
+          // Ignore special case of empty file object
+          if (
+            !Object.prototype.hasOwnProperty.call(value, 'contentType') ||
+            Object.prototype.hasOwnProperty.call(value, 'data')
+          ) {
             if (isFileWithMetadata(value)) {
-              const fileObj = await buildRequestFileObject(value);
+              const fileObj = await buildRequestFileObject(value); // eslint-disable-line
               multipartForm.append(key, fileObj.value, fileObj.options);
             } else {
               if (typeof value === 'object' && !isFileData(value)) {
@@ -196,8 +193,9 @@ export class RequestWrapper {
               }
               multipartForm.append(key, value);
             }
-          });
-      });
+          }
+        }
+      }
     }
 
     // Path params


### PR DESCRIPTION
This issue was caused by an oversight in adding an `await` statement within a `forEach` loop, which will result in asynchronous operations happening without the synchronous control you'd expect from async/await.

This solves the issue by simply converting the loops to "for of" loops.

This caused a subtle server error so unfortunately, I can't think of a great test case for it. I should've known not to put an `await` call within a `forEach` though. Logically, this is a simple refactor, but practically it makes the code behave in the way it was actually intended to.

cc @apaparazzi0329 