### PR TITLE
build: update `nock` to resolve security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "eslint-plugin-node": "^9.0.0",
         "eslint-plugin-prettier": "^3.0.1",
         "jest": "^27.2.4",
-        "nock": "^13.1.2",
+        "nock": "^13.2.9",
         "npm-run-all": "^4.1.5",
         "object.assign": "~4.1.0",
         "package-json-reducer": "^1.0.18",
@@ -8513,12 +8513,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -8871,14 +8865,14 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
-      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       },
       "engines": {
@@ -20861,12 +20855,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -21127,14 +21115,14 @@
       }
     },
     "nock": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
-      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-node": "^9.0.0",
     "eslint-plugin-prettier": "^3.0.1",
     "jest": "^27.2.4",
-    "nock": "^13.1.2",
+    "nock": "^13.2.9",
     "npm-run-all": "^4.1.5",
     "object.assign": "~4.1.0",
     "package-json-reducer": "^1.0.18",


### PR DESCRIPTION
The current version of `nock` uses `lodash.set` which is vulnerable. They've resolved this in the latest version.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>