### PR TITLE
refactor: cookie support via interceptors

### DIFF
--- a/lib/cookie-support.ts
+++ b/lib/cookie-support.ts
@@ -1,0 +1,75 @@
+/**
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import extend from 'extend';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { CookieJar } from 'tough-cookie';
+import logger from './logger';
+
+export class CookieInterceptor {
+  private readonly cookieJar: CookieJar;
+
+  constructor(cookieJar: CookieJar | boolean) {
+    if (cookieJar) {
+      if (cookieJar === true) {
+        logger.debug('CookieInterceptor: creating new CookieJar');
+        this.cookieJar = new CookieJar();
+      } else {
+        logger.debug('CookieInterceptor: using supplied CookieJar');
+        this.cookieJar = cookieJar;
+      }
+    } else {
+      throw new Error('Must supply a cookie jar or true.');
+    }
+  }
+
+  public async requestInterceptor(config: AxiosRequestConfig) {
+    logger.debug('CookieInterceptor: intercepting request');
+    if (config && config.url) {
+      logger.debug(`CookieInterceptor: getting cookies for: ${config.url}`);
+      const cookieHeaderValue = await this.cookieJar.getCookieString(config.url);
+      if (cookieHeaderValue) {
+        logger.debug('CookieInterceptor: setting cookie header');
+        const cookieHeader = { cookie: cookieHeaderValue };
+        config.headers = extend(true, {}, config.headers, cookieHeader);
+      } else {
+        logger.debug(`CookieInterceptor: no cookies for: ${config.url}`);
+      }
+    } else {
+      logger.debug('CookieInterceptor: no request URL.');
+    }
+    return config;
+  }
+
+  public async responseInterceptor(response: AxiosResponse) {
+    logger.debug('CookieInterceptor: intercepting response.');
+    if (response && response.headers) {
+      logger.debug('CookieInterceptor: checking for set-cookie headers.');
+      const cookies: string[] = response.headers['set-cookie'];
+      if (cookies) {
+        logger.debug(`CookieInterceptor: setting cookies in jar for URL ${response.config.url}.`);
+        cookies.forEach(async (cookie: string) => {
+          await this.cookieJar.setCookie(cookie, response.config.url);
+        });
+      } else {
+        logger.debug('CookieInterceptor: no set-cookie headers.');
+      }
+    } else {
+      logger.debug('CookieInterceptor: no response headers.');
+    }
+    return response;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/node": "~10.14.19",
         "@types/tough-cookie": "^4.0.0",
         "axios": "^0.26.1",
-        "axios-cookiejar-support": "^1.0.0",
         "camelcase": "^5.3.1",
         "debug": "^4.1.1",
         "dotenv": "^6.2.0",
@@ -3155,23 +3154,6 @@
         "follow-redirects": "^1.14.8"
       }
     },
-    "node_modules/axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
-      "dependencies": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@types/tough-cookie": ">=2.3.3",
-        "axios": ">=0.16.2",
-        "tough-cookie": ">=2.3.3"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -6259,14 +6241,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -12013,17 +11987,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -16716,15 +16679,6 @@
         "follow-redirects": "^1.14.8"
       }
     },
-    "axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
-      "requires": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -19013,11 +18967,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -23331,11 +23280,6 @@
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
       "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
-    },
-    "pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/node": "~10.14.19",
     "@types/tough-cookie": "^4.0.0",
     "axios": "^0.26.1",
-    "axios-cookiejar-support": "^1.0.0",
     "camelcase": "^5.3.1",
     "debug": "^4.1.1",
     "dotenv": "^6.2.0",

--- a/test/unit/cookiejar.test.js
+++ b/test/unit/cookiejar.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2020, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,58 +15,207 @@
  */
 
 const tough = require('tough-cookie');
+const { CookieInterceptor } = require('../../dist/lib/cookie-support');
 const { RequestWrapper } = require('../../dist/lib/request-wrapper');
 
+// DEBUG also uses an interceptor so if we want to debug when running the tests
+// we need our expectations adjusted by 1
+const noCookieInterceptorSize = process.env.NODE_DEBUG === 'axios' || process.env.DEBUG ? 1 : 0;
+const cookieInterceptorSize = process.env.NODE_DEBUG === 'axios' || process.env.DEBUG ? 2 : 1;
+const mockRequest = { url: 'https://cookie.example' };
+const mockResponse = {
+  headers: { 'set-cookie': ['foo=bar'] },
+  config: { url: 'https://cookie.example' },
+};
+
+function getInterceptors(requestWrapper, type) {
+  return requestWrapper.axiosInstance.interceptors[type].handlers;
+}
+
+/**
+ * Helper to get the cookie interceptor from potentially multiple interceptors.
+ * The ordering of interceptors is different between different axios versions
+ * so identify the correct interceptor from the function name.
+ */
+function getCookieInterceptor(requestWrapper, type) {
+  const interceptors = getInterceptors(requestWrapper, type);
+  for (let i = 0; i < interceptors.length; i++) {
+    const iFulfilledFn = interceptors[i].fulfilled;
+    expect(iFulfilledFn).toBeInstanceOf(Function);
+    if (`${type}CookieInterceptor` === iFulfilledFn.name) {
+      return iFulfilledFn;
+    }
+  }
+  throw new Error(`There should have been a cookie ${type} interceptor`);
+}
+
+describe('cookie interceptor', () => {
+  it('should create a tough-cookie jar provided jar: true', () => {
+    const cookieInterceptor = new CookieInterceptor(true);
+    expect(cookieInterceptor.cookieJar).toBeInstanceOf(tough.CookieJar);
+  });
+
+  it('should error provided jar: false', () => {
+    expect(() => {
+      const interceptor = new CookieInterceptor(false);
+    }).toThrow();
+  });
+
+  it('should use proivded CookieJar', () => {
+    const cookieJar = new tough.CookieJar();
+    const cookieInterceptor = new CookieInterceptor(cookieJar);
+    expect(cookieInterceptor.cookieJar).toEqual(cookieJar);
+  });
+
+  it('should use arbitrarly provided jar', () => {
+    const mockCookieJar = {
+      getCookieString: () => 'mock-string',
+    };
+    const cookieInterceptor = new CookieInterceptor(mockCookieJar);
+    expect(cookieInterceptor.cookieJar).toEqual(mockCookieJar);
+  });
+
+  it('request interceptor should get cookies', () => {
+    const jar = new tough.CookieJar();
+    const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
+    const cookieInterceptor = new CookieInterceptor(jar);
+    cookieInterceptor.requestInterceptor(mockRequest);
+    expect(spiedGetCookie).toHaveBeenCalled();
+  });
+
+  it('response interceptor should store cookies', () => {
+    const jar = new tough.CookieJar();
+    const spiedSetCookie = jest.spyOn(jar, 'setCookie');
+    const cookieInterceptor = new CookieInterceptor(jar);
+    cookieInterceptor.responseInterceptor(mockResponse);
+    expect(spiedSetCookie).toHaveBeenCalled();
+  });
+
+  it('should store a cookie and then use the cookie', async () => {
+    const jar = new tough.CookieJar();
+    const cookieInterceptor = new CookieInterceptor(jar);
+    const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
+    await cookieInterceptor.responseInterceptor(mockResponse);
+    await cookieInterceptor.requestInterceptor(mockRequest);
+    return expect(spiedGetCookie.mock.results[0].value).resolves.toEqual('foo=bar');
+  });
+
+  it('should store and retrieve multiple cookies', async () => {
+    const jar = new tough.CookieJar();
+    const cookieInterceptor = new CookieInterceptor(jar);
+    const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
+    const mockResponseMulti = {
+      headers: { 'set-cookie': ['foo=bar', 'baz=boo'] },
+      config: { url: 'https://cookie.example' },
+    };
+    await cookieInterceptor.responseInterceptor(mockResponseMulti);
+    await cookieInterceptor.requestInterceptor(mockRequest);
+    return expect(spiedGetCookie.mock.results[0].value).resolves.toEqual('foo=bar; baz=boo');
+  });
+
+  it('should return coookies for paths', async () => {
+    const jar = new tough.CookieJar();
+    const cookieInterceptor = new CookieInterceptor(jar);
+    const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
+    const mockOperationRequest = { url: 'https://cookie.example/api/v3/operation/path' };
+    const mockLoginResponse = {
+      headers: {
+        'set-cookie': ['foo=bar; Max-Age=86400; Path=/; HttpOnly; Secure; SameSite=Strict'],
+      },
+      config: { url: 'https://cookie.example/session/login' },
+    };
+    await cookieInterceptor.responseInterceptor(mockLoginResponse);
+    await cookieInterceptor.requestInterceptor(mockOperationRequest);
+    return expect(spiedGetCookie.mock.results[0].value).resolves.toEqual('foo=bar');
+  });
+
+  it('should not return coookies for other domains', async () => {
+    const jar = new tough.CookieJar();
+    const cookieInterceptor = new CookieInterceptor(jar);
+    const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
+    const mockOperationRequest = { url: 'https://more-cookies.example/api' };
+    const mockLoginResponse = {
+      headers: {
+        'set-cookie': ['foo=bar; Max-Age=86400; Path=/; HttpOnly; Secure; SameSite=Strict'],
+      },
+      config: { url: 'https://cookie.example/api' },
+    };
+    await cookieInterceptor.responseInterceptor(mockLoginResponse);
+    await cookieInterceptor.requestInterceptor(mockOperationRequest);
+    return expect(spiedGetCookie.mock.results[0].value).resolves.toBeFalsy();
+  });
+});
+
 describe('cookie jar support', () => {
-  it('should not wrap the axios instance by default', () => {
+  it('should not add interceptors by default', () => {
     const wrapper = new RequestWrapper();
-    expect(wrapper.axiosInstance.defaults.withCredentials).not.toBeDefined();
-    expect(wrapper.axiosInstance.interceptors.request.handlers).toHaveLength(0);
+    expect(getInterceptors(wrapper, 'request')).toHaveLength(noCookieInterceptorSize);
+    expect(getInterceptors(wrapper, 'response')).toHaveLength(noCookieInterceptorSize);
   });
 
-  it('passing a value for `jar` should produce interceptors and set flags', () => {
-    const wrapper = new RequestWrapper({ jar: true });
-    expect(wrapper.axiosInstance.defaults.withCredentials).toBe(true);
-    expect(wrapper.axiosInstance.interceptors.request.handlers).toHaveLength(1);
-  });
-
-  it('given `true` for `jar`, the interceptors should create an instance of tough-cookie', () => {
+  it('given `true` for `jar`, the request-wrapper should have interceptors', () => {
     const wrapper = new RequestWrapper({ jar: true });
 
-    expect(wrapper.axiosInstance.interceptors.request.handlers).toHaveLength(1);
-    expect(wrapper.axiosInstance.interceptors.request.handlers[0].fulfilled).toBeInstanceOf(
-      Function
-    );
+    expect(getInterceptors(wrapper, 'request')).toHaveLength(cookieInterceptorSize);
+    expect(getInterceptors(wrapper, 'response')).toHaveLength(cookieInterceptorSize);
 
-    // should initially set the default to true
-    expect(wrapper.axiosInstance.defaults.jar).toBe(true);
+    const cookieRequestInterceptor = getCookieInterceptor(wrapper, 'request');
+    const cookieResponseInterceptor = getCookieInterceptor(wrapper, 'response');
 
-    // invoke the interceptor - it should be the one added by the cookie jar library
-    // it should see that `jar` is `true` and create a default instance of tough.CookieJar
-    // this would noramlly happen just before a request is sent
-    wrapper.axiosInstance.interceptors.request.handlers[0].fulfilled(
-      wrapper.axiosInstance.defaults
-    );
-
-    expect(wrapper.axiosInstance.defaults.jar).toBeInstanceOf(tough.CookieJar);
+    // invoke the interceptors
+    const fn = cookieRequestInterceptor({
+      ...wrapper.axiosInstance.defaults,
+      ...mockRequest,
+    });
+    cookieResponseInterceptor(mockResponse);
   });
 
-  it('given arbitrary value for `jar`, the interceptor should use it as cookie jar', () => {
-    // the axios-cookiejar-support interceptor requires the jar object
-    // to have the method `getCookieString`
-    const mockCookieJar = { getCookieString: () => 'mock-string' };
+  it('given a tough-cookie jar for `jar`, the jar should be used', () => {
+    const cookieJar = new tough.CookieJar();
+    const wrapper = new RequestWrapper({ jar: cookieJar });
+
+    expect(wrapper.axiosInstance.defaults.jar).toEqual(cookieJar);
+
+    expect(getInterceptors(wrapper, 'request')).toHaveLength(cookieInterceptorSize);
+    expect(getInterceptors(wrapper, 'response')).toHaveLength(cookieInterceptorSize);
+
+    const cookieRequestInterceptor = getCookieInterceptor(wrapper, 'request');
+    const cookieResponseInterceptor = getCookieInterceptor(wrapper, 'response');
+
+    // Invoke the interceptors and assert they called the jar
+    // Request
+    const spiedGetCookie = jest.spyOn(cookieJar, 'getCookieString');
+    cookieRequestInterceptor({ ...wrapper.axiosInstance.defaults, ...mockRequest });
+    expect(spiedGetCookie).toHaveBeenCalledTimes(1);
+    // Response
+    const spiedSetCookie = jest.spyOn(cookieJar, 'setCookie');
+    cookieResponseInterceptor(mockResponse);
+    expect(spiedSetCookie).toHaveBeenCalledTimes(1);
+  });
+
+  it('given arbitrary value for `jar` it should be used as cookie jar', () => {
+    const mockCookieJar = {
+      getCookieString: () => 'mock-string',
+      setCookie: () => {},
+    };
     const wrapper = new RequestWrapper({ jar: mockCookieJar });
 
-    // should still set interceptors and withCredentials flag
-    expect(wrapper.axiosInstance.interceptors.request.handlers).toHaveLength(1);
-    expect(wrapper.axiosInstance.defaults.withCredentials).toBe(true);
     expect(wrapper.axiosInstance.defaults.jar).toEqual(mockCookieJar);
 
-    // invoke the interceptor, the default jar should remain the same
-    wrapper.axiosInstance.interceptors.request.handlers[0].fulfilled(
-      wrapper.axiosInstance.defaults
-    );
+    expect(getInterceptors(wrapper, 'request')).toHaveLength(cookieInterceptorSize);
+    expect(getInterceptors(wrapper, 'response')).toHaveLength(cookieInterceptorSize);
 
-    expect(wrapper.axiosInstance.defaults.jar).toEqual(mockCookieJar);
+    const cookieRequestInterceptor = getCookieInterceptor(wrapper, 'request');
+    const cookieResponseInterceptor = getCookieInterceptor(wrapper, 'response');
+
+    // Invoke the interceptors and assert they called the jar
+    // Request
+    const spiedGetCookie = jest.spyOn(mockCookieJar, 'getCookieString');
+    cookieRequestInterceptor({ ...wrapper.axiosInstance.defaults, ...mockRequest });
+    expect(spiedGetCookie).toHaveBeenCalledTimes(1);
+    // Response
+    const spiedSetCookie = jest.spyOn(mockCookieJar, 'setCookie');
+    cookieResponseInterceptor(mockResponse);
+    expect(spiedSetCookie).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/cookiejar.test.js
+++ b/test/unit/cookiejar.test.js
@@ -75,19 +75,19 @@ describe('cookie interceptor', () => {
     expect(cookieInterceptor.cookieJar).toEqual(mockCookieJar);
   });
 
-  it('request interceptor should get cookies', () => {
+  it('request interceptor should get cookies', async () => {
     const jar = new tough.CookieJar();
     const spiedGetCookie = jest.spyOn(jar, 'getCookieString');
     const cookieInterceptor = new CookieInterceptor(jar);
-    cookieInterceptor.requestInterceptor(mockRequest);
+    await cookieInterceptor.requestInterceptor(mockRequest);
     expect(spiedGetCookie).toHaveBeenCalled();
   });
 
-  it('response interceptor should store cookies', () => {
+  it('response interceptor should store cookies', async () => {
     const jar = new tough.CookieJar();
     const spiedSetCookie = jest.spyOn(jar, 'setCookie');
     const cookieInterceptor = new CookieInterceptor(jar);
-    cookieInterceptor.responseInterceptor(mockResponse);
+    await cookieInterceptor.responseInterceptor(mockResponse);
     expect(spiedSetCookie).toHaveBeenCalled();
   });
 
@@ -153,7 +153,7 @@ describe('cookie jar support', () => {
     expect(getInterceptors(wrapper, 'response')).toHaveLength(noCookieInterceptorSize);
   });
 
-  it('given `true` for `jar`, the request-wrapper should have interceptors', () => {
+  it('given `true` for `jar`, the request-wrapper should have interceptors', async () => {
     const wrapper = new RequestWrapper({ jar: true });
 
     expect(getInterceptors(wrapper, 'request')).toHaveLength(cookieInterceptorSize);
@@ -163,14 +163,14 @@ describe('cookie jar support', () => {
     const cookieResponseInterceptor = getCookieInterceptor(wrapper, 'response');
 
     // invoke the interceptors
-    const fn = cookieRequestInterceptor({
+    await cookieRequestInterceptor({
       ...wrapper.axiosInstance.defaults,
       ...mockRequest,
     });
-    cookieResponseInterceptor(mockResponse);
+    await cookieResponseInterceptor(mockResponse);
   });
 
-  it('given a tough-cookie jar for `jar`, the jar should be used', () => {
+  it('given a tough-cookie jar for `jar`, the jar should be used', async () => {
     const cookieJar = new tough.CookieJar();
     const wrapper = new RequestWrapper({ jar: cookieJar });
 
@@ -185,15 +185,15 @@ describe('cookie jar support', () => {
     // Invoke the interceptors and assert they called the jar
     // Request
     const spiedGetCookie = jest.spyOn(cookieJar, 'getCookieString');
-    cookieRequestInterceptor({ ...wrapper.axiosInstance.defaults, ...mockRequest });
+    await cookieRequestInterceptor({ ...wrapper.axiosInstance.defaults, ...mockRequest });
     expect(spiedGetCookie).toHaveBeenCalledTimes(1);
     // Response
     const spiedSetCookie = jest.spyOn(cookieJar, 'setCookie');
-    cookieResponseInterceptor(mockResponse);
+    await cookieResponseInterceptor(mockResponse);
     expect(spiedSetCookie).toHaveBeenCalledTimes(1);
   });
 
-  it('given arbitrary value for `jar` it should be used as cookie jar', () => {
+  it('given arbitrary value for `jar` it should be used as cookie jar', async () => {
     const mockCookieJar = {
       getCookieString: () => 'mock-string',
       setCookie: () => {},
@@ -215,7 +215,7 @@ describe('cookie jar support', () => {
     expect(spiedGetCookie).toHaveBeenCalledTimes(1);
     // Response
     const spiedSetCookie = jest.spyOn(mockCookieJar, 'setCookie');
-    cookieResponseInterceptor(mockResponse);
+    await cookieResponseInterceptor(mockResponse);
     expect(spiedSetCookie).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Attempts to upgrade to axios 1.x (#209/#213) have been impeded by incompatibilities with `axios-cookiejar-support`:
* 1.x version is [incompatible with newer axios versions](https://github.com/3846masa/axios-cookiejar-support/issues/310)
* 2.x+ versions are [incompatible with retries](https://github.com/3846masa/axios-cookiejar-support/issues/602)
Remove axios-cookiejar-support depdenency.

This PR:
* Removes `axios-cookiejar-support` dependency.
* Adds `cookie-support.ts` for providing axios interceptors to interact with `tough-cookie`.
* Updates the cookiejar tests for the above.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added - N/A current docs about cookies remain valid
