### PR TITLE
fix(auth): revert to using decode instead verify for jwt

### DIFF
--- a/auth/token-managers/jwt-token-manager.ts
+++ b/auth/token-managers/jwt-token-manager.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { verify } from 'jsonwebtoken';
+import { decode } from 'jsonwebtoken';
 import logger from '../../lib/logger';
 import { TokenManager, TokenManagerOptions } from './token-manager';
 
@@ -80,18 +80,7 @@ export class JwtTokenManager extends TokenManager {
       throw new Error(err);
     }
 
-    let decodedResponse;
-    try {
-      decodedResponse = verify(this.accessToken);
-    } catch (e) {
-      // the token is either an invalid JWT or it could not be verified
-      logger.error('Failed to verify the JWT. See error message:');
-      logger.error(e);
-      throw new Error(e);
-    }
-
-    // the 'catch' method above should handle any verificiation/decoding issues but
-    // this check is here as a failsafe
+    const decodedResponse = decode(this.accessToken);
     if (!decodedResponse) {
       const err = 'Access token recieved is not a valid JWT';
       logger.error(err);

--- a/test/unit/iam-token-manager.test.js
+++ b/test/unit/iam-token-manager.test.js
@@ -16,12 +16,13 @@
  * limitations under the License.
  */
 
-const jwt = require('jsonwebtoken');
+jest.mock('jsonwebtoken/decode');
+const decode = require('jsonwebtoken/decode');
+
+decode.mockImplementation(() => ({ exp: 100, iat: 100 }));
 
 jest.mock('../../dist/lib/request-wrapper');
 const { RequestWrapper } = require('../../dist/lib/request-wrapper');
-
-jwt.verify = jest.fn(() => ({ exp: 100, iat: 100 }));
 
 const { IamTokenManager } = require('../../dist/auth');
 


### PR DESCRIPTION
The move to `verify` was a bit shortsighted. It requires a public key or secret as an argument to verify the signed token. Typical usage of IBM's IAM service doesn't lend itself to this flow and the tokens returned don't have valid JWT signatures. This led to a runtime error everytime the core made an IAM request - a bit of a showstopping bug.

Additionally, we never had a goal of performing client-side validation of these tokens, we only decode them to determine the expiration time for usage in our refresh logic. The `decode` method is perfectly sufficient for that and indeed is called within the `verify` method anyways. Perhaps this flow will change in the future but this is all we need for now.

This reverts the logic to what we were using before but still using the safe version of the dependency. The new version makes the `decode` function read-only so I had to adjust our approach to mocking in the unit tests.