### PR TITLE
fix(VpcInstanceAuthenticator): use correct version string

### DIFF
--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021, 2022.
+ * (C) Copyright IBM Corp. 2021, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import { atMostOne } from '../utils';
 import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 
 const DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254';
-const METADATA_SERVICE_VERSION = '2021-09-20';
+const METADATA_SERVICE_VERSION = '2022-03-01';
 
 /** Configuration options for VPC token retrieval. */
 interface Options extends JwtTokenManagerOptions {

--- a/test/unit/vpc-instance-token-manager.test.js
+++ b/test/unit/vpc-instance-token-manager.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert, no-console */
 
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters.options.method).toBe('PUT');
 
       expect(parameters.options.qs).toBeDefined();
-      expect(parameters.options.qs.version).toBe('2021-09-20');
+      expect(parameters.options.qs.version).toBe('2022-03-01');
 
       expect(parameters.options.body).toBeDefined();
       expect(parameters.options.body.expires_in).toBe(300);
@@ -159,7 +159,7 @@ describe('VPC Instance Token Manager', () => {
       expect(parameters.options.method).toBe('POST');
 
       expect(parameters.options.qs).toBeDefined();
-      expect(parameters.options.qs.version).toBe('2021-09-20');
+      expect(parameters.options.qs.version).toBe('2022-03-01');
 
       // if neither the profile id or crn is set, then the body should be undefined
       expect(parameters.options.body).toBeUndefined();


### PR DESCRIPTION
This PR modifies the VpcInstanceAuthenticator to use the correct value for the version query parameter ("2022-03-01").

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
