### PR TITLE
fix: return json error response body as object

### DIFF
--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -310,6 +310,9 @@ export function isFileWithMetadata(obj: any): obj is FileWithMetadata;
 export function isHTML(text: string): boolean;
 
 // @public
+export function isJsonMimeType(mimeType: string): boolean;
+
+// @public
 export class JwtTokenManager extends TokenManager {
     constructor(options: JwtTokenManagerOptions);
     protected requestToken(): Promise<any>;

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2014, 2022.
+ * (C) Copyright IBM Corp. 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -339,4 +339,15 @@ export function constructServiceUrl(
   });
 
   return formattedUrl;
+}
+
+/**
+ * Returns true if and only if "mimeType" is a "JSON-like" mime type
+ * (e.g. "application/json; charset=utf-8").
+ * @param mimeType - the mimeType string
+ * @returns true if "mimeType" represents a JSON media type and false otherwise
+ */
+export function isJsonMimeType(mimeType: string) {
+  logger.debug(`Determining if the mime type '${mimeType}' specifies JSON content.`);
+  return !!mimeType && /^application\/json(\s*;.*)?$/i.test(mimeType);
 }

--- a/test/unit/is-json-mime-type.test.js
+++ b/test/unit/is-json-mime-type.test.js
@@ -1,0 +1,80 @@
+/**
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { isJsonMimeType } = require('../../dist/lib/helper');
+const logger = require('../../dist/lib/logger').default;
+
+const debugLogSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+
+describe('isJsonMimeType()', () => {
+  afterEach(() => {
+    debugLogSpy.mockClear();
+  });
+
+  it('should return `false` for `undefined`', async () => {
+    expect(isJsonMimeType(undefined)).toBe(false);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type 'undefined' specifies JSON content."
+    );
+  });
+
+  it('should return `false` for `null`', async () => {
+    expect(isJsonMimeType(null)).toBe(false);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type 'null' specifies JSON content."
+    );
+  });
+
+  it('should return `false` for empty-string', async () => {
+    expect(isJsonMimeType('')).toBe(false);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type '' specifies JSON content."
+    );
+  });
+
+  it('should return `false` for non-JSON mimetype', async () => {
+    expect(isJsonMimeType('application/octect-stream')).toBe(false);
+    expect(isJsonMimeType('text/plain')).toBe(false);
+    expect(isJsonMimeType('multipart/form-data; charset=utf-8')).toBe(false);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type 'application/octect-stream' specifies JSON content."
+    );
+    expect(debugLogSpy.mock.calls[1][0]).toBe(
+      "Determining if the mime type 'text/plain' specifies JSON content."
+    );
+    expect(debugLogSpy.mock.calls[2][0]).toBe(
+      "Determining if the mime type 'multipart/form-data; charset=utf-8' specifies JSON content."
+    );
+  });
+
+  it('should return `true` for a JSON mimetype', async () => {
+    expect(isJsonMimeType('application/json')).toBe(true);
+    expect(isJsonMimeType('application/json;charset=utf-8')).toBe(true);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type 'application/json' specifies JSON content."
+    );
+    expect(debugLogSpy.mock.calls[1][0]).toBe(
+      "Determining if the mime type 'application/json;charset=utf-8' specifies JSON content."
+    );
+  });
+
+  it('should return `true` for a JSON mimetype including optional whitespace', async () => {
+    expect(isJsonMimeType('application/json  ; charset=utf-8')).toBe(true);
+    expect(debugLogSpy.mock.calls[0][0]).toBe(
+      "Determining if the mime type 'application/json  ; charset=utf-8' specifies JSON content."
+    );
+  });
+});


### PR DESCRIPTION
Error response bodies are currently returned as strings, even when the content is JSON. This is a bug - the SDK should return the result as an object. This commit adds logic to return the result as an object, converting it if necessary.

It also updates the error object to use the "result" field for the response body, in order to be consistent with the success path. The "body" field is still set for backward-compatibility but is marked as deprecated.

Additionally, for both success and error responses, if the content is JSON but the result cannot be parsed as an object, an exception will be raised, alerting the user that the service returned a malformed body.

cc @ricellis