### PR TITLE
build(deps): bump axios from 1.2.1 to 1.4.0

### DIFF
--- a/lib/cookie-support.ts
+++ b/lib/cookie-support.ts
@@ -15,7 +15,7 @@
  */
 
 import extend from 'extend';
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { InternalAxiosRequestConfig, AxiosResponse } from 'axios';
 import { Cookie, CookieJar } from 'tough-cookie';
 import logger from './logger';
 
@@ -36,7 +36,7 @@ export class CookieInterceptor {
     }
   }
 
-  public async requestInterceptor(config: AxiosRequestConfig) {
+  public async requestInterceptor(config: InternalAxiosRequestConfig) {
     logger.debug('CookieInterceptor: intercepting request');
     if (config && config.url) {
       logger.debug(`CookieInterceptor: getting cookies for: ${config.url}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/isstream": "^0.1.0",
         "@types/node": "~10.14.19",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.2.1",
+        "axios": "1.4.0",
         "camelcase": "^5.3.1",
         "debug": "^4.1.1",
         "dotenv": "^6.2.0",
@@ -3724,9 +3724,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -17235,9 +17235,9 @@
       "peer": true
     },
     "axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/isstream": "^0.1.0",
     "@types/node": "~10.14.19",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "1.2.1",
+    "axios": "1.4.0",
     "camelcase": "^5.3.1",
     "debug": "^4.1.1",
     "dotenv": "^6.2.0",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

The aim of this PR is to bump `axios` from `1.2.1` to `1.4.0`. There was a type change in https://github.com/axios/axios/pull/5486 that was applied in [`1.2.4`](https://github.com/axios/axios/releases/tag/v1.2.4), so the request interceptor gets `InternalAxiosRequestConfig` config instead of the previous `AxiosRequestConfig`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included - no need
- [x] documentation is changed or added - no need
