### PR TITLE
fix(ContainerAuthenticator): add sa-token as default CR token filename

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -252,7 +252,8 @@ The IAM access token is added to each outbound request in the `Authorization` he
 ### Properties
 
 - crTokenFilename: (optional) the name of the file containing the injected CR token value.
-If not specified, then `/var/run/secrets/tokens/vault-token` is used as the default value.
+If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
+and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iamProfileName: (optional) the name of the linked trusted IAM profile to be used when obtaining the

--- a/auth/utils/file-reading-helpers.ts
+++ b/auth/utils/file-reading-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,21 +92,15 @@ export function readCrTokenFile(filepath: string): string {
     return '';
   }
 
-  let token: string = '';
-  const fileExists = fileExistsAtPath(filepath);
-  if (fileExists) {
+  try {
+    let token: string = '';
+    logger.debug(`Attempting to read CR token from file: ${filepath}`);
     token = readFileSync(filepath, 'utf8');
     logger.debug(`Successfully read CR token from file: ${filepath}`);
+    return token;
+  } catch (err) {
+    const msg = `Error reading CR token: ${err.toString()}`;
+    logger.debug(msg);
+    throw new Error(msg);
   }
-
-  if (token === '') {
-    if (fileExists) {
-      logger.error(`Expected to read CR token from file but the file is empty: ${filepath}`);
-    } else {
-      logger.error(`Expected to find CR token file but the file does not exist: ${filepath}`);
-    }
-    throw new Error(`Unable to retrieve the CR token value from file: ${filepath}`);
-  }
-
-  return token;
 }

--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -149,6 +149,7 @@ export class ContainerAuthenticator extends IamRequestBasedAuthenticator {
 export class ContainerTokenManager extends IamRequestBasedTokenManager {
     // Warning: (ae-forgotten-export) The symbol "Options_7" needs to be exported by the entry point index.d.ts
     constructor(options: Options_7);
+    protected getCrToken(): string;
     protected requestToken(): Promise<any>;
     setCrTokenFilename(crTokenFilename: string): void;
     setIamProfileId(iamProfileId: string): void;

--- a/test/unit/container-authenticator.test.js
+++ b/test/unit/container-authenticator.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,9 +67,7 @@ describe('Container Authenticator', () => {
   it('should re-set crTokenFilename using the setter', () => {
     const authenticator = new ContainerAuthenticator({ iamProfileName: config.iamProfileName });
     expect(authenticator.crTokenFilename).toBeUndefined();
-    // the default is set on the token manager
-    expect(authenticator.tokenManager.crTokenFilename).toBeDefined();
-    expect(authenticator.tokenManager.crTokenFilename).not.toBe(config.crTokenFilename);
+    expect(authenticator.tokenManager.crTokenFilename).toBeUndefined();
 
     authenticator.setCrTokenFilename(config.crTokenFilename);
     expect(authenticator.crTokenFilename).toEqual(config.crTokenFilename);

--- a/test/unit/container-token-manager.test.js
+++ b/test/unit/container-token-manager.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert, no-console */
 
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,6 @@ describe('Container Token Manager', () => {
       );
     });
 
-    // use default filename
-    it('should use default filename if none is given', () => {
-      const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
-      expect(instance.crTokenFilename).toBe('/var/run/secrets/tokens/vault-token');
-    });
-
     it('should set given values', () => {
       const instance = new ContainerTokenManager({
         crTokenFilename: CR_TOKEN_FILENAME,
@@ -74,7 +68,7 @@ describe('Container Token Manager', () => {
   describe('setters', () => {
     it('should set crTokenFilename with the setter', () => {
       const instance = new ContainerTokenManager({ iamProfileName: IAM_PROFILE_NAME });
-      expect(instance.crTokenFilename).toBe('/var/run/secrets/tokens/vault-token');
+      expect(instance.crTokenFilename).toBeUndefined();
 
       instance.setCrTokenFilename(CR_TOKEN_FILENAME);
       expect(instance.crTokenFilename).toBe(CR_TOKEN_FILENAME);

--- a/test/unit/file-reading-helpers.test.js
+++ b/test/unit/file-reading-helpers.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,49 +139,20 @@ describe('read ibm credentials file', () => {
 });
 
 describe('Read CR Token File', () => {
-  const loggerDebugMock = jest.spyOn(logger, 'debug').mockImplementation(() => {});
-  const loggerErrorMock = jest.spyOn(logger, 'error').mockImplementation(() => {});
-
-  afterEach(() => {
-    loggerDebugMock.mockClear();
-    loggerErrorMock.mockClear();
-  });
-
-  afterAll(() => {
-    loggerDebugMock.mockRestore();
-    loggerErrorMock.mockRestore();
-  });
-
   it('should successfully return contents of file as a string', () => {
     const filename = `${__dirname}/../resources/vault-token`;
     const token = readCrTokenFile(filename);
 
     expect(token).toBe('my-cr-token-123');
-    expect(loggerDebugMock).toHaveBeenCalledWith(
-      `Successfully read CR token from file: ${filename}`
-    );
   });
 
   it('should throw an error if given file does not exist', () => {
     const filename = '/path/to/nowhere/';
+    const expectedMessage = new RegExp('Error reading CR token:.*ENOENT:.*/path/to/nowhere');
+
     expect(() => {
       const token = readCrTokenFile(filename);
-    }).toThrow(`Unable to retrieve the CR token value from file: ${filename}`);
-
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      `Expected to find CR token file but the file does not exist: ${filename}`
-    );
-  });
-
-  it('should throw an error if given file is empty', () => {
-    const filename = `${__dirname}/../resources/empty-file`;
-    expect(() => {
-      const token = readCrTokenFile(filename);
-    }).toThrow(`Unable to retrieve the CR token value from file: ${filename}`);
-
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      `Expected to read CR token from file but the file is empty: ${filename}`
-    );
+    }).toThrow(expectedMessage);
   });
 
   it('should throw an error if file read goes wrong', () => {
@@ -194,9 +165,6 @@ describe('Read CR Token File', () => {
     expect(() => {
       const token = readCrTokenFile(filename);
     }).toThrow(fileReadingError);
-
-    expect(loggerDebugMock).not.toHaveBeenCalled();
-    expect(loggerErrorMock).not.toHaveBeenCalled();
 
     readFileMock.mockRestore();
   });


### PR DESCRIPTION
This PR modifies the ContainerAuthenticator so that it supports a second default CR token
filename.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
