### PR TITLE
fix(deps): bump axios to 1.6.4

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-31T18:31:08Z",
+  "generated_at": "2024-01-04T12:07:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -96,7 +96,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 111,
+        "line_number": 118,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/isstream": "^0.1.0",
         "@types/node": "~10.14.19",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.6.3",
+        "axios": "1.6.4",
         "camelcase": "^5.3.1",
         "debug": "^4.3.4",
         "dotenv": "^6.2.0",
@@ -4939,11 +4939,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -21270,11 +21270,11 @@
       "peer": true
     },
     "axios": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/isstream": "^0.1.0",
     "@types/node": "~10.14.19",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "1.6.3",
+    "axios": "1.6.4",
     "camelcase": "^5.3.1",
     "debug": "^4.3.4",
     "dotenv": "^6.2.0",


### PR DESCRIPTION
Fixes some newly discovered vulnerabilities. From the release notes:
> security: fixed formToJSON prototype pollution vulnerability; (https://github.com/axios/axios/issues/6167) ([3c0c11c](https://github.com/axios/axios/commit/3c0c11cade045c4412c242b5727308cff9897a0e))
    security: fixed security vulnerability in follow-redirects (https://github.com/axios/axios/issues/6163) ([75af1cd](https://github.com/axios/axios/commit/75af1cdff5b3a6ca3766d3d3afbc3115bb0811b8))

Closes https://github.com/IBM/node-sdk-core/issues/264

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
