### PR TITLE
fix(token-manager): handle request errors when refreshing tokens

### DIFF
--- a/auth/token-managers/token-manager.ts
+++ b/auth/token-managers/token-manager.ts
@@ -104,9 +104,22 @@ export class TokenManager {
     }
     // If refresh needed, kick one off
     if (this.tokenNeedsRefresh()) {
-      this.requestToken().then((tokenResponse) => {
-        this.saveTokenInfo(tokenResponse);
-      });
+      this.requestToken().then(
+        (tokenResponse) => {
+          this.saveTokenInfo(tokenResponse);
+        },
+        (err) => {
+          // If the refresh request failed: catch the error, log a message, and return the stored token.
+          // The attempt to get a new token will be retried upon the next request.
+          let message =
+            'Attempted token refresh failed. The refresh will be retried with the next request.';
+          if (err && err.message) {
+            message += ` ${err.message}`;
+          }
+          logger.error(message);
+          logger.debug(err);
+        }
+      );
     }
     // 2. use valid, managed token
     return Promise.resolve(this.accessToken);


### PR DESCRIPTION
This commit introduces a Promise rejection handler to the `getToken` method where it was previously lacking. The refresh token kick-off did not catch any exceptions, resulting in the program crashing when a refresh error occurred. Now, the error will be caught and logged but the logic will continue as-is and the request will be retried later.

Note: I also discovered that one of our tests wasn't actually doing what it said it was doing 🙂 So I updated it to match its intentions and added a new test to verify the behavior that should have been captured by it.

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
