### PR TITLE
feat: send user-agent header with auth token requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-04-10T16:52:29Z",
+  "generated_at": "2024-04-16T16:00:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -200,7 +200,7 @@
         "hashed_secret": "184ee1f04a018aa3b897e085516a9b657fea0f6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 85,
+        "line_number": 86,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -210,7 +210,7 @@
         "hashed_secret": "d5ff02fa48e492fac0a245ad63d1ae608e705c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 98,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +218,7 @@
         "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 98,
+        "line_number": 99,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -226,7 +226,7 @@
         "hashed_secret": "45a15668db917c293f16e8add0f5d801889e5923",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -234,7 +234,7 @@
         "hashed_secret": "65e622227634e8876cfa733000233fb80c6f0473",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 117,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -270,7 +270,7 @@
         "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -278,7 +278,7 @@
         "hashed_secret": "0358c67856fb6a21c4767daf02fcb8fe4dc0a318",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 63,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -286,7 +286,7 @@
         "hashed_secret": "dbb19b8ae3b78f908e1467721fe4c9f0b0529d9b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 64,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -296,7 +296,7 @@
         "hashed_secret": "8f4bfc22c4fd7cb884f94ec175ff4a3284a174a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 79,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -304,7 +304,7 @@
         "hashed_secret": "65e622227634e8876cfa733000233fb80c6f0473",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 91,
+        "line_number": 95,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -442,7 +442,7 @@
         "hashed_secret": "1572bd30ac06678a82df42b5913e5e52e27f9a12",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 27,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -450,7 +450,7 @@
         "hashed_secret": "16856d955c788df03735a24feb2e3ffefd91f3dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 28,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -512,7 +512,7 @@
         "hashed_secret": "43ed4c2d8375dfc89e3dc8c917f404b9481d355b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 30,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -522,7 +522,7 @@
         "hashed_secret": "a7ef1be18bb8d37af79f3d87761a203378bf26a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 169,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -542,7 +542,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 26,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/auth/token-managers/container-token-manager.ts
+++ b/auth/token-managers/container-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, 2023 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import { atLeastOne } from '../utils/helpers';
 import { readCrTokenFile } from '../utils/file-reading-helpers';
+import { buildUserAgent } from '../../lib/build-user-agent';
 import { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-based-token-manager';
 
 const DEFAULT_CR_TOKEN_FILEPATH1 = '/var/run/secrets/tokens/vault-token';
@@ -83,6 +84,8 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
 
     // construct form data for the cr token use case of iam token management
     this.formData.grant_type = 'urn:ibm:params:oauth:grant-type:cr-token';
+
+    this.userAgent = buildUserAgent('container-authenticator');
   }
 
   /**

--- a/auth/token-managers/cp4d-token-manager.ts
+++ b/auth/token-managers/cp4d-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2023.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import extend from 'extend';
 import { validateInput } from '../utils/helpers';
+import { buildUserAgent } from '../../lib/build-user-agent';
 import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 
 /** Configuration options for CP4D token retrieval. */
@@ -96,12 +97,15 @@ export class Cp4dTokenManager extends JwtTokenManager {
     this.username = options.username;
     this.password = options.password;
     this.apikey = options.apikey;
+
+    this.userAgent = buildUserAgent('cp4d-authenticator');
   }
 
   protected requestToken(): Promise<any> {
     // these cannot be overwritten
     const requiredHeaders = {
       'Content-Type': 'application/json',
+      'User-Agent': this.userAgent,
     };
 
     const parameters = {

--- a/auth/token-managers/iam-request-based-token-manager.ts
+++ b/auth/token-managers/iam-request-based-token-manager.ts
@@ -157,7 +157,8 @@ export class IamRequestBasedTokenManager extends JwtTokenManager {
   protected requestToken(): Promise<any> {
     // these cannot be overwritten
     const requiredHeaders = {
-      'Content-type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': this.userAgent,
     } as OutgoingHttpHeaders;
 
     // If both the clientId and secret were specified by the user, then use them.

--- a/auth/token-managers/iam-token-manager.ts
+++ b/auth/token-managers/iam-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2023.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 import { validateInput } from '../utils/helpers';
+import { buildUserAgent } from '../../lib/build-user-agent';
 import { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-based-token-manager';
 
 /** Configuration options for IAM token retrieval. */
@@ -62,5 +63,7 @@ export class IamTokenManager extends IamRequestBasedTokenManager {
     this.formData.apikey = this.apikey;
     this.formData.grant_type = 'urn:ibm:params:oauth:grant-type:apikey';
     this.formData.response_type = 'cloud_iam';
+
+    this.userAgent = buildUserAgent('iam-authenticator');
   }
 }

--- a/auth/token-managers/mcsp-token-manager.ts
+++ b/auth/token-managers/mcsp-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import extend from 'extend';
 import { validateInput } from '../utils/helpers';
+import { buildUserAgent } from '../../lib/build-user-agent';
 import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 
 /**
@@ -76,12 +77,15 @@ export class McspTokenManager extends JwtTokenManager {
     validateInput(options, this.requiredOptions);
 
     this.apikey = options.apikey;
+
+    this.userAgent = buildUserAgent('mcsp-authenticator');
   }
 
   protected requestToken(): Promise<any> {
     const requiredHeaders = {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      'User-Agent': this.userAgent,
     };
 
     const parameters = {

--- a/auth/token-managers/token-manager.ts
+++ b/auth/token-managers/token-manager.ts
@@ -47,6 +47,8 @@ export type TokenManagerOptions = {
 export class TokenManager {
   protected url: string;
 
+  protected userAgent: string;
+
   protected disableSslVerification: boolean;
 
   protected headers: OutgoingHttpHeaders;

--- a/auth/token-managers/vpc-instance-token-manager.ts
+++ b/auth/token-managers/vpc-instance-token-manager.ts
@@ -16,6 +16,7 @@
 
 import logger from '../../lib/logger';
 import { atMostOne, getCurrentTime } from '../utils/helpers';
+import { buildUserAgent } from '../../lib/build-user-agent';
 import { JwtTokenManager, JwtTokenManagerOptions } from './jwt-token-manager';
 
 const DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254';
@@ -87,6 +88,8 @@ export class VpcInstanceTokenManager extends JwtTokenManager {
     if (options.iamProfileId) {
       this.iamProfileId = options.iamProfileId;
     }
+
+    this.userAgent = buildUserAgent('vpc-instance-authenticator');
   }
 
   /**
@@ -130,6 +133,7 @@ export class VpcInstanceTokenManager extends JwtTokenManager {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'User-Agent': this.userAgent,
           Accept: 'application/json',
           Authorization: `Bearer ${instanceIdentityToken}`,
         },
@@ -154,6 +158,7 @@ export class VpcInstanceTokenManager extends JwtTokenManager {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
+          'User-Agent': this.userAgent,
           Accept: 'application/json',
           'Metadata-Flavor': 'ibm',
         },

--- a/etc/ibm-cloud-sdk-core.api.md
+++ b/etc/ibm-cloud-sdk-core.api.md
@@ -426,6 +426,8 @@ export class TokenManager {
     setHeaders(headers: OutgoingHttpHeaders): void;
     // (undocumented)
     protected url: string;
+    // (undocumented)
+    protected userAgent: string;
 }
 
 // @public

--- a/lib/build-user-agent.ts
+++ b/lib/build-user-agent.ts
@@ -1,0 +1,31 @@
+/**
+ * (C) Copyright IBM Corp. 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const os = require('os');
+const { version } = require('../package.json');
+
+/**
+ * Returns a string suitable as a value for the User-Agent header
+ * @param componentName optional name of a component to be included in the returned string
+ * @returns the user agent header value
+ */
+export function buildUserAgent(componentName: string = null): string {
+  const subComponent = componentName ? `/${componentName}` : '';
+  const userAgent = `ibm-node-sdk-core${subComponent}-${version} os.name=${os.platform()} os.version=${os.release()} node.version=${
+    process.version
+  }`;
+  return userAgent;
+}

--- a/test/unit/iam-request-based-token-manager.test.js
+++ b/test/unit/iam-request-based-token-manager.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert, no-console */
 
 /**
- * Copyright 2021 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 jest.mock('../../dist/lib/request-wrapper');
 const { RequestWrapper } = require('../../dist/lib/request-wrapper');
+const { getRequestOptions } = require('./utils');
 const logger = require('../../dist/lib/logger').default;
 
 const { IamRequestBasedTokenManager } = require('../../dist/auth');
@@ -29,16 +30,6 @@ const CLIENT_ID = 'some-id';
 const CLIENT_SECRET = 'some-secret';
 const CLIENT_ID_SECRET_WARNING =
   'Warning: Client ID and Secret must BOTH be given, or the header will not be included.';
-
-// a function to pull the arguments out of the `sendRequest` mock
-// and verify the structure looks like it is supposed to
-function getRequestOptions(sendRequestMock) {
-  const sendRequestArgs = sendRequestMock.mock.calls[0][0];
-  expect(sendRequestArgs).toBeDefined();
-  expect(sendRequestArgs.options).toBeDefined();
-
-  return sendRequestArgs.options;
-}
 
 describe('IAM Request Based Token Manager', () => {
   // set up mocks
@@ -186,7 +177,7 @@ describe('IAM Request Based Token Manager', () => {
 
       const requestOptions = getRequestOptions(sendRequestMock);
       expect(requestOptions.headers).toBeDefined();
-      expect(requestOptions.headers['Content-type']).toBe('application/x-www-form-urlencoded');
+      expect(requestOptions.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
     });
 
     // add custom headers if set
@@ -201,7 +192,7 @@ describe('IAM Request Based Token Manager', () => {
 
       const requestOptions = getRequestOptions(sendRequestMock);
       expect(requestOptions.headers).toBeDefined();
-      expect(requestOptions.headers['Content-type']).toBeDefined(); // verify default headers aren't overwritten
+      expect(requestOptions.headers['Content-Type']).toBeDefined(); // verify default headers aren't overwritten
       expect(requestOptions.headers['My-Header']).toBe('some-value');
     });
 

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,27 @@
+/**
+ * (C) Copyright IBM Corp. 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// a function to pull the arguments out of the `sendRequest` mock
+// and verify the structure looks like it is supposed to
+function getRequestOptions(sendRequestMock, requestIndex = 0) {
+  const sendRequestArgs = sendRequestMock.mock.calls[requestIndex][0];
+  expect(sendRequestArgs).toBeDefined();
+  expect(sendRequestArgs.options).toBeDefined();
+
+  return sendRequestArgs.options;
+}
+
+module.exports = { getRequestOptions };


### PR DESCRIPTION
This commit updates our various request-based authenticators so that the User-Agent header is included with each outbound token request. The value of the User-Agent header will be of the form `ibm-node-sdk-core/<authenticator-type>-<core-version> <os-info>`.

Edit: I also updated `BaseService.createRequest()` so that it will add a default User-Agent header to the outbound request if one was not passed in with the request options.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
