### PR TITLE
feat(sse): add support for server side events

### DIFF
--- a/lib/request-wrapper.ts
+++ b/lib/request-wrapper.ts
@@ -312,6 +312,11 @@ export class RequestWrapper {
       headers = extend(true, {}, headers, multipartForm.getHeaders());
     }
 
+    // allow axiosInstance to return streams for server side events
+    if (headers.Accept === 'text/event-stream') {
+      options.responseType = 'stream';
+    }
+
     // accept gzip encoded responses if Accept-Encoding is not already set
     headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'gzip';
 

--- a/test/unit/request-wrapper.test.js
+++ b/test/unit/request-wrapper.test.js
@@ -227,6 +227,40 @@ describe('sendRequest', () => {
     expect(mockAxiosInstance.mock.calls).toHaveLength(1);
   });
 
+  it('should send a streaming request when Accept header is text/event-stream', async () => {
+    const parameters = {
+      defaultOptions: {
+        body: 'post=body',
+        formData: '',
+        qs: {},
+        method: 'POST',
+        url: 'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id',
+        headers: {
+          'test-header': 'test-header-value',
+          Accept: 'text/event-stream',
+        },
+      },
+    };
+
+    mockAxiosInstance.mockResolvedValue(axiosResolveValue);
+
+    const res = await requestWrapperInstance.sendRequest(parameters);
+    // assert results
+    expect(mockAxiosInstance.mock.calls[0][0].data).toEqual('post=body');
+    expect(mockAxiosInstance.mock.calls[0][0].url).toEqual(
+      'https://example.ibm.com/v1/environments/environment-id/configurations/configuration-id'
+    );
+    expect(mockAxiosInstance.mock.calls[0][0].headers).toEqual({
+      'Accept-Encoding': 'gzip',
+      'test-header': 'test-header-value',
+      Accept: 'text/event-stream',
+    });
+    expect(mockAxiosInstance.mock.calls[0][0].method).toEqual(parameters.defaultOptions.method);
+    expect(mockAxiosInstance.mock.calls[0][0].responseType).toEqual('stream');
+    expect(res).toEqual(expectedResult);
+    expect(mockAxiosInstance.mock.calls).toHaveLength(1);
+  });
+
   it('sendRequest should strip trailing slashes', async () => {
     const parameters = {
       defaultOptions: {


### PR DESCRIPTION
This commit adds support for http server side event streaming by setting the axios responseType to 'stream' when the Accept header is 'text/event-stream'
