### PR TITLE
feat(ContainerAuthenticator): enhance ContainerAuthenticator to support Code Engine workload

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -356,10 +356,10 @@ const service = ExampleServiceV1.newInstance(options);
 ## Container Authentication
 The `ContainerAuthenticator` is intended to be used by application code
 running inside a compute resource managed by the IBM Kubernetes Service (IKS)
-in which a secure compute resource token (CR token) has been stored in a file
-within the compute resource's local file system.
+or IBM Cloud Code Engine in which a secure compute resource token (CR token)
+has been stored in a file within the compute resource's local file system.
 The CR token is similar to an IAM apikey except that it is managed automatically by
-the compute resource provider (IKS).
+the compute resource provider (IKS or Code Engine).
 This allows the application developer to:
 - avoid storing credentials in application code, configuration files or a password vault
 - avoid managing or rotating credentials
@@ -379,7 +379,9 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - crTokenFilename: (optional) the name of the file containing the injected CR token value.
 If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
-and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
+and then `/var/run/secrets/tokens/sa-token` and finally
+`/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token` as the default value
+(first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iamProfileName: (optional) the name of the linked trusted IAM profile to be used when obtaining the

--- a/auth/token-managers/container-token-manager.ts
+++ b/auth/token-managers/container-token-manager.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021, 2024.
+ * (C) Copyright IBM Corp. 2021, 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import { IamRequestBasedTokenManager, IamRequestOptions } from './iam-request-ba
 
 const DEFAULT_CR_TOKEN_FILEPATH1 = '/var/run/secrets/tokens/vault-token';
 const DEFAULT_CR_TOKEN_FILEPATH2 = '/var/run/secrets/tokens/sa-token';
+const DEFAULT_CR_TOKEN_FILEPATH3 =
+  '/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token';
 
 /** Configuration options for IAM token retrieval. */
 interface Options extends IamRequestOptions {
@@ -144,6 +146,7 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
    * 1. User-specified filename (if specified)
    * 2. Default file #1 (/var/run/secrets/tokens/vault-token)
    * 3. Default file #2 (/var/run/secrets/tokens/sa-token)
+   * 4. Default file #3 (/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token)
    * First one found wins.
    *
    * @returns the CR token value as a string
@@ -159,7 +162,11 @@ export class ContainerTokenManager extends IamRequestBasedTokenManager {
         try {
           crToken = readCrTokenFile(DEFAULT_CR_TOKEN_FILEPATH1);
         } catch (err) {
-          crToken = readCrTokenFile(DEFAULT_CR_TOKEN_FILEPATH2);
+          try {
+            crToken = readCrTokenFile(DEFAULT_CR_TOKEN_FILEPATH2);
+          } catch (err1) {
+            crToken = readCrTokenFile(DEFAULT_CR_TOKEN_FILEPATH3);
+          }
         }
       }
       return crToken;


### PR DESCRIPTION
This pull request extends the existing ContainerAuthenticator to be aware of the hard-coded compute resource token path used by Code Engine. This allows a seamless usage of that authenticator and a move of workload between IKS/ROKS/Code Engine without changing a single line of code.

Documentation is adjusted to mention Code Engine in the context of the ContainerAuthenticator.