### PR TITLE
fix(deps): upgrade axios to 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/debug": "^4.1.12",
         "@types/node": "^22.13.9",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.7.9",
+        "axios": "^1.8.2",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
@@ -3984,9 +3984,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^22.13.9",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "1.7.9",
+    "axios": "^1.8.2",
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
fix(deps): upgrade axios to 1.8.2 https://github.com/advisories/GHSA-jr5f-v2jv-69x6

<!--
Thank you for your pull request!

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added


With this change, this repo should have safe version for axios.

```sh
$ npm ls axios
ibm-cloud-sdk-core@5.1.2 /Users/akira/dev/node-sdk-core
├── axios@1.8.2
└─┬ retry-axios@2.6.0
  └── axios@1.8.2 deduped
```

