### PR TITLE
fix(deps): bump axios to 1.11.0 to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3798,13 +3798,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "^1.8.2",
+        "axios": "^1.11.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^18.19.80",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "^1.8.2",
+    "axios": "^1.11.0",
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Bumps axios to 1.11.0 to avoid vulnerabilities.