### PR TITLE
fix(deps): bump axios to 1.12.2 to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3798,9 +3798,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^18.19.80",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Bumps axios to 1.12.2 to avoid vulnerabilities.
