### PR TITLE
fix(deps): lock axios to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "^1.13.5",
+        "axios": "1.14.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
@@ -3814,14 +3814,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -13350,10 +13350,13 @@
       "license": "ISC"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^18.19.80",
     "@types/tough-cookie": "^4.0.0",
-    "axios": "^1.13.5",
+    "axios": "1.14.0",
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Newest version of axios (1.14.1) has a severe vulnerability so we need to lock the axios version 1.14.0.