### PR TITLE
fix(deps): lock api-documenter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commitlint/cli": "12.0.1",
     "@commitlint/config-conventional": "7.0.1",
     "@masterodin/publisher": "0.10.0",
-    "@microsoft/api-documenter": "^7.30.5",
+    "@microsoft/api-documenter": "7.30.5",
     "@microsoft/api-extractor": "7.58.7",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",


### PR DESCRIPTION
Locks the version of `api-documenter` in `package.json`.