### PR TITLE
fix(deps): bump axios to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/debug": "4.1.12",
         "@types/node": "18.19.80",
         "@types/tough-cookie": "4.0.0",
-        "axios": "1.16.1",
+        "axios": "1.18.0",
         "camelcase": "6.3.0",
         "debug": "4.3.4",
         "dotenv": "16.4.5",
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/debug": "4.1.12",
     "@types/node": "18.19.80",
     "@types/tough-cookie": "4.0.0",
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "camelcase": "6.3.0",
     "debug": "4.3.4",
     "dotenv": "16.4.5",


### PR DESCRIPTION
Bumps axios to 1.18.0 to avoid CVEs. 
