### PR TITLE
build: re-enable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false,
+  "enabled": true,
   "prConcurrentLimit": 4,
   "reviewers": ["pyrooka", "diatrcz", "Andris28"],
   "extends": ["config:recommended", "security:minimumReleaseAgeNpm", "group:all"]


### PR DESCRIPTION
We disabled Renovate previously because it was spamming us with PRs.
Recently, we've enabled PR grouping which makes the history and the project
much cleaner, so we should give another try to Renovate.
Having a PR open for packages updates would be nice and make our life
easier in the long run. We'll see how it goes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run lint-fix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
